### PR TITLE
Unify GPIO selection model and add per-entry @GPIO[H|L] support

### DIFF
--- a/config/wsprrypi.ini
+++ b/config/wsprrypi.ini
@@ -36,12 +36,6 @@ LED Pin = 18
 ; Valid hardware range is 0 to 7.
 Power Level = 7
 
-; Frequency Control GPIO Polarity:
-; Polarity for optional per-band/frequency selector GPIOs.
-; False = active low
-; True  = active high
-Frequency Control GPIO Polarity = False
-
 ; Web Port:
 ; Port used for REST interface.
 Web Port = 31415

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -139,7 +139,7 @@ namespace
 {
 struct DirectToneStartupRequest
 {
-    WsprDialFrequencyEntry entry{};
+    WsprFrequencyEntry entry{};
     double actual_rf_frequency_hz = 0.0;
 };
 
@@ -322,33 +322,6 @@ static std::string transmit_gpio_validation_message()
     return oss.str();
 }
 
-static bool parse_tx_gpio_polarity(std::string_view raw_value, bool &active_high_out)
-{
-    std::string lowered(raw_value);
-    std::transform(
-        lowered.begin(),
-        lowered.end(),
-        lowered.begin(),
-        [](unsigned char c)
-        {
-            return static_cast<char>(std::tolower(c));
-        });
-
-    if (lowered == "high" || lowered == "active-high" || lowered == "active_high")
-    {
-        active_high_out = true;
-        return true;
-    }
-
-    if (lowered == "low" || lowered == "active-low" || lowered == "active_low")
-    {
-        active_high_out = false;
-        return true;
-    }
-
-    return false;
-}
-
 /**
  * @brief Rounds an input power level to the nearest valid WSPR power level.
  *
@@ -478,12 +451,11 @@ static std::vector<std::string> split_frequency_tokens(const std::string &raw_li
 
 static bool parse_frequency_entry_token(
     std::string_view raw_token,
-    WsprDialFrequencyEntry &entry,
+    WsprFrequencyEntry &entry,
     std::string &error_message)
 {
-    // Frequency-entry tokens may optionally carry a scheduler-owned @GPIO
-    // suffix. The suffix is metadata for per-frequency control GPIO, not a
-    // separate persistent transmit GPIO setting.
+    // Frequency-entry tokens may carry @GPIO[H|L] suffixes that override the
+    // selected band GPIO for one scheduler slot.
     const std::string token = trim_copy_string(std::string(raw_token));
     if (token.empty())
     {
@@ -495,7 +467,8 @@ static bool parse_frequency_entry_token(
     if (at_pos == std::string::npos)
     {
         entry.token = token;
-        entry.control_gpio = kFrequencyEntryControlGpioUnset;
+        entry.selector_gpio = kSelectorGpioUnset;
+        entry.selector_gpio_active_high = false;
         return true;
     }
 
@@ -508,7 +481,7 @@ static bool parse_frequency_entry_token(
     }
 
     const std::string base_token = trim_copy_string(token.substr(0, at_pos));
-    const std::string gpio_token =
+    std::string gpio_token =
         trim_copy_string(token.substr(at_pos + 1U));
 
     if (base_token.empty())
@@ -527,16 +500,33 @@ static bool parse_frequency_entry_token(
         return false;
     }
 
-    int parsed_gpio = kFrequencyEntryControlGpioUnset;
+    bool parsed_active_high = false;
+    const char polarity_suffix = gpio_token.empty() ? '\0' : gpio_token.back();
+    if (polarity_suffix == 'H' || polarity_suffix == 'h' ||
+        polarity_suffix == 'L' || polarity_suffix == 'l')
+    {
+        parsed_active_high = (polarity_suffix == 'H' || polarity_suffix == 'h');
+        gpio_token.pop_back();
+        gpio_token = trim_copy_string(gpio_token);
+        if (gpio_token.empty())
+        {
+            error_message =
+                "Invalid frequency token '" + token +
+                "': GPIO value is missing before polarity suffix.";
+            return false;
+        }
+    }
+
+    int parsed_gpio = kSelectorGpioUnset;
     if (!parse_gpio_number_strict(gpio_token, parsed_gpio))
     {
         error_message =
             "Invalid frequency token '" + token +
-            "': GPIO suffix must be an integer BCM GPIO.";
+            "': GPIO suffix must be an integer BCM GPIO optionally followed by H or L.";
         return false;
     }
 
-    if (!is_valid_frequency_entry_control_gpio(parsed_gpio))
+    if (!is_valid_selector_gpio(parsed_gpio))
     {
         error_message =
             "Invalid frequency token '" + token +
@@ -545,7 +535,8 @@ static bool parse_frequency_entry_token(
     }
 
     entry.token = base_token;
-    entry.control_gpio = parsed_gpio;
+    entry.selector_gpio = parsed_gpio;
+    entry.selector_gpio_active_high = parsed_active_high;
     return true;
 }
 
@@ -555,7 +546,7 @@ bool set_direct_tone_startup_request(
 {
     // --test-tone creates a transient startup request only. It does not
     // persist tone mode or RF frequency into configuration files.
-    WsprDialFrequencyEntry entry;
+    WsprFrequencyEntry entry;
     std::string local_error;
     if (!parse_frequency_entry_token(raw_token, entry, local_error))
     {
@@ -603,7 +594,7 @@ bool has_direct_tone_startup_request() noexcept
 }
 
 bool try_get_direct_tone_startup_request(
-    WsprDialFrequencyEntry &entry_out,
+    WsprFrequencyEntry &entry_out,
     double &actual_rf_frequency_hz_out) noexcept
 {
     if (!direct_tone_startup_request.has_value())
@@ -947,8 +938,6 @@ void print_usage(const std::string &message, int exit_code)
               << "    Load parameters from an INI file. Provide the path and filename.\n\n"
               << "  -a, --transmit-gpio <gpio>\n"
               << "    Select the RF transmit GPIO (supported: 4 or 20).\n\n"
-              << "  --tx-gpio-polarity <high|low>\n"
-              << "    Set polarity for per-frequency LPF/control GPIO outputs.\n\n"
               << "See the documentation for a complete list of available options.\n\n";
 
     // Handle exit behavior
@@ -989,9 +978,6 @@ void show_config_values(bool reload)
     llog.logS(DEBUG, "Transmit Power:", config.power_dbm);
     llog.logS(DEBUG, "WSPR Dial Frequencies:", config.frequencies);
     llog.logS(DEBUG, "Transmit Pin:", config.tx_pin);
-    llog.logS(DEBUG,
-              "Frequency Control GPIO Polarity:",
-              config.tx_freq_control_active_high ? "active high" : "active low");
     // [Extended]
     llog.logS(DEBUG, "PPM Offset:", config.ppm);
     llog.logS(DEBUG, "Synchronize with NTP:", config.use_ntp ? "true" : "false");
@@ -1209,9 +1195,6 @@ bool validate_config_candidate(
 void apply_runtime_config_side_effects()
 {
     llog.logS(INFO, "Transmit GPIO:", config.tx_pin);
-    llog.logS(INFO,
-              "Frequency-entry control GPIO polarity:",
-              config.tx_freq_control_active_high ? "active high" : "active low");
 
     if (!config.use_ntp && config.ppm != 0.0)
     {
@@ -1254,7 +1237,7 @@ void apply_runtime_config_side_effects()
 
     if (config.mode == ModeType::TONE)
     {
-        WsprDialFrequencyEntry entry;
+        WsprFrequencyEntry entry;
         double actual_rf_frequency_hz = 0.0;
         if (!try_get_direct_tone_startup_request(entry, actual_rf_frequency_hz))
         {
@@ -1499,7 +1482,7 @@ bool validate_config_data()
 
     if (config.mode == ModeType::TONE)
     {
-        WsprDialFrequencyEntry entry;
+        WsprFrequencyEntry entry;
         double actual_rf_frequency_hz = 0.0;
         if (!try_get_direct_tone_startup_request(entry, actual_rf_frequency_hz))
         {
@@ -1600,17 +1583,17 @@ bool set_frequencies(ArgParserConfig &target)
     }
 
     std::vector<double> parsed_frequencies;
-    std::vector<WsprDialFrequencyEntry> parsed_entries;
+    std::vector<WsprFrequencyEntry> parsed_entries;
 
     for (const std::string &token : split_frequency_tokens(raw_list))
     {
-        WsprDialFrequencyEntry entry;
+        WsprFrequencyEntry entry;
         std::string entry_error;
         if (!parse_frequency_entry_token(token, entry, entry_error))
         {
             llog.logE(ERROR, entry_error);
             target.wspr_dial_freq_set.clear();
-            target.wspr_dial_frequency_entries.clear();
+            target.wspr_frequency_entries.clear();
             return false;
         }
 
@@ -1618,6 +1601,7 @@ bool set_frequencies(ArgParserConfig &target)
         {
             const double freq = lookup.parse_string_to_frequency(entry.token, false);
             entry.dial_frequency_hz = freq;
+            entry.allow_band_gpio_fallback = target.use_ini;
             if (token_looks_numeric_frequency(entry.token))
             {
                 const auto legacy_alias =
@@ -1646,19 +1630,19 @@ bool set_frequencies(ArgParserConfig &target)
     if (!parsed_frequencies.empty())
     {
         target.wspr_dial_freq_set = parsed_frequencies;
-        target.wspr_dial_frequency_entries = parsed_entries;
+        target.wspr_frequency_entries = parsed_entries;
         return true;
     }
 
     if (target.mode != ModeType::WSPR || !target.transmit)
     {
-        target.wspr_dial_frequency_entries.clear();
+        target.wspr_frequency_entries.clear();
         return true;
     }
 
     llog.logE(ERROR, "Empty or invalid WSPR dial-frequency list.");
     target.wspr_dial_freq_set.clear();
-    target.wspr_dial_frequency_entries.clear();
+    target.wspr_frequency_entries.clear();
     return false;
 }
 
@@ -1844,7 +1828,6 @@ bool parse_command_line(int argc, char *argv[])
         {"journald", no_argument, nullptr, 'J'},      // Global: config.use_journald
         {"date-time-log", no_argument, nullptr, 'D'}, // Global: config.date_time_log
         {"require-paired", no_argument, nullptr, 1001}, // Global: config.wspr_planner_preference
-        {"tx-gpio-polarity", required_argument, nullptr, 1002},
         {"qrss-message", required_argument, nullptr, 1003},
         {"qrss-frequency", required_argument, nullptr, 1004},
         {"qrss-dot-seconds", required_argument, nullptr, 1005},
@@ -1918,21 +1901,6 @@ bool parse_command_line(int argc, char *argv[])
         case 1001: // Require paired WSPR planning
         {
             config.wspr_planner_preference = WsprPlannerPreference::RequirePaired;
-            break;
-        }
-        case 1002:
-        {
-            bool active_high = false;
-            if (!parse_tx_gpio_polarity(optarg, active_high))
-            {
-                print_usage(
-                    "Invalid TX GPIO polarity. Expected 'high' or 'low'.",
-                    EXIT_FAILURE);
-            }
-
-            // This applies to per-frequency selector GPIO outputs derived
-            // from frequency tokens with optional @GPIO suffixes.
-            config.tx_freq_control_active_high = active_high;
             break;
         }
         case 1003:

--- a/src/arg_parser.hpp
+++ b/src/arg_parser.hpp
@@ -5,8 +5,8 @@
  * This layer translates CLI input into runtime configuration and transient
  * startup requests. Persistent configuration remains in `config_handler.*`.
  * In particular, `--test-tone` creates a transient startup request rather
- * than persistent config, and frequency tokens may carry optional `@GPIO`
- * suffixes consumed later by scheduling.
+ * than persistent config, and frequency tokens may carry optional
+ * `@GPIO[H|L]` selector suffixes.
  *
  * This project is is licensed under the MIT License. See LICENSE.md
  * for more information.
@@ -185,7 +185,7 @@ bool set_direct_tone_startup_request(
     std::string *error_message = nullptr);
 bool has_direct_tone_startup_request() noexcept;
 bool try_get_direct_tone_startup_request(
-    WsprDialFrequencyEntry &entry_out,
+    WsprFrequencyEntry &entry_out,
     double &actual_rf_frequency_hz_out) noexcept;
 void clear_direct_tone_startup_request() noexcept;
 bool set_qrss_startup_request(

--- a/src/band_gpio_selector.cpp
+++ b/src/band_gpio_selector.cpp
@@ -52,6 +52,8 @@ bool BandGPIOSelector::prepareBand(
 {
     if (!enabled_)
     {
+        llog.logS(DEBUG, tag,
+                  "Unified scheduler selector prepare skipped; band GPIO control disabled.");
         return true;
     }
 
@@ -59,6 +61,10 @@ bool BandGPIOSelector::prepareBand(
 
     if (!config.enabled || config.gpio < 0)
     {
+        llog.logS(DEBUG, tag,
+                  "Unified scheduler selector prepare failed for band ",
+                  band_to_string(band),
+                  ": no enabled GPIO is configured.");
         return false;
     }
 
@@ -69,8 +75,8 @@ bool BandGPIOSelector::prepareBand(
     if (!drive_gpio_)
     {
         llog.logS(DEBUG, tag,
-                  "Prepared band ",
-                  ham_band_to_string(band),
+                  "Unified scheduler selector prepared band ",
+                  band_to_string(band),
                   ", GPIO ",
                   config.gpio,
                   ", polarity ",
@@ -84,54 +90,89 @@ bool BandGPIOSelector::prepareBand(
     {
         if (!gpio_.lastError().empty())
         {
-            llog.logS(ERROR, tag, gpio_.lastError());
+            llog.logS(ERROR, tag,
+                      "Unified scheduler selector failed to prepare band ",
+                      band_to_string(band),
+                      ", GPIO ",
+                      config.gpio,
+                      ": ",
+                      gpio_.lastError());
+        }
+        else
+        {
+            llog.logS(ERROR, tag,
+                      "Unified scheduler selector failed to prepare band ",
+                      band_to_string(band),
+                      ", GPIO ",
+                      config.gpio,
+                      ".");
         }
         has_band_ = false;
         current_config_ = BandGPIOConfig{};
         return false;
     }
 
+    llog.logS(DEBUG, tag,
+              "Unified scheduler selector prepared band ",
+              band_to_string(band),
+              ", GPIO ",
+              config.gpio,
+              ", polarity ",
+              (config.active_high ? "active high" : "active low"),
+              ", drive enabled");
+
     return true;
-}
-
-bool BandGPIOSelector::prepareFrequency(double frequency_hz)
-{
-    const auto band = band_lookup_.lookup_ham_band(frequency_hz);
-    if (!band.has_value())
-    {
-        return false;
-    }
-
-    return prepareBand(*band);
 }
 
 bool BandGPIOSelector::setBandState(bool state)
 {
     if (!enabled_)
     {
+        llog.logS(DEBUG, tag,
+                  "Unified scheduler selector ",
+                  (state ? "assert" : "deassert"),
+                  " skipped; band GPIO control disabled.");
         return true;
     }
 
     if (!has_band_ || !current_config_.enabled || current_config_.gpio < 0)
     {
+        llog.logS(DEBUG, tag,
+                  "Unified scheduler selector failed to ",
+                  (state ? "assert" : "deassert"),
+                  ": no band GPIO is prepared.");
         return false;
     }
 
     if (!drive_gpio_)
     {
         llog.logS(DEBUG, tag,
-                  (state ? "Assert band " : "Deassert band "),
-                  ham_band_to_string(current_band_),
+                  "Unified scheduler selector ",
+                  (state ? "assert band " : "deassert band "),
+                  band_to_string(current_band_),
                   ", GPIO ",
                   current_config_.gpio,
                   ", polarity ",
                   (current_config_.active_high ? "active high" : "active low"),
-                  ", drive ",
-                  (drive_gpio_ ? "enabled" : "disabled"));
+                  ", drive disabled");
         return true;
     }
 
-    return gpio_.toggleGPIO(state);
+    const bool ok = gpio_.toggleGPIO(state);
+
+    llog.logS(ok ? DEBUG : ERROR,
+              tag,
+              "Unified scheduler selector ",
+              (state ? "asserted band " : "deasserted band "),
+              band_to_string(current_band_),
+              ", GPIO ",
+              current_config_.gpio,
+              ", polarity ",
+              (current_config_.active_high ? "active high" : "active low"),
+              ", result ",
+              (ok ? "ok" : "failed"));
+
+    return ok;
 }
 
 void BandGPIOSelector::stop()
@@ -143,6 +184,15 @@ void BandGPIOSelector::stop()
 
     if (drive_gpio_)
     {
+        if (has_band_)
+        {
+            llog.logS(DEBUG, tag,
+                      "Unified scheduler selector releasing band ",
+                      band_to_string(current_band_),
+                      ", GPIO ",
+                      current_config_.gpio,
+                      ".");
+        }
         gpio_.stop();
     }
     else
@@ -150,8 +200,8 @@ void BandGPIOSelector::stop()
         if (!drive_gpio_ && has_band_)
         {
             llog.logS(DEBUG, tag,
-                      "Releasing band ",
-                      ham_band_to_string(current_band_),
+                      "Unified scheduler selector releasing band ",
+                      band_to_string(current_band_),
                       ", GPIO ",
                       current_config_.gpio,
                       ", drive ",

--- a/src/band_gpio_selector.hpp
+++ b/src/band_gpio_selector.hpp
@@ -39,7 +39,6 @@
 
 #include "band_gpio.hpp"
 #include "gpio_output.hpp"
-#include "wspr_band_lookup.hpp"
 
 /**
  * @brief Controls scheduler-selected GPIO output for the active amateur band.
@@ -65,17 +64,6 @@ public:
      */
     bool prepareBand(HamBand band);
     bool prepareBand(HamBand band, const BandGPIOConfig &config);
