### PR TITLE
Improve runtime robustness: safe shutdown ordering, non-fatal RT scheduling, and dynamic config reload fixes

### DIFF
--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -1275,7 +1275,11 @@ namespace
         target.si5351_reference_hz = source.si5351_reference_hz;
         target.si5351_tx_output = source.si5351_tx_output;
         target.si5351_power_level = source.si5351_power_level;
+        target.use_led = source.use_led;
+        target.led_pin = source.led_pin;
+        target.web_port = source.web_port;
         target.socket_port = source.socket_port;
+        target.use_shutdown = source.use_shutdown;
         target.shutdown_pin = source.shutdown_pin;
         target.use_journald = source.use_journald;
         target.date_time_log = source.date_time_log;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -381,6 +381,19 @@ int main(int argc, char *argv[])
     }
     close_async_shutdown_pipe();
 
+    if (reboot_flag.load(std::memory_order_acquire))
+    {
+        llog.logS(INFO, "Rebooting.");
+        std::cerr << "[INFO ] Rebooting." << std::endl;
+        reboot_machine();
+    }
+    if (shutdown_flag.load(std::memory_order_acquire))
+    {
+        llog.logS(INFO, "Shutting down.");
+        std::cerr << "[INFO ] Shutting down." << std::endl;
+        shutdown_machine();
+    }
+
     // Graceful shutdown preserves Unix signal semantics by returning 128 +
     // signum after cleanup completes.
     if (retval == EXIT_SUCCESS)

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -2219,17 +2219,18 @@ StopTransmissionResult stop_transmission_by_user_request()
     return result;
 }
 
