### PR TITLE
Restrict GPIO transmission to Raspberry Pi <=4

### DIFF
--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1172,6 +1172,15 @@ bool validate_config_candidate(
     ArgParserConfig &candidate,
     std::string *error_message)
 {
+    resolve_backend_specific_config(candidate);
+
+    const bool backend_validation_required =
+        candidate.mode == ModeType::TONE ||
+        (!candidate.use_ini && candidate.mode != ModeType::WSPR) ||
+        (!candidate.use_ini && candidate.mode == ModeType::WSPR &&
+         !candidate.loop_tx) ||
+        candidate.transmit;
+
     if (candidate.modulation_dot_seconds <= 0.0)
     {
         if (error_message != nullptr)
@@ -1261,7 +1270,13 @@ bool validate_config_candidate(
 
     const bool requires_valid_transmit_gpio =
         candidate.transmit_backend == TransmitBackendKind::GPIO &&
-        (candidate.mode == ModeType::TONE || candidate.transmit);
+        backend_validation_required;
+
+    if (requires_valid_transmit_gpio &&
+        !platform_supports_gpio_clock_transmission(error_message))
+    {
+        return false;
+    }
 
     if (requires_valid_transmit_gpio &&
         !is_valid_runtime_transmit_gpio(candidate.gpio_tx_pin))
@@ -1275,7 +1290,7 @@ bool validate_config_candidate(
     }
 
     if (candidate.transmit_backend == TransmitBackendKind::SI5351 &&
-        (candidate.mode == ModeType::TONE || candidate.transmit))
+        backend_validation_required)
     {
         if (candidate.si5351_i2c_bus < 0)
         {
@@ -1335,7 +1350,7 @@ bool validate_config_candidate(
         }
     }
     else if (candidate.transmit_backend == TransmitBackendKind::GPIO &&
-             (candidate.mode == ModeType::TONE || candidate.transmit) &&
+             backend_validation_required &&
              (candidate.gpio_power_level < 0 || candidate.gpio_power_level > 7))
     {
         if (error_message != nullptr)
@@ -1781,14 +1796,32 @@ void apply_runtime_config_side_effects()
     }
 }
 
-bool validate_config_data()
+bool validate_config_data_for_test(
+    std::string *validation_error) noexcept
 {
+    // Regression tests need the same startup validation path without the
+    // process-exit behavior used by the normal CLI failure flow.
     resolve_backend_specific_config(config);
     sync_wspr_mode_config(config);
     ini_reload_pending.store(false, std::memory_order_relaxed);
 
+    std::string local_validation_error;
+    if (!validate_config_candidate(config, &local_validation_error))
+    {
+        if (validation_error != nullptr)
+        {
+            *validation_error = local_validation_error;
+        }
+        return false;
+    }
+
+    return true;
+}
+
+bool validate_config_data()
+{
     std::string validation_error;
-    if (!validate_config_candidate(config, &validation_error))
+    if (!validate_config_data_for_test(&validation_error))
     {
         llog.logE(
             FATAL,
@@ -1812,19 +1845,33 @@ bool validate_config_data()
         {
             llog.logE(ERROR, " - At least one WSPR dial frequency must be specified.");
         }
-        if ((config.mode == ModeType::TONE || config.transmit) &&
+        const bool backend_validation_required =
+            config.mode == ModeType::TONE ||
+            (!config.use_ini && config.mode != ModeType::WSPR) ||
+            (!config.use_ini && config.mode == ModeType::WSPR &&
+             !config.loop_tx) ||
+            config.transmit;
+        if (backend_validation_required &&
+            config.transmit_backend == TransmitBackendKind::GPIO &&
+            !platform_supports_gpio_clock_transmission())
+        {
+            std::string platform_error;
+            (void)platform_supports_gpio_clock_transmission(&platform_error);
+            llog.logE(ERROR, " - ", platform_error);
+        }
+        if (backend_validation_required &&
             config.transmit_backend == TransmitBackendKind::GPIO &&
             !is_valid_runtime_transmit_gpio(config.tx_pin))
         {
             llog.logE(ERROR, " - ", transmit_gpio_validation_message());
         }
-        if ((config.mode == ModeType::TONE || config.transmit) &&
+        if (backend_validation_required &&
             config.transmit_backend == TransmitBackendKind::GPIO &&
             (config.gpio_power_level < 0 || config.gpio_power_level > 7))
         {
             llog.logE(ERROR, " - Invalid GPIO power level. Expected 0 through 7.");
         }
-        if ((config.mode == ModeType::TONE || config.transmit) &&
+        if (backend_validation_required &&
             config.transmit_backend == TransmitBackendKind::SI5351)
         {
             if (config.si5351_i2c_bus < 0)

--- a/src/arg_parser.hpp
+++ b/src/arg_parser.hpp
@@ -172,6 +172,8 @@ extern void show_config_values(bool reload = false);
  * @return false if validation fails (application exits).
  */
 extern bool validate_config_data();
+bool validate_config_data_for_test(
+    std::string *validation_error = nullptr) noexcept;
 
 bool validate_config_candidate(
     ArgParserConfig &candidate,

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -2765,6 +2765,43 @@ bool set_config(bool force)
         bool do_config = force;
         bool do_random = false;
 
+        std::string backend_platform_error;
+        const bool backend_platform_supported =
+            !(working_config.mode == ModeType::TONE ||
+              runtime_transmit_requested(working_config))
+            || working_config.transmit_backend != TransmitBackendKind::GPIO
+            || platform_supports_gpio_clock_transmission(
+                &backend_platform_error);
+
+        if (!backend_platform_supported)
+        {
+            llog.logS(ERROR, backend_platform_error);
+
+            if (working_config.use_ini)
+            {
+                set_managed_reload_tx_inhibited(
+                    true,
+                    "No transmit due to invalid backend/platform combination.");
+                wsprTransmitter.stopAndJoin();
+                stop_active_transmission_selectors();
+                current_transmission_request = TransmissionRequest{};
+                current_dial_frequency = 0.0;
+                current_frequency_entry = WsprFrequencyEntry{};
+
+                if (!finalize_reload_pending())
+                {
+                    continue;
+                }
+                return true;
+            }
+
+            if (!finalize_reload_pending())
+            {
+                continue;
+            }
+            return false;
+        }
+
         bool ppm_running = ppmManager.isRunning();
         bool should_start_ppm = working_config.use_ntp && !ppm_running;
         if (should_start_ppm)
@@ -3259,4 +3296,9 @@ bool current_band_gpio_selection_for_test(
 TransmissionRequest current_transmission_request_for_test()
 {
     return current_transmission_request;
+}
+
+void reset_current_transmission_request_for_test() noexcept
+{
+    current_transmission_request = TransmissionRequest{};
 }

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -307,5 +307,6 @@ bool current_band_gpio_selection_for_test(
     BandGPIOConfig &config_out,
     std::string &band_label_out) noexcept;
 TransmissionRequest current_transmission_request_for_test();
+void reset_current_transmission_request_for_test() noexcept;
 
 #endif // _SCHEDULING_HPP

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -3,6 +3,7 @@
 #include "frequency_semantics.hpp"
 #include "scheduling.hpp"
 #include "wspr_band_lookup.hpp"
+#include "wspr_transmit_backend_si5351.hpp"
 
 #include <cmath>
 #include <cstdlib>
@@ -187,6 +188,11 @@ namespace
         set_scheduler_execution_suppressed_for_test(false);
     }
 
+    void clear_pi_generation_override_for_scope() noexcept
+    {
+        clear_raspberry_pi_generation_override_for_test();
+    }
+
     void require_patch_accepts_and_runtime_plans(
         const nlohmann::json &patch,
         const std::string &expected_plan_type,
@@ -295,6 +301,158 @@ int main()
             resolve_actual_rf_frequency_hz(730000.0, 1500.0, FrequencyPath::DirectRf),
             730000.0),
         "Direct-RF paths must not apply the WSPR audio offset");
+
+    {
+        set_raspberry_pi_generation_override_for_test(4);
+        prime_valid_runtime_identity_config();
+        reset_runtime_planning_state_for_identity_test();
+
+        std::string validation_error;
+        require(
+            validate_config_candidate(config, &validation_error),
+            "GPIO backend must remain allowed on Raspberry Pi 4");
+        require(
+            set_config(true),
+            "scheduler must allow GPIO execution requests on Raspberry Pi 4");
+        require(
+            current_transmission_request_for_test().mode == TransmissionMode::WSPR,
+            "scheduler must commit a normal WSPR request for GPIO on Raspberry Pi 4");
+
+        finish_runtime_planning_state_for_identity_test();
+        clear_pi_generation_override_for_scope();
+    }
+
+    {
+        set_raspberry_pi_generation_override_for_test(5);
+        prime_valid_runtime_identity_config();
+
+        std::string validation_error;
+        require(
+            !validate_config_candidate(config, &validation_error),
+            "GPIO backend must be rejected on Raspberry Pi 5");
+        require(
+            validation_error.find(
+                "GPIO transmission mode is unsupported on Raspberry Pi 5 and newer.") !=
+                std::string::npos,
+            "GPIO backend rejection on Raspberry Pi 5 must explain the unsupported platform");
+
+        PreparedConfigCandidate candidate;
+        iniFile.setData(make_managed_ini_data("AA0NT", "EM18", "20m", true));
+        prepare_ini_config_candidate("/tmp/gpio_pi5.ini", candidate);
+        require(
+            !candidate.valid,
+            "managed GPIO configuration must be rejected on Raspberry Pi 5");
+        require(
+            candidate.error_reason.find(
+                "GPIO transmission mode is unsupported on Raspberry Pi 5 and newer.") !=
+                std::string::npos,
+            "managed GPIO rejection on Raspberry Pi 5 must preserve the platform error");
+
+        clear_pi_generation_override_for_scope();
+    }
+
+    {
+        set_raspberry_pi_generation_override_for_test(5);
+        reset_current_transmission_request_for_test();
+        reset_getopt_state();
+
+        std::vector<std::string> args = {
+            "wsprrypi",
+            "--backend",
+            "gpio",
+            "AA0NT",
+            "EM18",
+            "20",
+            "20m"};
+        std::vector<char *> argv = argv_for(args);
+
+        require(
+            parse_command_line(static_cast<int>(argv.size()), argv.data()),
+            "CLI GPIO setup on Raspberry Pi 5 must still parse before validation");
+        std::string validation_error;
+        require(
+            !validate_config_data_for_test(&validation_error),
+            "CLI startup validation must fail for GPIO on Raspberry Pi 5");
+        require(
+            validation_error.find(
+                "GPIO transmission mode is unsupported on Raspberry Pi 5 and newer.") !=
+                std::string::npos,
+            "CLI startup validation on Raspberry Pi 5 must report the GPIO platform error");
+        require(
+            current_transmission_request_for_test().actual_rf_frequency_hz == 0.0 &&
+                current_transmission_request_for_test().payload.frames.empty(),
+            "CLI startup failure on Raspberry Pi 5 must not commit a transmission request");
+
+        clear_pi_generation_override_for_scope();
+    }
+
+    {
+        set_raspberry_pi_generation_override_for_test(5);
+        prime_valid_runtime_identity_config();
+        config.transmit_backend = TransmitBackendKind::SI5351;
+        config.si5351_i2c_bus = 1;
+        config.si5351_i2c_address = 0x60;
+        config.si5351_reference_hz = 27000000;
+        config.si5351_tx_output = 0;
+        config.si5351_power_level = 1;
+        resolve_backend_specific_config(config);
+
+        std::string validation_error;
+        require(
+            validate_config_candidate(config, &validation_error),
+            "non-GPIO backends must remain allowed on Raspberry Pi 5");
+
+        clear_pi_generation_override_for_scope();
+    }
+
+    {
+        set_raspberry_pi_generation_override_for_test(5);
+
+        WsprSi5351Backend::Config si5351_config;
+        si5351_config.device.i2c_bus = 1;
+        si5351_config.device.i2c_address = 0x60;
+        si5351_config.device.reference_hz = 27000000;
+        si5351_config.planner.reference_hz = 27000000;
+        si5351_config.planner.tx_output = Si5351Device::Output::CLK0;
+        si5351_config.power_level = 1;
+        si5351_config.dry_run = true;
+
+        WsprSi5351Backend backend(wsprTransmitter, si5351_config);
+
+        wsprrypi::ExecutionPlan plan;
+        plan.id.value = 1;
+        plan.request_id.value = 1;
+        plan.mode = wsprrypi::TransmissionMode::TONE;
+        plan.backend = wsprrypi::BackendKind::SI5351;
+        plan.reference_frequency_hz = 14097100.0;
+        plan.events.push_back(wsprrypi::RfEvent{
+            std::chrono::nanoseconds{0},
+            std::chrono::milliseconds{1},
+            wsprrypi::RfEventType::RF_ON,
+            14097100.0,
+            true,
+            {}});
+        plan.summary.total_duration = std::chrono::milliseconds{1};
+        plan.summary.event_count = plan.events.size();
+        plan.summary.min_frequency_hz = 14097100.0;
+        plan.summary.max_frequency_hz = 14097100.0;
+
+        wsprrypi::BackendExecutionInputs inputs;
+        inputs.power_level = 1;
+
+        const wsprrypi::BackendCompileResult compile_result =
+            backend.configure(plan, inputs);
+        require(
+            compile_result.ok,
+            "Si5351 backend configure path must remain allowed on Raspberry Pi 5");
+
+        const wsprrypi::ExecutionResult execute_result = backend.execute(plan);
+        require(
+            execute_result.ok,
+            "Si5351 backend execution path must remain allowed on Raspberry Pi 5");
+
+        clear_pi_generation_override_for_scope();
+    }
 
     {
         init_config_json();

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -33,10 +33,12 @@
 
 // Standard library headers
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <fstream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -46,6 +48,73 @@ constexpr bool kDebugWspr = true;
 #else
 constexpr bool kDebugWspr = false;
 #endif
+
+namespace
+{
+    std::optional<int> g_pi_generation_override;
+
+    std::optional<int> parse_generation_from_pi_model(
+        const std::string &model)
+    {
+        const std::size_t pi_pos = model.find("Raspberry Pi");
+        if (pi_pos == std::string::npos)
+        {
+            return std::nullopt;
+        }
+
+        for (std::size_t i = pi_pos; i < model.size(); ++i)
+        {
+            if (!std::isdigit(static_cast<unsigned char>(model[i])))
+            {
+                continue;
+            }
+
+            std::size_t end = i;
+            while (end < model.size() &&
+                   std::isdigit(static_cast<unsigned char>(model[end])))
+            {
+                ++end;
+            }
+
+            int generation = std::stoi(model.substr(i, end - i));
+            if (generation >= 100 && generation % 100 == 0)
+            {
+                generation /= 100;
+            }
+            return generation;
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<int> parse_generation_from_processor_string(
+        const std::string &processor)
+    {
+        if (processor.find("BCM2712") != std::string::npos)
+        {
+            return 5;
+        }
+        if (processor.find("BCM2711") != std::string::npos ||
+            processor.find("BCM2838") != std::string::npos)
+        {
+            return 4;
+        }
+        if (processor.find("BCM2837") != std::string::npos)
+        {
+            return 3;
+        }
+        if (processor.find("BCM2836") != std::string::npos)
+        {
+            return 2;
+        }
+        if (processor.find("BCM2835") != std::string::npos)
+        {
+            return 1;
+        }
+
+        return std::nullopt;
+    }
+}
 
 /**
  * @brief Converts a value to a string view.
@@ -360,6 +429,85 @@ std::string get_pi_model()
         model.pop_back();
 
     return model;
+}
+
+int get_raspberry_pi_generation()
+{
+    if (g_pi_generation_override.has_value())
+    {
+        return *g_pi_generation_override;
+    }
+
+    if (const auto model_generation =
+            parse_generation_from_pi_model(get_pi_model());
+        model_generation.has_value())
+    {
+        return *model_generation;
+    }
+
+    if (const auto processor_generation =
+            parse_generation_from_processor_string(get_processor_string());
+        processor_generation.has_value())
+    {
+        return *processor_generation;
+    }
+
+    return -1;
+}
+
+bool platform_supports_gpio_clock_transmission(
+    std::string *error_message)
+{
+    const int generation = get_raspberry_pi_generation();
+    if (generation >= 1 && generation <= 4)
+    {
+        return true;
+    }
+
+    if (generation >= 5)
+    {
+        std::string message =
+            "GPIO transmission mode is unsupported on Raspberry Pi 5 and newer.";
+        const std::string model = get_pi_model();
+        if (!model.empty())
+        {
+            message += " Detected platform: " + model + ".";
+        }
+
+        if (error_message != nullptr)
+        {
+            *error_message = message;
+        }
+        return false;
+    }
+
+    if (error_message != nullptr)
+    {
+        std::string message =
+            "GPIO transmission mode is supported only on Raspberry Pi 1 through 4.";
+        const std::string model = get_pi_model();
+        if (!model.empty())
+        {
+            message += " Detected platform: " + model + ".";
+        }
+        else
+        {
+            message += " Platform generation could not be confirmed.";
+        }
+        *error_message = message;
+    }
+
+    return false;
+}
+
+void set_raspberry_pi_generation_override_for_test(int generation) noexcept
+{
+    g_pi_generation_override = generation;
+}
+
+void clear_raspberry_pi_generation_override_for_test() noexcept
+{
+    g_pi_generation_override.reset();
 }
 
 /**

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -92,6 +92,11 @@ extern std::string get_debug_state();
  * ```
  */
 extern std::string get_pi_model();
+int get_raspberry_pi_generation();
+bool platform_supports_gpio_clock_transmission(
+    std::string *error_message = nullptr);
+void set_raspberry_pi_generation_override_for_test(int generation) noexcept;
+void clear_raspberry_pi_generation_override_for_test() noexcept;
 
 /**
  * @brief Return the operating system version name.


### PR DESCRIPTION
Disallow GPIO backend on Pi 5+ and unknown platforms. Enforce at config validation (CLI + INI), add scheduler and backend guards, and ensure invalid configs do not commit or transmit.

Includes tests for Pi 4 (allowed), Pi 5 (rejected), and Si5351 on Pi 5.