-
-    /**
-     * @brief Prepare a band based on a frequency in Hz.
-     *
-     * The frequency is resolved through WSPRBandLookup directly to HamBand and
-     * then the configured GPIO is enabled in its inactive state.
-     *
-     * @param frequency_hz The frequency in Hz.
-     * @return True on success, false on failure.
-     */
-    bool prepareFrequency(double frequency_hz);
 
     /**
      * @brief Set the currently selected band GPIO enabled or disabled.
@@ -143,7 +131,6 @@ public:
 
 private:
     GPIOOutput gpio_;
-    WSPRBandLookup band_lookup_;
     bool has_band_ = false;
     HamBand current_band_ = HamBand::BAND_2200M;
     BandGPIOConfig current_config_{};

--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -145,9 +145,7 @@ namespace
             {"Web Port", source.at("Runtime").at("Web Port")},
             {"Socket Port", source.at("Runtime").at("Socket Port")},
             {"Use Shutdown", source.at("Runtime").at("Use Shutdown")},
-            {"Shutdown Button", source.at("Runtime").at("Shutdown Button")},
-            {"Frequency Control GPIO Polarity",
-             source.at("Runtime").value("Frequency Control GPIO Polarity", false)}};
+            {"Shutdown Button", source.at("Runtime").at("Shutdown Button")}};
 
         public_json["Calibration"] = source.at("Calibration");
         public_json["WSPR"] = source.at("WSPR");
@@ -198,11 +196,6 @@ namespace
                 internal_json["Runtime"]["Use Shutdown"] = runtime.at("Use Shutdown");
             if (runtime.contains("Shutdown Button"))
                 internal_json["Runtime"]["Shutdown Button"] = runtime.at("Shutdown Button");
-            if (runtime.contains("Frequency Control GPIO Polarity"))
-            {
-                internal_json["Runtime"]["Frequency Control GPIO Polarity"] =
-                    runtime.at("Frequency Control GPIO Polarity");
-            }
         }
 
         if (public_json.contains("Calibration"))
@@ -507,7 +500,6 @@ void init_default_config()
 
     // Meta
     config.use_ini = true;
-    config.tx_freq_control_active_high = false;
 
     config.wspr.callsign = config.callsign;
     config.wspr.grid_square = config.grid_square;
@@ -660,8 +652,7 @@ namespace
                  key == "Web Port" ||
                  key == "Socket Port" ||
                  key == "Use Shutdown" ||
-                 key == "Shutdown Button" ||
-                 key == "Frequency Control GPIO Polarity")) ||
+                 key == "Shutdown Button")) ||
                (section == "WSPR" &&
                 (key == "Call Sign" ||
                  key == "Grid Square" ||
@@ -770,8 +761,7 @@ namespace
             {"Web Port", 31415},
             {"Socket Port", 31416},
             {"Use Shutdown", false},
-            {"Shutdown Button", 19},
-            {"Frequency Control GPIO Polarity", false}};
+            {"Shutdown Button", 19}};
 
         target["Calibration"] = {
             {"PPM", 0.0},
@@ -840,8 +830,6 @@ namespace
         target.ppm = source.at("Calibration").at("PPM").get<double>();
         target.use_ntp = source.at("Calibration").at("Use NTP").get<bool>();
         target.use_offset = source.at("WSPR").at("Use Random Offset").get<bool>();
-        target.tx_freq_control_active_high =
-            source.at("Runtime").value("Frequency Control GPIO Polarity", false);
         target.modulation_dot_seconds =
             source.contains("CW") &&
                     source.at("CW").contains("Dot Seconds")
@@ -967,8 +955,6 @@ namespace
         target["Runtime"]["Socket Port"] = source.socket_port;
         target["Runtime"]["Use Shutdown"] = source.use_shutdown;
         target["Runtime"]["Shutdown Button"] = source.shutdown_pin;
-        target["Runtime"]["Frequency Control GPIO Polarity"] =
-            source.tx_freq_control_active_high;
 
         target["Calibration"]["PPM"] = source.ppm;
         target["Calibration"]["Use NTP"] = source.use_ntp;
@@ -1050,8 +1036,7 @@ namespace
         target.use_ini = source.use_ini;
         target.ini_filename = source.ini_filename;
         target.wspr_dial_freq_set = source.wspr_dial_freq_set;
-        target.wspr_dial_frequency_entries = source.wspr_dial_frequency_entries;
-        target.tx_freq_control_active_high = source.tx_freq_control_active_high;
+        target.wspr_frequency_entries = source.wspr_frequency_entries;
         target.ntp_good = source.ntp_good;
         target.band_gpio = source.band_gpio;
     }
@@ -1293,8 +1278,7 @@ void json_to_ini()
                   key == "Web Port" ||
                   key == "Socket Port" ||
                   key == "Use Shutdown" ||
-                  key == "Shutdown Button" ||
-                  key == "Frequency Control GPIO Polarity")) ||
+                  key == "Shutdown Button")) ||
                 (section_name == "Calibration" &&
                  (key == "PPM" ||
                   key == "Use NTP")) ||
@@ -1433,8 +1417,6 @@ void patch_all_from_web(const nlohmann::json &j)
     try
     {
         json_to_config_impl(candidate_json, candidate_config);
-        candidate_config.tx_freq_control_active_high =
-            config.tx_freq_control_active_high;
 
         if (!validate_config_candidate(candidate_config, &error_message))
         {

--- a/src/config_handler.hpp
+++ b/src/config_handler.hpp
@@ -4,8 +4,8 @@
  *
  * This layer owns durable configuration values and their serialized
  * representation. Transient runtime requests such as `--test-tone` do not
- * live here. Frequency entries may include optional `@GPIO` metadata, and
- * `tx-gpio-polarity` applies to those per-frequency control outputs.
+ * live here. Frequency entries may include optional `@GPIO[H|L]` metadata
+ * that overrides the selected band GPIO for one scheduler slot.
  *
  * This project is is licensed under the MIT License. See LICENSE.md
  * for more information.
@@ -48,7 +48,7 @@
 inline constexpr int kTransmitGpioUnset = -1;
 inline constexpr int kDefaultTransmitGpio = 4;
 inline constexpr std::array<int, 2> kSupportedTransmitGpio = {4, 20};
-inline constexpr int kFrequencyEntryControlGpioUnset = -1;
+inline constexpr int kSelectorGpioUnset = -1;
 inline constexpr double WSPR_AUDIO_OFFSET_HZ = 1500.0;
 
 inline constexpr bool is_supported_transmit_gpio(int gpio) noexcept
@@ -64,16 +64,18 @@ inline constexpr bool is_supported_transmit_gpio(int gpio) noexcept
     return false;
 }
 
-inline constexpr bool is_valid_frequency_entry_control_gpio(int gpio) noexcept
+inline constexpr bool is_valid_selector_gpio(int gpio) noexcept
 {
     return gpio >= 0 && gpio <= 27;
 }
 
-struct WsprDialFrequencyEntry
+struct WsprFrequencyEntry
 {
-    std::string token; ///< Original frequency token without `@GPIO`.
+    std::string token; ///< Original frequency token without `@GPIO[H|L]`.
     double dial_frequency_hz = 0.0; ///< Resolved WSPR dial frequency in Hz.
-    int control_gpio = kFrequencyEntryControlGpioUnset; ///< Optional selector GPIO.
+    int selector_gpio = kSelectorGpioUnset; ///< Optional per-entry selector GPIO.
+    bool selector_gpio_active_high = false; ///< Optional selector GPIO polarity; false means active low.
+    bool allow_band_gpio_fallback = false; ///< True when [Band GPIO] may supply the selector.
 };
 
 /**
@@ -240,9 +242,8 @@ struct ArgParserConfig
     bool use_ini;                        ///< Load configuration from INI file.
     std::string ini_filename;            ///< INI file name and path.
     std::vector<double> wspr_dial_freq_set; ///< Parsed WSPR dial frequencies.
-    std::vector<WsprDialFrequencyEntry>
-        wspr_dial_frequency_entries; ///< Parsed entries with optional GPIO metadata.
-    bool tx_freq_control_active_high; ///< Global polarity for selector GPIO outputs.
+    std::vector<WsprFrequencyEntry>
+        wspr_frequency_entries; ///< Parsed entries with optional GPIO/polarity metadata.
     bool ntp_good;                       ///< A more qualitative measurement of NTP vs simply running
     std::array<BandGPIOConfig, HAM_BAND_COUNT> band_gpio; ///< Per-band GPIO assignment.
 
@@ -284,8 +285,7 @@ struct ArgParserConfig
           use_ini(false),
           ini_filename(""),
           wspr_dial_freq_set({}),
-          wspr_dial_frequency_entries({}),
-          tx_freq_control_active_high(false),
+          wspr_frequency_entries({}),
           ntp_good(false),
           band_gpio({})
     {
@@ -338,8 +338,7 @@ struct ArgParserConfig
         use_ini = other.use_ini;
         ini_filename = other.ini_filename;
         wspr_dial_freq_set = other.wspr_dial_freq_set;
-        wspr_dial_frequency_entries = other.wspr_dial_frequency_entries;
-        tx_freq_control_active_high = other.tx_freq_control_active_high;
+        wspr_frequency_entries = other.wspr_frequency_entries;
         ntp_good = other.ntp_good;
         band_gpio = other.band_gpio;
         return *this;
@@ -439,8 +438,7 @@ void ini_to_json(std::string filename);
  *       "Web Port": 31415,
  *       "Socket Port": 31416,
  *       "Use Shutdown": false,
- *       "Shutdown Button": 19,
- *       "Frequency Control GPIO Polarity": false
+ *       "Shutdown Button": 19
  *   },
  *   "Calibration": {
  *       "PPM": 0.0,

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -7,7 +7,7 @@
  * - Auto versus RequirePaired WSPR planning.
  * - WSPR versus direct-tone execution mode.
  * - Random WSPR RF offset application.
- * - Per-frequency control GPIO metadata and selector preparation.
+ * - Per-band selector GPIO preparation.
  * - When a built request is committed to the transmitter.
  *
  * The transmitter only consumes committed `TransmissionRequest`
@@ -90,77 +90,10 @@
  * transmission completes, is skipped, or is cancelled.
  */
 static BandGPIOSelector bandGPIOSelector;