-static void stop_runtime_components_for_early_exit() noexcept
+static void stop_runtime_components_for_process_exit() noexcept
 {
     ini_reload_pending.store(false, std::memory_order_relaxed);
-    iniMonitor.stop();
-    wsprTransmitter.stopAndJoin();
-    stop_active_transmission_selectors();
-    shutdownMonitor.stop();
-    ledControl.stop();
-    ppmManager.stop();
+
     webServer.stop();
     socketServer.stop();
+    iniMonitor.stop();
+    shutdownMonitor.stop();
+    ppmManager.stop();
+    wsprTransmitter.shutdownForProcessExit();
+    stop_active_transmission_selectors();
+    ledControl.stop();
 }
 
 /**
@@ -2344,7 +2345,7 @@ bool wspr_loop()
         ini_reload_pending.store(!startup_config_handoff, std::memory_order_relaxed);
         if (!set_config(startup_config_handoff ? false : true))
         {
-            stop_runtime_components_for_early_exit();
+            stop_runtime_components_for_process_exit();
             return false;
         }
     }
@@ -2356,7 +2357,7 @@ bool wspr_loop()
         if (!try_get_direct_tone_startup_request(entry, actual_rf_frequency_hz))
         {
             llog.logE(ERROR, "Direct RF test tone requested without a startup tone request.");
-            stop_runtime_components_for_early_exit();
+            stop_runtime_components_for_process_exit();
             return false;
         }
 
@@ -2389,7 +2390,7 @@ bool wspr_loop()
             shutdown_after_wspr_plan.store(false, std::memory_order_release);
             if (!start_non_wspr_transmission_now(config))
             {
-                stop_runtime_components_for_early_exit();
+                stop_runtime_components_for_process_exit();
                 return false;
             }
         }
@@ -2409,7 +2410,7 @@ bool wspr_loop()
             shutdown_after_wspr_plan.store(false, std::memory_order_release);
             if (!start_non_wspr_transmission_now(config))
             {
-                stop_runtime_components_for_early_exit();
+                stop_runtime_components_for_process_exit();
                 return false;
             }
         }
@@ -2429,7 +2430,7 @@ bool wspr_loop()
             shutdown_after_wspr_plan.store(false, std::memory_order_release);
             if (!start_non_wspr_transmission_now(config))
             {
-                stop_runtime_components_for_early_exit();
+                stop_runtime_components_for_process_exit();
                 return false;
             }
         }
@@ -2457,52 +2458,40 @@ bool wspr_loop()
     // -------------------------------------------------------------------------
     llog.logS(INFO, "Stopping runtime components.");
 
+    llog.logS(INFO, "Stopping web server.");
+    webServer.stop();
+    llog.logS(INFO, "Web server stopped.");
+
+    llog.logS(INFO, "Stopping socket server.");
+    socketServer.stop();
+    llog.logS(INFO, "Socket server stopped.");
+
     llog.logS(INFO, "Stopping configuration monitor.");
     ini_reload_pending.store(false, std::memory_order_relaxed);
     iniMonitor.stop(); // Stop config file monitor before transmitter teardown.
     llog.logS(INFO, "Configuration monitor stopped.");
 
+    llog.logS(INFO, "Stopping shutdown monitor.");
+    shutdownMonitor.stop(); // Stop the GPIO monitor
+    llog.logS(INFO, "Shutdown monitor stopped.");
+
+    llog.logS(INFO, "Stopping PPM manager.");
+    ppmManager.stop(); // Stop PPM manager (if active)
+    llog.logS(INFO, "PPM manager stopped.");
+
     llog.logS(INFO, "Stopping transmitter.");
-    wsprTransmitter.stopAndJoin(); // Stop the transmitter threads
+    wsprTransmitter.shutdownForProcessExit();
     llog.logS(INFO, "Transmitter stopped.");
 
     llog.logS(INFO, "Stopping band GPIO selector.");
     stop_active_transmission_selectors();
     llog.logS(INFO, "Band GPIO selector stopped.");
 
-    llog.logS(INFO, "Stopping shutdown monitor.");
-    shutdownMonitor.stop(); // Stop the GPIO monitor
-    llog.logS(INFO, "Shutdown monitor stopped.");
-
     llog.logS(INFO, "Stopping LED driver.");
     ledControl.stop(); // Stop LED driver
     llog.logS(INFO, "LED driver stopped.");
 
-    llog.logS(INFO, "Stopping PPM manager.");
-    ppmManager.stop(); // Stop PPM manager (if active)
-    llog.logS(INFO, "PPM manager stopped.");
-
-    llog.logS(INFO, "Stopping web server.");
-    webServer.stop(); // Stop web server
-
-    llog.logS(INFO, "Stopping socket server.");
-    socketServer.stop(); // Stop the socket server
-    llog.logS(INFO, "Socket server stopped.");
-
     llog.logS(INFO, "Runtime components stopped.");
-
-    if (reboot_flag.load())
-    {
-        llog.logS(INFO, "Rebooting.");
-        std::cerr << "[INFO ] Rebooting." << std::endl;
-        reboot_machine();
-    }
-    if (shutdown_flag.load())
-    {
-        llog.logS(INFO, "Shutting down.");
-        std::cerr << "[INFO ] Shutting down." << std::endl;
-        shutdown_machine();
-    }
 
     llog.logS(INFO, get_project_name(), "exiting.");
     // Flush all file system buffers to disk

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -95,6 +95,7 @@ extern bool exitwspr_ready;
  * Other threads can poll or wait on this flag to terminate safely.
  */
 extern std::atomic<bool> shutdown_flag;