-static void log_selected_frequency_entry_gpio(
-    const WsprDialFrequencyEntry &entry,
-    const ArgParserConfig &cfg);
 static bool prepare_band_gpio_for_frequency_or_log(
-    double frequency_hz,
+    double source_frequency_hz,
+    const WsprFrequencyEntry &entry,
     const ArgParserConfig &cfg);
-
-/**
- * @brief Runtime owner for the currently prepared per-frequency selector GPIO.
- *
- * Scheduling prepares and tears down this selector around the committed
- * request for the active slot. It is intentionally file-local so per-
- * frequency control remains an orchestration concern rather than a
- * transmitter or backend policy concern.
- */
-class FrequencyEntryGPIOSelector
-{
-public:
-    bool prepare(const WsprDialFrequencyEntry &entry, bool active_high)
-    {
-        stop();
-        last_error_.clear();
-
-        if (entry.control_gpio == kFrequencyEntryControlGpioUnset)
-        {
-            return true;
-        }
-
-        if (!gpio_.enableGPIOPin(entry.control_gpio, active_high))
-        {
-            last_error_ = gpio_.lastError();
-            return false;
-        }
-
-        has_gpio_ = true;
-        return true;
-    }
-
-    bool setState(bool state)
-    {
-        if (!has_gpio_)
-        {
-            return true;
-        }
-
-        return gpio_.toggleGPIO(state);
-    }
-
-    void stop()
-    {
-        if (!has_gpio_)
-        {
-            return;
-        }
-
-        gpio_.stop();
-        has_gpio_ = false;
-    }
-
-    const std::string &lastError() const noexcept
-    {
-        return last_error_;
-    }
-
-private:
-    GPIOOutput gpio_{};
-    bool has_gpio_ = false;
-    std::string last_error_{};
-};
-
-static FrequencyEntryGPIOSelector frequencyEntryGPIOSelector;
 
 /**
  * @brief Mutex to protect access to the shutdown flag for the WSPR loop.
@@ -210,7 +143,7 @@ int freq_iterator = 0;
  * A zero value indicates that no frequency is configured or the list was empty.
  */
 double current_dial_frequency = 0.0;