+extern std::atomic<bool> reboot_flag;
 
 /**
  * @brief Callback triggered by a shutdown GPIO event.

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1562,6 +1562,36 @@ int main()
     }
 
     {
+        init_default_config();
+        PreparedConfigCandidate candidate;
+        candidate.valid = true;
+        candidate.normalized_config = config;
+        candidate.normalized_config.use_led = true;
+        candidate.normalized_config.led_pin = 18;
+        candidate.normalized_config.web_port = 31555;
+        candidate.normalized_config.use_shutdown = true;
+        candidate.normalized_config.shutdown_pin = 19;
+        candidate.normalized_json = jConfig;
+        candidate.normalized_json["Operation"]["Use LED"] = true;
+        candidate.normalized_json["Operation"]["LED Pin"] = 18;
+        candidate.normalized_json["Operation"]["Web Port"] = 31555;
+        candidate.normalized_json["Operation"]["Use Shutdown"] = true;
+        candidate.normalized_json["Operation"]["Shutdown Button"] = 19;
+
+        commit_config_candidate(candidate);
+
+        require(
+            config.use_led && config.led_pin == 18,
+            "managed config candidate commit must update LED runtime settings");
+        require(
+            config.web_port == 31555,
+            "managed config candidate commit must update web server port in live config");
+        require(
+            config.use_shutdown && config.shutdown_pin == 19,
+            "managed config candidate commit must update shutdown GPIO settings");
+    }
+
+    {
         init_config_json();
         jConfig["CW"]["Dot Seconds"] = 2.0;
         jConfig["CW"]["Intra Element Gap"] = 1.5;


### PR DESCRIPTION
## Overview

This PR improves runtime reliability and correctness across three areas:

- Prevent process termination when real-time (RT) scheduling is unavailable
- Ensure orderly shutdown of major runtime threads before exit or system power actions
- Fix managed INI reload so runtime configuration changes (e.g. LED control) are applied correctly

These changes are intentionally narrow and focused on correctness and predictable behavior without broad architectural refactors.

---

## 1. TX thread: make RT scheduling failure non-fatal

Previously, failure to apply RT scheduling (`pthread_setschedparam`) in the TX thread could throw out of the thread entry and trigger `std::terminate`.

### Changes

- Make `WsprTransmitter::set_thread_priority()` best-effort
- Log a warning on failure instead of throwing
- Continue execution under current scheduler (typically `SCHED_OTHER`)

### Result

- Transmission no longer crashes when RT privileges are unavailable
- Behavior degrades safely while preserving RT timing when permitted

---

## 2. Shutdown: enforce stop-then-join before exit and reboot

Shutdown paths previously allowed OS reboot/poweroff to be triggered before all runtime threads were fully stopped.

### Changes

- Move `reboot_machine()` / `shutdown_machine()` out of scheduler and into `main()`
- Ensure scheduler performs full runtime teardown before returning:
  - web server and websocket server
  - INI monitor and GPIO shutdown monitor
  - PPM manager
  - transmitter (TX thread, scheduler, watchdog/backend)
- Add `WsprTransmitter::shutdownForProcessExit()` to explicitly stop:
  - backend-owned threads (e.g. recovery/watchdog)
  - transmitter callback worker
- Stop signal handler and async shutdown monitor in `main()` before invoking OS power actions

### Result

- All major owned runtime threads are stopped before process exit or OS reboot/poweroff
- Eliminates race where system shutdown could occur while threads were still active

### Note

- Two detached helper threads (non-WSPR launch helper and PPM callback dispatch) are not part of this guarantee and may still exist briefly during exit

---

## 3. Config reload: apply LED and shutdown settings dynamically

Managed INI reload was not applying certain runtime configuration changes due to incomplete copying of config fields.

### Root cause

`copy_config()` did not copy:

- `use_led`
- `led_pin`
- `use_shutdown`
- `web_port`

As a result, runtime side effects used stale values.

### Changes

- Copy missing fields into live config during candidate commit
- Add regression test to verify correct propagation

### Result

The following settings now update dynamically on INI reload without restart:

- Use LED
- LED Pin
- Use Shutdown
- Shutdown Button

### Important nuance

- `web_port` is now updated in live config, but the web server does not restart/rebind on reload, so port changes remain startup-only in practice

---

## Validation

- `make debug` passed
- `make semantics-test` passed
- Added regression coverage for managed config reload behavior

---

## Summary

This PR:

- Removes a crash condition in TX thread startup
- Guarantees orderly shutdown of major runtime threads before exit/reboot
- Fixes dynamic config reload for LED and shutdown controls

Overall, it improves robustness, correctness, and runtime predictability on Raspberry Pi systems.