-WsprDialFrequencyEntry current_frequency_entry{};
+WsprFrequencyEntry current_frequency_entry{};
 TransmissionRequest current_transmission_request{};
 
 /**
@@ -281,60 +214,23 @@ static std::atomic<std::uint64_t> non_wspr_schedule_generation{0};
 PreparedWsprTransmission active_wspr_plan{};
 std::size_t active_wspr_frame_index = 0;
 double active_wspr_plan_dial_frequency = 0.0;
-WsprDialFrequencyEntry active_wspr_plan_frequency_entry{};
+WsprFrequencyEntry active_wspr_plan_frequency_entry{};
 bool active_wspr_plan_in_progress = false;
 
 /**
- * @brief Tear down every selector prepared for the active committed request.
+ * @brief Tear down the selector prepared for the active committed request.
  *
- * This is the single teardown path for scheduler-owned selector GPIO state.
- * Any code that needs to release band-selection or per-frequency control
- * GPIOs must call this helper rather than stopping selectors individually.
+ * This is the single teardown path for scheduler-owned band-selection GPIO
+ * state. Any code that needs to release the active selector must call this
+ * helper rather than stopping the selector directly.
  */
 static void stop_active_transmission_selectors() noexcept
 {
-    bandGPIOSelector.setBandState(false);
-    bandGPIOSelector.stop();
-    frequencyEntryGPIOSelector.setState(false);
-    frequencyEntryGPIOSelector.stop();
-}
-
-/**
- * @brief Prepare the per-frequency control GPIO for the next committed slot.
- *
- * This helper logs the selected entry metadata and prepares the transient
- * runtime selector state that belongs to the current scheduler slot. It
- * does not start transmission or commit a request by itself.
- *
- * @param entry Frequency entry selected by the scheduler.
- * @param failure_level Log level used if preparation fails.
- * @return `true` if no GPIO is needed or preparation succeeded.
- */
-static bool prepare_frequency_entry_gpio_or_log(
-    const WsprDialFrequencyEntry &entry,
-    const ArgParserConfig &cfg,
-    bool active_high,
-    LogLevel failure_level)
-{
-    log_selected_frequency_entry_gpio(entry, cfg);
-    if (frequencyEntryGPIOSelector.prepare(
-            entry,
-            active_high))
+    if (bandGPIOSelector.currentConfig() != nullptr)
     {
-        return true;
+        bandGPIOSelector.setBandState(false);
     }
-
-    llog.logS(
-        failure_level,
-        "Unable to prepare frequency entry control GPIO ",
-        entry.control_gpio,
-        " for ",
-        entry.token,
-        ".",
-        frequencyEntryGPIOSelector.lastError().empty()
-            ? ""
-            : std::string(" ") + frequencyEntryGPIOSelector.lastError());
-    return false;
+    bandGPIOSelector.stop();
 }
 
 /**
@@ -565,7 +461,7 @@ static void reset_active_wspr_plan_state()
     active_wspr_plan = PreparedWsprTransmission{};
     active_wspr_frame_index = 0;
     active_wspr_plan_dial_frequency = 0.0;
-    active_wspr_plan_frequency_entry = WsprDialFrequencyEntry{};
+    active_wspr_plan_frequency_entry = WsprFrequencyEntry{};
     active_wspr_plan_in_progress = false;
 }
 
@@ -613,8 +509,8 @@ static void set_managed_reload_tx_inhibited(
     }
 }
 
-static WsprDialFrequencyEntry next_frequency_entry_from(
-    const std::vector<WsprDialFrequencyEntry> &entries,
+static WsprFrequencyEntry next_frequency_entry_from(
+    const std::vector<WsprFrequencyEntry> &entries,
     int &iterator,
     bool reset)
 {
@@ -625,17 +521,17 @@ static WsprDialFrequencyEntry next_frequency_entry_from(
 
     if (entries.empty())
     {
-        return WsprDialFrequencyEntry{};
+        return WsprFrequencyEntry{};
     }
 
     const auto idx =
         static_cast<std::size_t>(iterator % static_cast<int>(entries.size()));
-    const WsprDialFrequencyEntry entry = entries[idx];
+    const WsprFrequencyEntry entry = entries[idx];
     ++iterator;
     return entry;
 }
 
-static WsprDialFrequencyEntry next_frequency_entry(bool reset);
+static WsprFrequencyEntry next_frequency_entry(bool reset);
 
 /**
  * @brief Return the prepared plan for a single frame from a saved plan.
@@ -730,52 +626,83 @@ void consume_tx_iteration_if_needed()
     }
 }
 
-static void log_selected_frequency_entry_gpio(
-    const WsprDialFrequencyEntry &entry,
-    const ArgParserConfig &cfg)
-{
-    if (entry.control_gpio == kFrequencyEntryControlGpioUnset)
-    {
-        llog.logS(INFO,
-                  "Selected frequency entry control GPIO: none for ",
-                  entry.token,
-                  ".");
-        return;
-    }
-
-    llog.logS(INFO,
-              "Selected frequency entry control GPIO: ",
-              entry.control_gpio,
-              " (",
-              cfg.tx_freq_control_active_high ? "active high" : "active low",
-              ") for ",
-              entry.token,
-              ".");
-}
-
 static bool prepare_band_gpio_for_frequency_or_log(
-    double frequency_hz,
+    double source_frequency_hz,
+    const WsprFrequencyEntry &entry,
     const ArgParserConfig &cfg)
 {
-    const auto band = lookup.lookup_ham_band(frequency_hz);
+    const auto band = lookup.lookup_ham_band(source_frequency_hz);
     if (!band.has_value())
     {
         llog.logS(
             WARN,
-            "Unable to map frequency ",
-            lookup.freq_display_string(frequency_hz),
+            "Unable to map source frequency ",
+            lookup.freq_display_string(source_frequency_hz),
             " to a ham band for band-selector GPIO preparation.");
         return false;
     }
 
-    const BandGPIOConfig &band_gpio_config =
-        cfg.band_gpio[ham_band_index(*band)];
+    BandGPIOConfig band_gpio_config{};
+    const char *selector_source = "frequency entry";
+    if (entry.selector_gpio != kSelectorGpioUnset)
+    {
+        band_gpio_config.gpio = entry.selector_gpio;
+        band_gpio_config.enabled = true;
+        band_gpio_config.active_high = entry.selector_gpio_active_high;
+    }
+    else if (entry.allow_band_gpio_fallback)
+    {
+        band_gpio_config = cfg.band_gpio[ham_band_index(*band)];
+        selector_source = "band configuration";
+        if (!band_gpio_config.enabled || band_gpio_config.gpio < 0)
+        {
+            stop_active_transmission_selectors();
+            llog.logS(
+                DEBUG,
+                "[BandGPIO]",
+                "No selector GPIO requested for frequency entry ",
+                entry.token,
+                "; no configured band GPIO for band ",
+                ham_band_to_string(*band),
+                "; leaving LPF selection inactive.");
+            return true;
+        }
+    }
+    else
+    {
+        stop_active_transmission_selectors();
+        llog.logS(
+            DEBUG,
+            "[BandGPIO]",
+            "No selector GPIO requested for frequency entry ",
+            entry.token,
+            "; leaving LPF selection inactive.");
+        return true;
+    }
+
+    llog.logS(
+        DEBUG,
+        "[BandGPIO]",
+        "Unified scheduler selector derived band ",
+        ham_band_to_string(*band),
+        " from source frequency ",
+        lookup.freq_display_string(source_frequency_hz),
+        "; selected GPIO ",
+        band_gpio_config.gpio,
+        " (",
+        (band_gpio_config.active_high ? "active high" : "active low"),
+        ")",
+        " from ",
+        selector_source,
+        ", enabled ",
+        (band_gpio_config.enabled ? "true" : "false"),
+        ".");
     if (!bandGPIOSelector.prepareBand(*band, band_gpio_config))
     {
         llog.logS(
             WARN,
-            "Unable to prepare band GPIO for ",
-            wsprTransmitter.formatFrequencyMHz(frequency_hz),
+            "Unable to prepare unified scheduler band GPIO for ",
+            wsprTransmitter.formatFrequencyMHz(source_frequency_hz),
             " MHz.");
         return false;
     }
@@ -809,7 +736,7 @@ static TransmissionRequest make_tone_request(
     double committed_ppm,
     double actual_rf_frequency_hz,
     double dial_frequency_hz,
-    const WsprDialFrequencyEntry &entry)
+    const WsprFrequencyEntry &entry)
 {
     TransmissionRequest request;
     request.mode = TransmissionMode::TONE;
@@ -818,8 +745,6 @@ static TransmissionRequest make_tone_request(
     request.ppm = committed_ppm;
     request.power_level = cfg.power_level;
     request.tx_gpio = cfg.tx_pin;
-    request.frequency_control_gpio = entry.control_gpio;
-    request.frequency_control_active_high = cfg.tx_freq_control_active_high;
     request.frequency_entry_label = entry.token;
     return request;
 }
@@ -835,7 +760,7 @@ static TransmissionRequest make_direct_tone_request(
     double committed_ppm,
     double actual_rf_frequency_hz)
 {
-    WsprDialFrequencyEntry entry;
+    WsprFrequencyEntry entry;
     double ignored_actual_rf_frequency_hz = 0.0;
     if (try_get_direct_tone_startup_request(entry, ignored_actual_rf_frequency_hz))
     {
@@ -852,7 +777,7 @@ static TransmissionRequest make_direct_tone_request(
         committed_ppm,
         actual_rf_frequency_hz,
         actual_rf_frequency_hz,
-        WsprDialFrequencyEntry{});
+        WsprFrequencyEntry{});
 }
 
 static std::chrono::nanoseconds seconds_to_nanoseconds(double seconds)
@@ -1169,8 +1094,8 @@ static void schedule_next_non_wspr_launch(const ArgParserConfig &cfg)
  * @brief Build the scheduler-side request for one WSPR execution slot.
  *
  * The request captures all execution-time state, including the prepared
- * WSPR frame for this slot, the committed RF frequency, and scheduler-owned
- * per-frequency GPIO metadata.
+ * WSPR frame for this slot, the committed RF frequency, and the original
+ * scheduler frequency-entry label used for diagnostics.
  */
 static TransmissionRequest make_wspr_request(
     const ArgParserConfig &cfg,
@@ -1178,7 +1103,7 @@ static TransmissionRequest make_wspr_request(
     const PreparedWsprTransmission &slot_plan,
     double dial_frequency_hz,
     double actual_rf_frequency_hz,
-    const WsprDialFrequencyEntry &entry,
+    const WsprFrequencyEntry &entry,
     double applied_offset_hz)
 {
     TransmissionRequest request;
@@ -1191,8 +1116,6 @@ static TransmissionRequest make_wspr_request(
     request.tx_gpio = cfg.tx_pin;
     request.use_offset = cfg.use_offset;
     request.applied_offset_hz = applied_offset_hz;
-    request.frequency_control_gpio = entry.control_gpio;
-    request.frequency_control_active_high = cfg.tx_freq_control_active_high;
     request.frequency_entry_label = entry.token;
     return request;
 }
@@ -1244,11 +1167,11 @@ static bool configure_current_wspr_transmission(
     const ArgParserConfig &cfg,
     double committed_ppm,
     double dial_frequency_hz,
-    const WsprDialFrequencyEntry &frequency_entry,
+    const WsprFrequencyEntry &frequency_entry,
     PreparedWsprTransmission &active_plan,
     std::size_t &active_frame_index,
     double &active_plan_dial_frequency,
-    WsprDialFrequencyEntry &active_plan_frequency_entry,
+    WsprFrequencyEntry &active_plan_frequency_entry,
     bool &active_plan_in_progress,
     double actual_rf_frequency_hz,
     TransmissionRequest &request_out)
@@ -1368,7 +1291,7 @@ static bool configure_current_wspr_transmission(
                 active_plan = PreparedWsprTransmission{};
                 active_frame_index = 0;
                 active_plan_dial_frequency = 0.0;
-                active_plan_frequency_entry = WsprDialFrequencyEntry{};
+                active_plan_frequency_entry = WsprFrequencyEntry{};
                 active_plan_in_progress = false;
             }
 
@@ -1413,7 +1336,7 @@ static bool configure_current_wspr_transmission(
         active_plan = PreparedWsprTransmission{};
         active_frame_index = 0;
         active_plan_dial_frequency = 0.0;
-        active_plan_frequency_entry = WsprDialFrequencyEntry{};
+        active_plan_frequency_entry = WsprFrequencyEntry{};
         active_plan_in_progress = false;
         shutdown_after_wspr_plan.store(false, std::memory_order_release);
         llog.logE(ERROR, "WSPR encoding/configuration failed: ", e.what());
@@ -1466,9 +1389,12 @@ void transmitter_cb(WsprTransmitter::TransmissionCallbackEvent event,
             consume_tx_iteration_if_needed();
         }
 
-        // Assert the precomputed band GPIO.
-        bandGPIOSelector.setBandState(true);
-        frequencyEntryGPIOSelector.setState(true);
+        // Assert the scheduler-selected band GPIO.
+        if (!bandGPIOSelector.setBandState(true))
+        {
+            llog.logS(DEBUG,
+                      "Band GPIO assert request was issued but did not complete.");
+        }
 
         // Turn on LED.
         ledControl.toggleGPIO(true);
@@ -1878,7 +1804,7 @@ void reboot_system()
  * @brief Start a transient runtime tone using scheduler-owned setup.
  *
  * The scheduler stops any active run, reuses the first configured
- * frequency entry, prepares selector GPIO state, commits a tone request,
+ * frequency entry, prepares band-selector GPIO state, commits a tone request,
  * and starts the transmitter. Tone mode here is runtime-only behavior.
  */
 void start_test_tone()
@@ -1905,7 +1831,7 @@ void start_test_tone()
 
         // Pick the first configured scheduler frequency entry, then commit
         // the resolved RF frequency into the request before execution.
-        const WsprDialFrequencyEntry entry =
+        const WsprFrequencyEntry entry =
             next_frequency_entry(/*restart=*/true);
         const double dial_freq = entry.dial_frequency_hz;
         current_frequency_entry = entry;
@@ -1940,19 +1866,7 @@ void start_test_tone()
         commit_execution_request(
             make_tone_request(config, committed_ppm, actual_rf_freq, dial_freq, entry));
 
-        (void)prepare_frequency_entry_gpio_or_log(
-            entry,
-            config,
-            config.tx_freq_control_active_high,
-            WARN);
-
-        if (!bandGPIOSelector.prepareFrequency(dial_freq))
-        {
-            llog.logS(WARN,
-                      "Unable to prepare band GPIO for WSPR dial frequency ",
-                      lookup.freq_display_string(dial_freq),
-                      ".");
-        }
+        (void)prepare_band_gpio_for_frequency_or_log(dial_freq, entry, config);
 
         wsprTransmitter.startAsync();
         llog.logS(INFO,
@@ -1997,7 +1911,7 @@ void end_test_tone()
         }
         else
         {
-            WsprDialFrequencyEntry entry;
+            WsprFrequencyEntry entry;
             double actual_rf_frequency_hz = 0.0;
             if (!try_get_direct_tone_startup_request(
                     entry,
@@ -2022,11 +1936,10 @@ void end_test_tone()
                     config,
                     committed_ppm,
                     actual_rf_frequency_hz));
-            (void)prepare_frequency_entry_gpio_or_log(
+            (void)prepare_band_gpio_for_frequency_or_log(
+                entry.dial_frequency_hz,
                 entry,
-                config,
-                config.tx_freq_control_active_high,
-                WARN);
+                config);
             wsprTransmitter.startAsync();
 
             llog.logS(INFO,
@@ -2075,7 +1988,7 @@ StopTransmissionResult stop_transmission_by_user_request()
 
         current_transmission_request = TransmissionRequest{};
         current_dial_frequency = 0.0;
-        current_frequency_entry = WsprDialFrequencyEntry{};
+        current_frequency_entry = WsprFrequencyEntry{};
         freq_iterator = 0;
         web_test_tone.store(false);
 
@@ -2255,7 +2168,7 @@ bool wspr_loop()
     else if (config.mode == ModeType::TONE)
     {
         log_scheduler_path_selection(config.mode);
-        WsprDialFrequencyEntry entry;
+        WsprFrequencyEntry entry;
         double actual_rf_frequency_hz = 0.0;
         if (!try_get_direct_tone_startup_request(entry, actual_rf_frequency_hz))
         {
@@ -2276,11 +2189,10 @@ bool wspr_loop()
                     config,
                     committed_ppm,
                     actual_rf_frequency_hz));
-            (void)prepare_frequency_entry_gpio_or_log(
+            (void)prepare_band_gpio_for_frequency_or_log(
+                entry.dial_frequency_hz,
                 entry,
-                config,
-                config.tx_freq_control_active_high,
-                WARN);
+                config);
             wsprTransmitter.startAsync();
             llog.logS(INFO, "transmitting tone, hit Ctrl-C to terminate tone.");
         }
@@ -2371,11 +2283,9 @@ bool wspr_loop()
     wsprTransmitter.stopAndJoin(); // Stop the transmitter threads
     llog.logS(INFO, "Transmitter stopped.");
 
-    llog.logS(INFO, "Stopping frequency entry GPIO selector.");
     llog.logS(INFO, "Stopping band GPIO selector.");
     stop_active_transmission_selectors();
     llog.logS(INFO, "Band GPIO selector stopped.");
-    llog.logS(INFO, "Frequency entry GPIO selector stopped.");
 
     llog.logS(INFO, "Stopping shutdown monitor.");
     shutdownMonitor.stop(); // Stop the GPIO monitor
@@ -2541,17 +2451,17 @@ WsprRuntimeStatusSnapshot current_tx_runtime_status_snapshot()
  * @brief Return the next configured scheduler frequency entry.
  *
  * The scheduler owns round-robin traversal of configured frequency entries,
- * including their optional `@GPIO` metadata. When `reset` is true, the next
- * returned entry is the first configured slot.
+ * using the returned source frequency for band-selector policy. When `reset`
+ * is true, the next returned entry is the first configured slot.
  *
  * @param reset True to restart from the first configured entry.
  * @return The next configured entry, or a default-constructed entry if none
  *         are configured.
  */
-WsprDialFrequencyEntry next_frequency_entry(bool reset)
+WsprFrequencyEntry next_frequency_entry(bool reset)
 {
     return next_frequency_entry_from(
-        config.wspr_dial_frequency_entries,
+        config.wspr_frequency_entries,
         freq_iterator,
         reset);
 }
@@ -2751,7 +2661,7 @@ bool set_config(bool force)
             stop_active_transmission_selectors();
             current_transmission_request = TransmissionRequest{};
             current_dial_frequency = 0.0;
-            current_frequency_entry = WsprDialFrequencyEntry{};
+            current_frequency_entry = WsprFrequencyEntry{};
             freq_iterator = 0;
             reset_active_wspr_plan_state();
             non_wspr_schedule_generation.fetch_add(1, std::memory_order_acq_rel);
@@ -2783,8 +2693,8 @@ bool set_config(bool force)
         int next_freq_iterator = force ? 0 : freq_iterator;
         double next_current_dial_frequency =
             force ? 0.0 : current_dial_frequency;
-        WsprDialFrequencyEntry next_current_frequency_entry =
-            force ? WsprDialFrequencyEntry{} : current_frequency_entry;
+        WsprFrequencyEntry next_current_frequency_entry =
+            force ? WsprFrequencyEntry{} : current_frequency_entry;
         TransmissionRequest next_transmission_request =
             force ? TransmissionRequest{} : current_transmission_request;
         PreparedWsprTransmission next_active_wspr_plan =
@@ -2793,8 +2703,8 @@ bool set_config(bool force)
             force ? 0U : active_wspr_frame_index;
         double next_active_wspr_plan_dial_frequency =
             force ? 0.0 : active_wspr_plan_dial_frequency;
-        WsprDialFrequencyEntry next_active_wspr_plan_frequency_entry =
-            force ? WsprDialFrequencyEntry{} : active_wspr_plan_frequency_entry;
+        WsprFrequencyEntry next_active_wspr_plan_frequency_entry =
+            force ? WsprFrequencyEntry{} : active_wspr_plan_frequency_entry;
         bool next_active_wspr_plan_in_progress =
             force ? false : active_wspr_plan_in_progress;
         if (force)
@@ -2803,7 +2713,7 @@ bool set_config(bool force)
         }
 
         static double last_freq = 0.0;
-        static WsprDialFrequencyEntry last_frequency_entry{};
+        static WsprFrequencyEntry last_frequency_entry{};
         if (next_active_wspr_plan_in_progress && next_active_wspr_frame_index > 0U)
         {
             next_current_dial_frequency = next_active_wspr_plan_dial_frequency;
@@ -2813,7 +2723,7 @@ bool set_config(bool force)
         else
         {
             next_current_frequency_entry = next_frequency_entry_from(
-                working_config.wspr_dial_frequency_entries,
+                working_config.wspr_frequency_entries,
                 next_freq_iterator,
                 force);
             next_current_dial_frequency =
@@ -2822,7 +2732,8 @@ bool set_config(bool force)
 
         const bool frequency_entry_changed =
             next_current_frequency_entry.token != last_frequency_entry.token ||
-            next_current_frequency_entry.control_gpio != last_frequency_entry.control_gpio;
+            next_current_frequency_entry.selector_gpio != last_frequency_entry.selector_gpio ||
+            next_current_frequency_entry.selector_gpio_active_high != last_frequency_entry.selector_gpio_active_high;
 
         if (next_current_dial_frequency != last_freq || frequency_entry_changed)
         {
@@ -2891,7 +2802,7 @@ bool set_config(bool force)
                 stop_active_transmission_selectors();
                 current_transmission_request = TransmissionRequest{};
                 current_dial_frequency = 0.0;
-                current_frequency_entry = WsprDialFrequencyEntry{};
+                current_frequency_entry = WsprFrequencyEntry{};
                 freq_iterator = next_freq_iterator;
                 active_wspr_plan = next_active_wspr_plan;
                 active_wspr_frame_index = next_active_wspr_frame_index;
@@ -2987,40 +2898,9 @@ bool set_config(bool force)
 
             next_transmission_request.applied_offset_hz = applied_offset_hz;
 
-            if (!prepare_frequency_entry_gpio_or_log(
-                    next_current_frequency_entry,
-                    working_config,
-                    working_config.tx_freq_control_active_high,
-                    ERROR))
-            {
-                stop_active_transmission_selectors();
-
-                if (newer_reload_arrived())
-                {
-                    continue;
-                }
-
-                if (is_managed_persistent_mode())
-                {
-                    set_managed_reload_tx_inhibited(
-                        true,
-                        "Managed reload could not prepare selector GPIO. Future transmissions disabled until a valid configuration is loaded.");
-                    send_ws_message("configuration", "reload_failed");
-                    if (!finalize_reload_pending())
-                    {
-                        continue;
-                    }
-                    return true;
-                }
-
-                ini_reload_pending.store(false, std::memory_order_relaxed);
-                config.transmit = false;
-                config_to_json();
-                return false;
-            }
-
             if (!prepare_band_gpio_for_frequency_or_log(
                     next_current_dial_frequency,
+                    next_current_frequency_entry,
                     working_config))
             {
                 stop_active_transmission_selectors();

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -4,8 +4,8 @@
  *
  * This layer owns scheduling and request construction for the current
  * architecture. It decides whether a slot runs WSPR or direct tone,
- * applies any random WSPR offset, resolves per-frequency control GPIO
- * metadata, prepares selector state, and commits the single execution
+ * applies any random WSPR offset, resolves band-selector GPIO state from
+ * the scheduler source frequency, and commits the single execution
  * request consumed by the transmitter.
  *
  * The transmitter executes only already-committed requests. Hardware

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -171,18 +171,18 @@ namespace
 
         reset_runtime_planning_state_for_identity_test();
         require(set_config(true), message + " must succeed during scheduler planning");
-        const WsprTransmissionRequest request = current_transmission_request_for_test();
+        const TransmissionRequest request = current_transmission_request_for_test();
         require(
-            request.mode == WsprTransmissionMode::WSPR,
+            request.mode == TransmissionMode::WSPR,
             message + " must commit a WSPR execution request");
         require(
-            request.wspr_plan.plan_type == expected_plan_type,
+            request.payload.plan_type == expected_plan_type,
             message + " must commit the expected plan type");
         require(
-            request.wspr_plan.callsign == expected_callsign,
+            request.payload.callsign == expected_callsign,
             message + " must commit the normalized callsign expected by runtime planning");
         require(
-            request.wspr_plan.locator == expected_locator,
+            request.payload.locator == expected_locator,
             message + " must commit the normalized locator expected by runtime planning");
 
         const WsprRuntimeStatusSnapshot snapshot =
@@ -331,30 +331,35 @@ int main()
         init_config_json();
         json_to_config();
         config.transmit = true;
-        config.frequencies = "80m@17,40m@27,20m,14.097100MHz@22";
+        config.frequencies = "80m@17H,40m@27L,20m,14.097100MHz@22";
 
         require(
             set_frequencies(config),
             "mixed frequency lists with optional @GPIO suffixes must parse");
         require(
-            config.wspr_dial_frequency_entries.size() == 4,
+            config.wspr_frequency_entries.size() == 4,
             "parsed frequency entries must preserve all configured tokens");
         require(
-            config.wspr_dial_frequency_entries[0].control_gpio == 17 &&
-                nearly_equal(config.wspr_dial_frequency_entries[0].dial_frequency_hz, 3568600.0),
-            "80m@17 must retain the GPIO mapping and dial frequency");
+            config.wspr_frequency_entries[0].selector_gpio == 17 &&
+                config.wspr_frequency_entries[0].selector_gpio_active_high &&
+                nearly_equal(config.wspr_frequency_entries[0].dial_frequency_hz, 3568600.0),
+            "80m@17H must retain the GPIO mapping, polarity, and dial frequency");
         require(
-            config.wspr_dial_frequency_entries[1].control_gpio == 27 &&
-                nearly_equal(config.wspr_dial_frequency_entries[1].dial_frequency_hz, 7038600.0),
-            "40m@27 must retain the GPIO mapping and dial frequency");
+            config.wspr_frequency_entries[1].selector_gpio == 27 &&
+                !config.wspr_frequency_entries[1].selector_gpio_active_high &&
+                nearly_equal(config.wspr_frequency_entries[1].dial_frequency_hz, 7038600.0),
+            "40m@27L must retain the GPIO mapping, polarity, and dial frequency");
         require(
-            config.wspr_dial_frequency_entries[2].control_gpio == kFrequencyEntryControlGpioUnset &&
-                nearly_equal(config.wspr_dial_frequency_entries[2].dial_frequency_hz, 14095600.0),
-            "entries without @GPIO must remain unmapped");
+            config.wspr_frequency_entries[2].selector_gpio == kSelectorGpioUnset &&
+                !config.wspr_frequency_entries[2].selector_gpio_active_high &&
+                !config.wspr_frequency_entries[2].allow_band_gpio_fallback &&
+                nearly_equal(config.wspr_frequency_entries[2].dial_frequency_hz, 14095600.0),
+            "CLI entries without @GPIO must remain unmapped, explicit-only, and default active low");
         require(
-            config.wspr_dial_frequency_entries[3].control_gpio == 22 &&
-                nearly_equal(config.wspr_dial_frequency_entries[3].dial_frequency_hz, 14097100.0),
-            "unit-qualified frequencies must also support @GPIO");
+            config.wspr_frequency_entries[3].selector_gpio == 22 &&
+                !config.wspr_frequency_entries[3].selector_gpio_active_high &&
+                nearly_equal(config.wspr_frequency_entries[3].dial_frequency_hz, 14097100.0),
+            "unit-qualified frequencies must also support @GPIO with default active-low polarity");
     }
 
     {
@@ -382,18 +387,16 @@ int main()
     {
         WsprTransmitter transmitter;
 
-        WsprTransmissionRequest committed_request;
-        committed_request.mode = WsprTransmissionMode::WSPR;
+        TransmissionRequest committed_request;
+        committed_request.mode = TransmissionMode::WSPR;
         committed_request.actual_rf_frequency_hz = 14097100.0;
         committed_request.ppm = 1.75;
         committed_request.power_level = 5;
         committed_request.tx_gpio = 20;
         committed_request.use_offset = true;
         committed_request.applied_offset_hz = 42.0;
-        committed_request.frequency_control_gpio = 17;
-        committed_request.frequency_control_active_high = true;
         committed_request.frequency_entry_label = "20m@17";
-        committed_request.wspr_plan.frames.resize(2);
+        committed_request.payload.frames.resize(2);
 
         transmitter.current_request_ = committed_request;
 
@@ -1129,11 +1132,11 @@ int main()
         require(
             set_config(true),
             "lowercase identity patch must still succeed during scheduler planning");
-        const WsprTransmissionRequest request = current_transmission_request_for_test();
+        const TransmissionRequest request = current_transmission_request_for_test();
         require(
-            request.wspr_plan.plan_type == "Type2Single" &&
-                request.wspr_plan.callsign == "AA0NT/12" &&
-                request.wspr_plan.locator == "EM18",
+            request.payload.plan_type == "Type2Single" &&
+                request.payload.callsign == "AA0NT/12" &&
+                request.payload.locator == "EM18",
             "runtime planning must agree with config-boundary normalization for lowercase identities");
         finish_runtime_planning_state_for_identity_test();
     }
@@ -1150,13 +1153,13 @@ int main()
         require(
             set_config(true),
             "whitespace-surrounded identities must still succeed during scheduler planning");
-        const WsprTransmissionRequest request = current_transmission_request_for_test();
+        const TransmissionRequest request = current_transmission_request_for_test();
         require(
-            request.wspr_plan.plan_type == "Type1Single",
+            request.payload.plan_type == "Type1Single",
             "runtime planning must still classify whitespace-surrounded identities as a valid Type 1 plan");
         require(
-            request.wspr_plan.callsign == "AA0NT" &&
-                request.wspr_plan.locator == "EM18",
+            request.payload.callsign == "AA0NT" &&
+                request.payload.locator == "EM18",
             "committed single-frame requests must use the same normalized identities as accepted config and planner results");
         finish_runtime_planning_state_for_identity_test();
     }
@@ -1198,11 +1201,11 @@ int main()
         require(
             set_config(true),
             "rejecting an invalid config patch must leave the prior valid config runnable");
-        const WsprTransmissionRequest request = current_transmission_request_for_test();
+        const TransmissionRequest request = current_transmission_request_for_test();
         require(
-            request.wspr_plan.plan_type == "Type1Single" &&
-                request.wspr_plan.callsign == "AA0NT" &&
-                request.wspr_plan.locator == "EM18",
+            request.payload.plan_type == "Type1Single" &&
+                request.payload.callsign == "AA0NT" &&
+                request.payload.locator == "EM18",
             "invalid config patches must fail before scheduling and preserve the prior valid runtime plan");
         finish_runtime_planning_state_for_identity_test();
     }


### PR DESCRIPTION
- Introduce WsprFrequencyEntry (rename from WsprDialFrequencyEntry)
- Replace control_gpio with selector_gpio and add selector_gpio_active_high
- Add @GPIO[H|L] parsing for per-entry selector override (default active low)
- Remove legacy per-frequency GPIO selector path; use BandGPIOSelector exclusively
- Remove tx_freq_control_active_high and all related CLI/INI plumbing
- Implement clear selection policy:
  - CLI entries: no GPIO unless explicitly specified via @GPIO[H|L]
  - INI/config entries: allow fallback to [Band GPIO] if defined
  - Unassigned bands: no selector GPIO used
- Add allow_band_gpio_fallback flag to distinguish CLI vs config behavior
- Update scheduler to derive selector source:
  - per-entry override
  - band configuration fallback (INI only)
  - or no selector
- Improve logging to clearly indicate selector source and inactive cases
- Remove dead compatibility code and obsolete JSON/INI fields
- Update semantics tests to validate GPIO parsing, polarity, and fallback behavior

Result: single, predictable GPIO selection path with explicit CLI behavior and config-driven defaults, eliminating legacy ambiguity and dead code.