### PR TITLE
Fix GPIO resolver ambiguity by collapsing duplicate gpiochip views

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -113,6 +113,8 @@ TEST_OUT := $(strip $(EXE_NAME)_debug)
 SEMANTICS_TEST_OUT := dial_frequency_semantics_test
 BAND_GPIO_ROTATION_TEST_OUT := band_gpio_rotation_test
 MONITOR_FILE_REGRESSION_TEST_OUT := monitor_file_regression_test
+GPIO_LOOPBACK_TEST_OUT := gpio_loopback_test
+BAND_GPIO_LIVE_MONITOR_OUT := band_gpio_live_monitor
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Output directories
@@ -148,6 +150,12 @@ MONITOR_FILE_REGRESSION_TEST_SRC := tests/monitor_file_regression_test.cpp
 MONITOR_FILE_REGRESSION_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/monitor_file_regression_test.o
 MONITOR_FILE_DEBUG_OBJ := $(OBJ_DIR_DEBUG)/./MonitorFile/src/monitorfile.o
 MONITOR_FILE_REGRESSION_TEST_DEPS := $(MONITOR_FILE_DEBUG_OBJ)
+GPIO_LOOPBACK_TEST_SRC := tests/gpio_loopback_test.cpp
+GPIO_LOOPBACK_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/gpio_loopback_test.o
+GPIO_LOOPBACK_TEST_DEPS := $(GPIO_LOOPBACK_TEST_OBJ)
+BAND_GPIO_LIVE_MONITOR_SRC := tests/band_gpio_live_monitor.cpp
+BAND_GPIO_LIVE_MONITOR_OBJ := $(OBJ_DIR_DEBUG)/tests/band_gpio_live_monitor.o
+BAND_GPIO_LIVE_MONITOR_DEPS := $(BAND_GPIO_LIVE_MONITOR_OBJ)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Dependency includes
@@ -254,6 +262,12 @@ ifeq ($(GPIOD_API_MAJOR),)
 GPIOD_API_MAJOR := 1
 endif
 
+ifeq ($(shell [ "$(GPIOD_API_MAJOR)" -ge 2 ] 2>/dev/null && echo yes),yes)
+GPIOD_HAS_V2 := 1
+else
+GPIOD_HAS_V2 := 0
+endif
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Flags
 # ─────────────────────────────────────────────────────────────────────────────
@@ -357,6 +371,30 @@ $(BIN_DIR)/$(MONITOR_FILE_REGRESSION_TEST_OUT): $(MONITOR_FILE_REGRESSION_TEST_O
 	$(Q)echo "Linking debug: $(MONITOR_FILE_REGRESSION_TEST_OUT)"
 	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
 
+ifeq ($(GPIOD_HAS_V2),1)
+$(GPIO_LOOPBACK_TEST_OBJ): $(GPIO_LOOPBACK_TEST_SRC)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)mkdir -p $(DEP_DIR)/tests
+	$(Q)echo "Compiling (debug) $< into $@"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) -MF $(DEP_DIR)/tests/gpio_loopback_test.d -c $< -o $@
+
+$(BIN_DIR)/$(GPIO_LOOPBACK_TEST_OUT): $(GPIO_LOOPBACK_TEST_DEPS)
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)echo "Linking debug: $(GPIO_LOOPBACK_TEST_OUT)"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
+
+$(BAND_GPIO_LIVE_MONITOR_OBJ): $(BAND_GPIO_LIVE_MONITOR_SRC)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)mkdir -p $(DEP_DIR)/tests
+	$(Q)echo "Compiling (debug) $< into $@"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) -MF $(DEP_DIR)/tests/band_gpio_live_monitor.d -c $< -o $@
+
+$(BIN_DIR)/$(BAND_GPIO_LIVE_MONITOR_OUT): $(BAND_GPIO_LIVE_MONITOR_DEPS)
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)echo "Linking debug: $(BAND_GPIO_LIVE_MONITOR_OUT)"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
+endif
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Compile rules (release)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -386,7 +424,7 @@ $(BIN_DIR)/$(OUT): $(CPP_OBJECTS)
 # Phony targets
 # ─────────────────────────────────────────────────────────────────────────────
 
-.PHONY: clean release debug test test-tone test-oneshot semantics-test band-gpio-rotation-test monitor-file-regression-test gdb install debuginstall uninstall lint macros help
+.PHONY: clean release debug test test-tone test-oneshot semantics-test band-gpio-rotation-test monitor-file-regression-test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
 DEBUG: debug
 RELEASE: release
 
@@ -424,6 +462,22 @@ band-gpio-rotation-test: $(BIN_DIR)/$(BAND_GPIO_ROTATION_TEST_OUT)
 monitor-file-regression-test: $(BIN_DIR)/$(MONITOR_FILE_REGRESSION_TEST_OUT)
 	$(Q)echo "Running MonitorFile regression tests."
 	$(Q)./$(BIN_DIR)/$(MONITOR_FILE_REGRESSION_TEST_OUT)
+
+ifeq ($(GPIOD_HAS_V2),1)
+gpio-loopback-test: $(BIN_DIR)/$(GPIO_LOOPBACK_TEST_OUT)
+	$(Q)echo "Built $(GPIO_LOOPBACK_TEST_OUT). Run it manually on Pi hardware."
+
+band-gpio-live-monitor: $(BIN_DIR)/$(BAND_GPIO_LIVE_MONITOR_OUT)
+	$(Q)echo "Built $(BAND_GPIO_LIVE_MONITOR_OUT). Run it manually on Pi hardware."
+else
+gpio-loopback-test:
+	$(Q)echo "$(GPIO_LOOPBACK_TEST_OUT) requires libgpiod v2 (detected major $(GPIOD_API_MAJOR))."
+	$(Q)exit 1
+
+band-gpio-live-monitor:
+	$(Q)echo "$(BAND_GPIO_LIVE_MONITOR_OUT) requires libgpiod v2 (detected major $(GPIOD_API_MAJOR))."
+	$(Q)exit 1
+endif
 
 gdb: debug
 	$(Q)echo "Running debug session."

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1568,7 +1568,14 @@ void apply_runtime_config_side_effects()
 
     if (config.use_led && (config.led_pin >= 0 && config.led_pin <= 27))
     {
-        ledControl.enableGPIOPin(config.led_pin, true);
+        if (!ledControl.enableGPIOPin(config.led_pin, true))
+        {
+            llog.logS(ERROR,
+                      "Failed to enable TX LED GPIO ",
+                      config.led_pin,
+                      ": ",
+                      ledControl.lastError());
+        }
     }
     else
     {
@@ -1578,12 +1585,24 @@ void apply_runtime_config_side_effects()
 
     if (config.use_shutdown && (config.shutdown_pin >= 0 && config.shutdown_pin <= 27))
     {
-        shutdownMonitor.enable(
+        if (!shutdownMonitor.enable(
             config.shutdown_pin,
             false,
             GPIOInput::PullMode::PullUp,
-            callback_shutdown_system);
-        shutdownMonitor.setPriority(SCHED_RR, 10);
+            callback_shutdown_system))
+        {
+            llog.logS(ERROR,
+                      "Failed to enable shutdown monitor GPIO ",
+                      config.shutdown_pin,
+                      ".");
+        }
+        else if (!shutdownMonitor.setPriority(SCHED_RR, 10))
+        {
+            llog.logS(WARN,
+                      "Shutdown monitor GPIO ",
+                      config.shutdown_pin,
+                      " enabled, but failed to raise thread priority.");
+        }
     }
     else
     {

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1594,7 +1594,8 @@ void apply_runtime_config_side_effects()
             llog.logS(ERROR,
                       "Failed to enable shutdown monitor GPIO ",
                       config.shutdown_pin,
-                      ".");
+                      ": ",
+                      shutdownMonitor.lastError());
         }
         else if (!shutdownMonitor.setPriority(SCHED_RR, 10))
         {

--- a/src/gpio_input.cpp
+++ b/src/gpio_input.cpp
@@ -50,6 +50,7 @@ GPIOInput::GPIOInput()
       monitor_thread_(),
       monitor_mutex_(),
       cv_(),
+      last_error_(),
       status_(Status::NotConfigured),
       resolved_line_(),
       chip_(nullptr)
@@ -92,6 +93,8 @@ bool GPIOInput::enable(int pin,
                        PullMode pull_mode,
                        std::function<void()> callback)
 {
+    last_error_.clear();
+
     if (running_)
     {
         (void)stop();
@@ -121,12 +124,12 @@ bool GPIOInput::enable(int pin,
         std::string resolution_error;
         if (!resolve_gpio_line(gpio_pin_, resolved_line_, resolution_error))
         {
+            last_error_ =
+                "GPIOInput resolution failure for BCM " +
+                std::to_string(gpio_pin_) + ": " + resolution_error;
             llog.logS(
                 ERROR,
-                "GPIOInput: resolution error for BCM ",
-                gpio_pin_,
-                ": ",
-                resolution_error);
+                last_error_);
             status_ = Status::Error;
             running_ = false;
             return false;
@@ -204,13 +207,12 @@ bool GPIOInput::enable(int pin,
     catch (const std::exception& e)
     {
         std::lock_guard<std::mutex> lock(monitor_mutex_);
+        last_error_ =
+            "GPIOInput request failure for " +
+            describe_resolved_gpio_line(resolved_line_) + ": " + e.what();
         releaseGPIOResources();
         resolved_line_ = ResolvedGPIOLine{};
-        llog.logS(ERROR,
-                  "GPIOInput: request failure for BCM ",
-                  gpio_pin_,
-                  ": ",
-                  e.what());
+        llog.logS(ERROR, last_error_);
         status_ = Status::Error;
         running_ = false;
         return false;
@@ -224,7 +226,15 @@ bool GPIOInput::enable(int pin,
     }
     catch (const std::exception& e)
     {
-        llog.logE(ERROR, "GPIOInput: thread start error.", e.what());
+        last_error_ =
+            "GPIOInput thread start failure for " +
+            describe_resolved_gpio_line(resolved_line_) + ": " + e.what();
+        llog.logS(ERROR, last_error_);
+        {
+            std::lock_guard<std::mutex> lock(monitor_mutex_);
+            releaseGPIOResources();
+            resolved_line_ = ResolvedGPIOLine{};
+        }
         status_ = Status::Error;
         running_ = false;
         return false;
@@ -283,6 +293,11 @@ GPIOInput::Status GPIOInput::getStatus() const
     return status_;
 }
 
+const std::string &GPIOInput::lastError() const noexcept
+{
+    return last_error_;
+}
+
 void GPIOInput::monitorLoop()
 {
     while (!stop_thread_)
@@ -329,12 +344,13 @@ void GPIOInput::monitorLoop()
         }
         catch (const std::exception& e)
         {
+            last_error_ =
+                "GPIOInput loop failure for " +
+                describe_resolved_gpio_line(resolved_line_) + ": " + e.what();
             status_ = Status::Error;
-            llog.logS(ERROR,
-                      "GPIOInput: loop error for ",
-                      describe_resolved_gpio_line(resolved_line_),
-                      ": ",
-                      e.what());
+            running_ = false;
+            stop_thread_ = true;
+            llog.logS(ERROR, last_error_);
         }
     }
 }

--- a/src/gpio_input.cpp
+++ b/src/gpio_input.cpp
@@ -51,6 +51,7 @@ GPIOInput::GPIOInput()
       monitor_mutex_(),
       cv_(),
       status_(Status::NotConfigured),
+      resolved_line_(),
       chip_(nullptr)
 #if GPIOD_API_MAJOR >= 2
       ,
@@ -112,12 +113,27 @@ bool GPIOInput::enable(int pin,
         debounce_triggered_ = false;
         stop_thread_ = false;
         status_ = Status::NotConfigured;
+        resolved_line_ = ResolvedGPIOLine{};
     }
 
     try
     {
+        std::string resolution_error;
+        if (!resolve_gpio_line(gpio_pin_, resolved_line_, resolution_error))
+        {
+            llog.logS(
+                ERROR,
+                "GPIOInput: resolution error for BCM ",
+                gpio_pin_,
+                ": ",
+                resolution_error);
+            status_ = Status::Error;
+            running_ = false;
+            return false;
+        }
+
 #if GPIOD_API_MAJOR >= 2
-        chip_ = std::make_unique<gpiod::chip>("/dev/gpiochip0");
+        chip_ = std::make_unique<gpiod::chip>(resolved_line_.chip_path);
 
         gpiod::line_settings ls;
         ls.set_direction(gpiod::line::direction::INPUT);
@@ -142,19 +158,23 @@ bool GPIOInput::enable(int pin,
 
         auto builder = chip_->prepare_request();
         builder.set_consumer("GPIOInput");
-        gpiod::line::offset off = static_cast<gpiod::line::offset>(gpio_pin_);
+        gpiod::line::offset off = resolved_line_.offset;
         request_ = builder.add_line_settings(off, ls).do_request();
 
-        llog.logS(DEBUG, "GPIOInput: v2 request on /dev/gpiochip0. offset:",
-                  gpio_pin_, " edge:", trigger_high_ ? "RISING" : "FALLING",
+        llog.logS(DEBUG,
+                  "GPIOInput: request success for ",
+                  describe_resolved_gpio_line(resolved_line_),
+                  " edge:",
+                  trigger_high_ ? "RISING" : "FALLING",
                   " bias:",
                   (pull_mode_ == PullMode::PullUp)   ? "PULL_UP" :
                   (pull_mode_ == PullMode::PullDown) ? "PULL_DOWN" :
                                                        "DISABLED", ".");
 #else
-        chip_ = std::make_unique<gpiod::chip>("/dev/gpiochip0");
+        chip_ = std::make_unique<gpiod::chip>(resolved_line_.chip_path);
 
-        line_ = chip_->get_line(gpio_pin_);
+        line_ = chip_->get_line(
+            static_cast<unsigned int>(resolved_line_.offset));
 
         gpiod::line_request req;
         req.consumer = "GPIOInput";
@@ -170,8 +190,11 @@ bool GPIOInput::enable(int pin,
 
         line_.request(req);
 
-        llog.logS(DEBUG, "GPIOInput: v1 request on /dev/gpiochip0. offset:",
-                  gpio_pin_, " edge:", trigger_high_ ? "RISING" : "FALLING",
+        llog.logS(DEBUG,
+                  "GPIOInput: request success for ",
+                  describe_resolved_gpio_line(resolved_line_),
+                  " edge:",
+                  trigger_high_ ? "RISING" : "FALLING",
                   " bias:",
                   (pull_mode_ == PullMode::PullUp)   ? "PULL_UP" :
                   (pull_mode_ == PullMode::PullDown) ? "PULL_DOWN" :
@@ -182,7 +205,12 @@ bool GPIOInput::enable(int pin,
     {
         std::lock_guard<std::mutex> lock(monitor_mutex_);
         releaseGPIOResources();
-        llog.logE(ERROR, "GPIOInput: init error.", e.what());
+        resolved_line_ = ResolvedGPIOLine{};
+        llog.logS(ERROR,
+                  "GPIOInput: request failure for BCM ",
+                  gpio_pin_,
+                  ": ",
+                  e.what());
         status_ = Status::Error;
         running_ = false;
         return false;
@@ -220,6 +248,7 @@ bool GPIOInput::stop()
     {
         std::lock_guard<std::mutex> lock(monitor_mutex_);
         releaseGPIOResources();
+        resolved_line_ = ResolvedGPIOLine{};
         status_ = Status::Stopped;
     }
 
@@ -266,6 +295,12 @@ void GPIOInput::monitorLoop()
                 auto count = request_->read_edge_events(event_buf_);
                 if (count > 0 && !debounce_triggered_)
                 {
+                    llog.logS(DEBUG,
+                              "GPIOInput: edge event on ",
+                              describe_resolved_gpio_line(resolved_line_),
+                              ", count ",
+                              count,
+                              ".");
                     debounce_triggered_ = true;
                     if (callback_)
                     {
@@ -279,6 +314,10 @@ void GPIOInput::monitorLoop()
                 (void)line_.event_read();
                 if (!debounce_triggered_)
                 {
+                    llog.logS(DEBUG,
+                              "GPIOInput: edge event on ",
+                              describe_resolved_gpio_line(resolved_line_),
+                              ".");
                     debounce_triggered_ = true;
                     if (callback_)
                     {
@@ -291,7 +330,11 @@ void GPIOInput::monitorLoop()
         catch (const std::exception& e)
         {
             status_ = Status::Error;
-            llog.logE(ERROR, "GPIO loop error.", e.what());
+            llog.logS(ERROR,
+                      "GPIOInput: loop error for ",
+                      describe_resolved_gpio_line(resolved_line_),
+                      ": ",
+                      e.what());
         }
     }
 }

--- a/src/gpio_input.hpp
+++ b/src/gpio_input.hpp
@@ -30,6 +30,7 @@
 #define GPIO_INPUT_HPP
 
 #include "gpio_include.hpp"
+#include "gpio_line_resolver.hpp"
 
 #include <atomic>
 #include <condition_variable>
@@ -41,15 +42,15 @@
 
 /**
  * @class GPIOInput
- * @brief Monitors a GPIO pin using libgpiod with thread-based event handling.
+ * @brief Monitors a BCM GPIO pin using libgpiod with thread-based event handling.
  *
  * This class allows for edge-triggered monitoring of a GPIO pin using the
  * libgpiod C++ API. It supports edge detection (rising or falling), optional
  * internal pull-up or pull-down configuration, CPU priority control, debounce
  * management, and thread-safe lifecycle operations.
  *
- * Designed for use on the Raspberry Pi platform with BCM GPIO numbering, the
- * class is thread-based and suitable for global instantiation.
+ * Designed for Raspberry Pi BCM numbering, the class resolves the runtime
+ * chip/offset mapping internally and is suitable for global instantiation.
  *
  * Dependencies: libgpiod >= 1.6.
  *
@@ -117,6 +118,7 @@ private:
     std::condition_variable cv_; ///< Coordinates thread shutdown.
 
     Status status_;                     ///< Current operational state.
+    ResolvedGPIOLine resolved_line_;    ///< Resolved chip/offset metadata.
     std::unique_ptr<gpiod::chip> chip_; ///< GPIO chip handle.
 
 #if GPIOD_API_MAJOR >= 2

--- a/src/gpio_input.hpp
+++ b/src/gpio_input.hpp
@@ -38,6 +38,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
 #include <thread>
 
 /**
@@ -99,6 +100,7 @@ public:
     bool setPriority(int schedPolicy, int priority);
 
     Status getStatus() const;
+    const std::string &lastError() const noexcept;
 
 private:
     void monitorLoop();
@@ -117,6 +119,7 @@ private:
     std::mutex monitor_mutex_;   ///< Protects shared state.
     std::condition_variable cv_; ///< Coordinates thread shutdown.
 
+    std::string last_error_;            ///< Last setup/runtime error text.
     Status status_;                     ///< Current operational state.
     ResolvedGPIOLine resolved_line_;    ///< Resolved chip/offset metadata.
     std::unique_ptr<gpiod::chip> chip_; ///< GPIO chip handle.

--- a/src/gpio_line_resolver.cpp
+++ b/src/gpio_line_resolver.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <set>
 #include <sstream>
 #include <vector>
 
@@ -10,10 +11,114 @@ namespace
     struct ChipEntry
     {
         std::filesystem::path path;
+        std::filesystem::path backing_device_path;
         std::string name;
         std::string label;
         std::size_t num_lines = 0;
     };
+
+    std::filesystem::path gpiochip_sysfs_dir(const std::filesystem::path &chip_path)
+    {
+        return std::filesystem::path("/sys/class/gpio") / chip_path.filename();
+    }
+
+    std::filesystem::path gpiochip_backing_device_path(
+        const std::filesystem::path &chip_path)
+    {
+        const std::filesystem::path device_link =
+            gpiochip_sysfs_dir(chip_path) / "device";
+        std::error_code ec;
+        const std::filesystem::path canonical =
+            std::filesystem::weakly_canonical(device_link, ec);
+        if (ec)
+        {
+            return {};
+        }
+
+        return canonical;
+    }
+
+    int gpiochip_number(const std::filesystem::path &chip_path)
+    {
+        const std::string filename = chip_path.filename().string();
+        constexpr char prefix[] = "gpiochip";
+        if (filename.rfind(prefix, 0) != 0)
+        {
+            return -1;
+        }
+
+        try
+        {
+            return std::stoi(filename.substr(sizeof(prefix) - 1U));
+        }
+        catch (...)
+        {
+            return -1;
+        }
+    }
+
+    bool chip_path_less(
+        const std::filesystem::path &lhs,
+        const std::filesystem::path &rhs)
+    {
+        const int lhs_num = gpiochip_number(lhs);
+        const int rhs_num = gpiochip_number(rhs);
+        if (lhs_num >= 0 && rhs_num >= 0 && lhs_num != rhs_num)
+        {
+            return lhs_num < rhs_num;
+        }
+
+        return lhs < rhs;
+    }
+
+    bool resolved_chip_less(
+        const ResolvedGPIOLine &lhs,
+        const ResolvedGPIOLine &rhs)
+    {
+        return chip_path_less(lhs.chip_path, rhs.chip_path);
+    }
+
+    bool collapse_equivalent_candidates(
+        const std::vector<ResolvedGPIOLine> &candidates,
+        ResolvedGPIOLine &resolved_line)
+    {
+        if (candidates.empty())
+        {
+            return false;
+        }
+
+        std::set<std::filesystem::path> backing_devices;
+        for (const ResolvedGPIOLine &candidate : candidates)
+        {
+            if (candidate.backing_device_path.empty())
+            {
+                return false;
+            }
+
+            backing_devices.insert(candidate.backing_device_path);
+        }
+
+        if (backing_devices.size() != 1U)
+        {
+            return false;
+        }
+
+        const auto canonical_it =
+            std::min_element(candidates.begin(), candidates.end(), resolved_chip_less);
+        if (canonical_it == candidates.end())
+        {
+            return false;
+        }
+
+        resolved_line = *canonical_it;
+        std::ostringstream note;
+        note << "Multiple gpiochips map to the same backing device '"
+             << resolved_line.backing_device_path
+             << "'. Using '" << resolved_line.chip_path
+             << "' as canonical view.";
+        resolved_line.resolution_note = note.str();
+        return true;
+    }
 
 #if GPIOD_API_MAJOR < 2
     std::string trim_copy(std::string value)
@@ -40,11 +145,6 @@ namespace
         buffer << input.rdbuf();
         return trim_copy(buffer.str());
     }
-
-    std::filesystem::path gpiochip_sysfs_dir(const std::filesystem::path &chip_path)
-    {
-        return std::filesystem::path("/sys/class/gpio") / chip_path.filename();
-    }
 #endif
 
     std::vector<ChipEntry> enumerate_gpiochips()
@@ -70,12 +170,15 @@ namespace
             const gpiod::chip_info info = chip.get_info();
             entries.push_back(ChipEntry{
                 entry.path(),
+                gpiochip_backing_device_path(entry.path()),
                 info.name(),
                 info.label(),
                 info.num_lines()});
 #else
             ChipEntry chip_entry;
             chip_entry.path = entry.path();
+            chip_entry.backing_device_path =
+                gpiochip_backing_device_path(chip_entry.path);
             chip_entry.name = filename;
 
             const std::filesystem::path sysfs_dir =
@@ -109,7 +212,7 @@ namespace
             entries.end(),
             [](const ChipEntry &lhs, const ChipEntry &rhs)
             {
-                return lhs.path < rhs.path;
+                return chip_path_less(lhs.path, rhs.path);
             });
 
         return entries;
@@ -127,6 +230,7 @@ namespace
         resolved_line = ResolvedGPIOLine{};
         resolved_line.bcm = bcm;
         resolved_line.chip_path = entry.path;
+        resolved_line.backing_device_path = entry.backing_device_path;
         resolved_line.chip_name = entry.name;
         resolved_line.chip_label = entry.label;
 
@@ -264,12 +368,21 @@ bool resolve_gpio_line(
 
     if (named_candidates.size() > 1U)
     {
+        if (collapse_equivalent_candidates(named_candidates, resolved_line))
+        {
+            return true;
+        }
+
         std::ostringstream oss;
         oss << "BCM GPIO " << bcm
             << " resolved by kernel line name on multiple gpiochips:";
         for (const ResolvedGPIOLine &candidate : named_candidates)
         {
             oss << " " << candidate.chip_path;
+            if (!candidate.backing_device_path.empty())
+            {
+                oss << "(device=" << candidate.backing_device_path << ")";
+            }
         }
         oss << ". Chip selection is ambiguous.";
         error_message = oss.str();
@@ -291,12 +404,21 @@ bool resolve_gpio_line(
         return false;
     }
 
+    if (collapse_equivalent_candidates(fallback_candidates, resolved_line))
+    {
+        return true;
+    }
+
     std::ostringstream oss;
     oss << "BCM GPIO " << bcm
         << " could only be mapped by raw offset on multiple gpiochips:";
     for (const ResolvedGPIOLine &candidate : fallback_candidates)
     {
         oss << " " << candidate.chip_path;
+        if (!candidate.backing_device_path.empty())
+        {
+            oss << "(device=" << candidate.backing_device_path << ")";
+        }
     }
     oss << ". Refusing ambiguous raw-offset mapping.";
     error_message = oss.str();
@@ -321,6 +443,14 @@ std::string describe_resolved_gpio_line(const ResolvedGPIOLine &resolved_line)
     if (!resolved_line.chip_label.empty())
     {
         oss << " chip-label=\"" << resolved_line.chip_label << "\"";
+    }
+    if (!resolved_line.backing_device_path.empty())
+    {
+        oss << " backing-device=" << resolved_line.backing_device_path;
+    }
+    if (!resolved_line.resolution_note.empty())
+    {
+        oss << " note=\"" << resolved_line.resolution_note << "\"";
     }
     return oss.str();
 }

--- a/src/gpio_line_resolver.cpp
+++ b/src/gpio_line_resolver.cpp
@@ -1,0 +1,326 @@
+#include "gpio_line_resolver.hpp"
+
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+namespace
+{
+    struct ChipEntry
+    {
+        std::filesystem::path path;
+        std::string name;
+        std::string label;
+        std::size_t num_lines = 0;
+    };
+
+#if GPIOD_API_MAJOR < 2
+    std::string trim_copy(std::string value)
+    {
+        const auto first = value.find_first_not_of(" \t\r\n");
+        if (first == std::string::npos)
+        {
+            return {};
+        }
+
+        const auto last = value.find_last_not_of(" \t\r\n");
+        return value.substr(first, last - first + 1U);
+    }
+
+    std::string read_trimmed_text_file(const std::filesystem::path &path)
+    {
+        std::ifstream input(path);
+        if (!input)
+        {
+            return {};
+        }
+
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return trim_copy(buffer.str());
+    }
+
+    std::filesystem::path gpiochip_sysfs_dir(const std::filesystem::path &chip_path)
+    {
+        return std::filesystem::path("/sys/class/gpio") / chip_path.filename();
+    }
+#endif
+
+    std::vector<ChipEntry> enumerate_gpiochips()
+    {
+        std::vector<ChipEntry> entries;
+        const std::filesystem::path dev_dir{"/dev"};
+
+        for (const auto &entry : std::filesystem::directory_iterator(dev_dir))
+        {
+            if (!entry.is_character_file() && !entry.is_symlink())
+            {
+                continue;
+            }
+
+            const std::string filename = entry.path().filename().string();
+            if (filename.rfind("gpiochip", 0) != 0)
+            {
+                continue;
+            }
+
+#if GPIOD_API_MAJOR >= 2
+            gpiod::chip chip(entry.path());
+            const gpiod::chip_info info = chip.get_info();
+            entries.push_back(ChipEntry{
+                entry.path(),
+                info.name(),
+                info.label(),
+                info.num_lines()});
+#else
+            ChipEntry chip_entry;
+            chip_entry.path = entry.path();
+            chip_entry.name = filename;
+
+            const std::filesystem::path sysfs_dir =
+                gpiochip_sysfs_dir(chip_entry.path);
+            if (std::filesystem::exists(sysfs_dir))
+            {
+                chip_entry.label = read_trimmed_text_file(sysfs_dir / "label");
+
+                const std::string num_lines_text =
+                    read_trimmed_text_file(sysfs_dir / "ngpio");
+                if (!num_lines_text.empty())
+                {
+                    try
+                    {
+                        chip_entry.num_lines =
+                            static_cast<std::size_t>(std::stoul(num_lines_text));
+                    }
+                    catch (...)
+                    {
+                        chip_entry.num_lines = 0;
+                    }
+                }
+            }
+
+            entries.push_back(std::move(chip_entry));
+#endif
+        }
+
+        std::sort(
+            entries.begin(),
+            entries.end(),
+            [](const ChipEntry &lhs, const ChipEntry &rhs)
+            {
+                return lhs.path < rhs.path;
+            });
+
+        return entries;
+    }
+
+    bool try_resolve_line_on_chip(
+        const ChipEntry &entry,
+        int bcm,
+        ResolvedGPIOLine &resolved_line,
+        bool &used_offset_fallback)
+    {
+        gpiod::chip chip(entry.path);
+        const std::string expected_name = "GPIO" + std::to_string(bcm);
+
+        resolved_line = ResolvedGPIOLine{};
+        resolved_line.bcm = bcm;
+        resolved_line.chip_path = entry.path;
+        resolved_line.chip_name = entry.name;
+        resolved_line.chip_label = entry.label;
+
+#if GPIOD_API_MAJOR >= 2
+        const int named_offset = chip.get_line_offset_from_name(expected_name);
+        if (named_offset >= 0)
+        {
+            resolved_line.offset =
+                gpiod::line::offset(static_cast<unsigned int>(named_offset));
+            resolved_line.resolved_by_name = true;
+            resolved_line.kernel_name = expected_name;
+            used_offset_fallback = false;
+            return true;
+        }
+
+        if (bcm < 0 || static_cast<std::size_t>(bcm) >= entry.num_lines)
+        {
+            return false;
+        }
+
+        resolved_line.offset =
+            gpiod::line::offset(static_cast<unsigned int>(bcm));
+        resolved_line.resolved_by_name = false;
+        try
+        {
+            resolved_line.kernel_name = chip.get_line_info(resolved_line.offset).name();
+        }
+        catch (...)
+        {
+            resolved_line.kernel_name.clear();
+        }
+
+        used_offset_fallback = true;
+        return true;
+#else
+        // libgpiod v1 builds in this tree use the older request/get_line API
+        // surface. It does not expose the v2 metadata helpers preferred by the
+        // resolver, so the compatibility path only accepts a raw-offset match
+        // after verifying that the candidate chip actually exposes that offset.
+        if (bcm < 0)
+        {
+            return false;
+        }
+
+        if (entry.num_lines > 0 && static_cast<std::size_t>(bcm) >= entry.num_lines)
+        {
+            return false;
+        }
+
+        try
+        {
+            (void)chip.get_line(static_cast<unsigned int>(bcm));
+        }
+        catch (...)
+        {
+            return false;
+        }
+
+        resolved_line.offset =
+            gpiod::line::offset(static_cast<unsigned int>(bcm));
+        resolved_line.resolved_by_name = false;
+        resolved_line.kernel_name.clear();
+        used_offset_fallback = true;
+        return true;
+#endif
+    }
+} // namespace
+
+bool resolve_gpio_line(
+    int bcm,
+    ResolvedGPIOLine &resolved_line,
+    std::string &error_message)
+{
+    error_message.clear();
+    resolved_line = ResolvedGPIOLine{};
+
+    if (bcm < 0 || bcm > 27)
+    {
+        error_message =
+            "BCM GPIO " + std::to_string(bcm) + " is out of supported range 0-27.";
+        return false;
+    }
+
+    std::vector<ChipEntry> entries;
+    try
+    {
+        entries = enumerate_gpiochips();
+    }
+    catch (const std::exception &e)
+    {
+        error_message = std::string("Failed to enumerate /dev/gpiochip*: ") + e.what();
+        return false;
+    }
+
+    if (entries.empty())
+    {
+        error_message = "No /dev/gpiochip* devices were found.";
+        return false;
+    }
+
+    std::vector<ResolvedGPIOLine> named_candidates;
+    std::vector<ResolvedGPIOLine> fallback_candidates;
+
+    for (const ChipEntry &entry : entries)
+    {
+        try
+        {
+            ResolvedGPIOLine candidate;
+            bool used_offset_fallback = false;
+            if (!try_resolve_line_on_chip(entry, bcm, candidate, used_offset_fallback))
+            {
+                continue;
+            }
+
+            if (used_offset_fallback)
+            {
+                fallback_candidates.push_back(candidate);
+            }
+            else
+            {
+                named_candidates.push_back(candidate);
+            }
+        }
+        catch (const std::exception &)
+        {
+            continue;
+        }
+    }
+
+    if (named_candidates.size() == 1U)
+    {
+        resolved_line = named_candidates.front();
+        return true;
+    }
+
+    if (named_candidates.size() > 1U)
+    {
+        std::ostringstream oss;
+        oss << "BCM GPIO " << bcm
+            << " resolved by kernel line name on multiple gpiochips:";
+        for (const ResolvedGPIOLine &candidate : named_candidates)
+        {
+            oss << " " << candidate.chip_path;
+        }
+        oss << ". Chip selection is ambiguous.";
+        error_message = oss.str();
+        return false;
+    }
+
+    if (fallback_candidates.size() == 1U)
+    {
+        resolved_line = fallback_candidates.front();
+        return true;
+    }
+
+    if (fallback_candidates.empty())
+    {
+        std::ostringstream oss;
+        oss << "BCM GPIO " << bcm
+            << " was not exposed by kernel line name and does not fit any detected gpiochip.";
+        error_message = oss.str();
+        return false;
+    }
+
+    std::ostringstream oss;
+    oss << "BCM GPIO " << bcm
+        << " could only be mapped by raw offset on multiple gpiochips:";
+    for (const ResolvedGPIOLine &candidate : fallback_candidates)
+    {
+        oss << " " << candidate.chip_path;
+    }
+    oss << ". Refusing ambiguous raw-offset mapping.";
+    error_message = oss.str();
+    return false;
+}
+
+std::string describe_resolved_gpio_line(const ResolvedGPIOLine &resolved_line)
+{
+    std::ostringstream oss;
+    oss << "BCM " << resolved_line.bcm
+        << " -> " << resolved_line.chip_path
+        << " offset " << static_cast<unsigned int>(resolved_line.offset)
+        << " (" << (resolved_line.resolved_by_name ? "kernel-name" : "raw-offset") << ")";
+    if (!resolved_line.kernel_name.empty())
+    {
+        oss << " line-name=\"" << resolved_line.kernel_name << "\"";
+    }
+    if (!resolved_line.chip_name.empty())
+    {
+        oss << " chip-name=" << resolved_line.chip_name;
+    }
+    if (!resolved_line.chip_label.empty())
+    {
+        oss << " chip-label=\"" << resolved_line.chip_label << "\"";
+    }
+    return oss.str();
+}

--- a/src/gpio_line_resolver.cpp
+++ b/src/gpio_line_resolver.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <set>
 #include <sstream>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <vector>
 
 namespace
@@ -17,25 +19,38 @@ namespace
         std::size_t num_lines = 0;
     };
 
-    std::filesystem::path gpiochip_sysfs_dir(const std::filesystem::path &chip_path)
-    {
-        return std::filesystem::path("/sys/class/gpio") / chip_path.filename();
-    }
-
-    std::filesystem::path gpiochip_backing_device_path(
+    std::filesystem::path gpiochip_sysfs_chip_path(
         const std::filesystem::path &chip_path)
     {
-        const std::filesystem::path device_link =
-            gpiochip_sysfs_dir(chip_path) / "device";
+        struct stat st
+        {
+        };
+        if (::stat(chip_path.c_str(), &st) != 0 || !S_ISCHR(st.st_mode))
+        {
+            return {};
+        }
+
+        std::ostringstream dev_char;
+        dev_char << "/sys/dev/char/"
+                 << major(st.st_rdev)
+                 << ":"
+                 << minor(st.st_rdev);
+
         std::error_code ec;
         const std::filesystem::path canonical =
-            std::filesystem::weakly_canonical(device_link, ec);
+            std::filesystem::canonical(dev_char.str(), ec);
         if (ec)
         {
             return {};
         }
 
         return canonical;
+    }
+
+    std::filesystem::path gpiochip_backing_device_path(
+        const std::filesystem::path &chip_path)
+    {
+        return gpiochip_sysfs_chip_path(chip_path);
     }
 
     int gpiochip_number(const std::filesystem::path &chip_path)
@@ -182,7 +197,7 @@ namespace
             chip_entry.name = filename;
 
             const std::filesystem::path sysfs_dir =
-                gpiochip_sysfs_dir(chip_entry.path);
+                gpiochip_sysfs_chip_path(chip_entry.path);
             if (std::filesystem::exists(sysfs_dir))
             {
                 chip_entry.label = read_trimmed_text_file(sysfs_dir / "label");

--- a/src/gpio_line_resolver.hpp
+++ b/src/gpio_line_resolver.hpp
@@ -11,11 +11,13 @@ struct ResolvedGPIOLine
 {
     int bcm = -1;
     std::filesystem::path chip_path;
+    std::filesystem::path backing_device_path;
     std::string chip_name;
     std::string chip_label;
     gpiod::line::offset offset{};
     bool resolved_by_name = false;
     std::string kernel_name;
+    std::string resolution_note;
 };
 
 bool resolve_gpio_line(

--- a/src/gpio_line_resolver.hpp
+++ b/src/gpio_line_resolver.hpp
@@ -1,0 +1,28 @@
+#ifndef GPIO_LINE_RESOLVER_HPP
+#define GPIO_LINE_RESOLVER_HPP
+
+#include "gpio_include.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+struct ResolvedGPIOLine
+{
+    int bcm = -1;
+    std::filesystem::path chip_path;
+    std::string chip_name;
+    std::string chip_label;
+    gpiod::line::offset offset{};
+    bool resolved_by_name = false;
+    std::string kernel_name;
+};
+
+bool resolve_gpio_line(
+    int bcm,
+    ResolvedGPIOLine &resolved_line,
+    std::string &error_message);
+
+std::string describe_resolved_gpio_line(const ResolvedGPIOLine &resolved_line);
+
+#endif // GPIO_LINE_RESOLVER_HPP

--- a/src/gpio_output.cpp
+++ b/src/gpio_output.cpp
@@ -250,7 +250,7 @@ bool GPIOOutput::toggleGPIO(bool state)
             describe_resolved_gpio_line(resolved_line_),
             ", logical ",
             state ? "1" : "0",
-            ", physical ",
+            ", requested line value ",
             physical,
             ".");
     }

--- a/src/gpio_output.cpp
+++ b/src/gpio_output.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "gpio_output.hpp"
+#include "logging.hpp"
 #include <iostream>
 
 // Global instance for the optional status LED.
@@ -38,16 +39,15 @@ GPIOOutput ledControl;
  *          - pin_ is set to -1 (no pin configured)
  *          - active_high_ is set to true (active-high logic)
  *          - enabled_ is false (GPIO not yet configured)
- *          - chip_ and line_ are initialized to nullptr
+ *          - libgpiod handles are empty until a resolved line is requested
  *
  * The object must be explicitly configured using enableGPIOPin() before use.
  */
-GPIOOutput::GPIOOutput() :
-    pin_(-1),
-    active_high_(true),
-    enabled_(false),
-    last_error_(),
-    chip_(nullptr)
+GPIOOutput::GPIOOutput() : pin_(-1),
+                           active_high_(true),
+                           enabled_(false),
+                           last_error_(),
+                           chip_(nullptr)
 {
 }
 
@@ -62,11 +62,9 @@ GPIOOutput::~GPIOOutput()
 
 /**
  * @brief Enables a GPIO pin for output.
- * @details Configures the specified BCM GPIO pin as an output on the default chip
- *          (/dev/gpiochip0) using libgpiod. If the pin is already enabled, it is first
- *          disabled via stop_gpio_pin(). The function requests the GPIO line for output,
- *          sets its initial value (computed based on the active high/low configuration),
- *          and marks the pin as enabled.
+ * @details Resolves the requested BCM GPIO line at runtime and requests the
+ * corresponding chip/offset through libgpiod. If the pin is already enabled,
+ * it is first released and then re-requested.
  *
  * @param pin The BCM GPIO pin number to be enabled.
  * @param active_high If true, the pin is configured for active-high logic; if false,
@@ -86,10 +84,21 @@ bool GPIOOutput::enableGPIOPin(int pin, bool active_high)
     }
     pin_ = pin;
     active_high_ = active_high;
+    resolved_line_ = ResolvedGPIOLine{};
 
     try
     {
-        chip_ = std::make_unique<gpiod::chip>("/dev/gpiochip0");
+        std::string resolution_error;
+        if (!resolve_gpio_line(pin_, resolved_line_, resolution_error))
+        {
+            last_error_ =
+                "Error resolving GPIO pin " + std::to_string(pin_) + ": " +
+                resolution_error;
+            enabled_ = false;
+            return false;
+        }
+
+        chip_ = std::make_unique<gpiod::chip>(resolved_line_.chip_path);
 
 #if GPIOD_API_MAJOR >= 2
         // ---- libgpiod v2 path (Trixie) ----
@@ -100,16 +109,16 @@ bool GPIOOutput::enableGPIOPin(int pin, bool active_high)
         ls.set_active_low(!active_high_);
 
         auto builder = chip_->prepare_request();
-        builder.set_consumer("GPIOOutput");                     // separate call: no copy
-        const gpiod::line::offset off = static_cast<gpiod::line::offset>(pin_);
+        builder.set_consumer("GPIOOutput"); // separate call: no copy
+        const gpiod::line::offset off = resolved_line_.offset;
         builder.add_line_settings(off, ls);
-        request_ = builder.do_request();                        // move into optional
+        request_ = builder.do_request(); // move into optional
 
         // Initial logical state: inactive (false). Kernel inverts if needed.
         request_->set_value(off, gpiod::line::value::INACTIVE);
 #else
         // ---- libgpiod v1 path (Bookworm) ----
-        line_ = chip_->get_line(pin_);
+        line_ = chip_->get_line(static_cast<unsigned int>(resolved_line_.offset));
 
         gpiod::line_request req;
         req.consumer = "GPIOOutput";
@@ -128,16 +137,25 @@ bool GPIOOutput::enableGPIOPin(int pin, bool active_high)
 #endif
 
         enabled_ = true;
+        llog.logS(
+            DEBUG,
+            "GPIOOutput: request success for ",
+            describe_resolved_gpio_line(resolved_line_),
+            ", active_high ",
+            active_high_ ? "true" : "false",
+            ".");
     }
-    catch (const std::exception& e)
+    catch (const std::exception &e)
     {
         last_error_ =
-            "Error enabling GPIO pin " + std::to_string(pin_) + ": " + e.what();
+            "Error enabling " + describe_resolved_gpio_line(resolved_line_) +
+            ": " + e.what();
         enabled_ = false;
 #if GPIOD_API_MAJOR >= 2
         request_.reset();
 #endif
         chip_.reset();
+        llog.logS(ERROR, "GPIOOutput: request failure. ", last_error_);
         return false;
     }
     return enabled_;
@@ -145,9 +163,9 @@ bool GPIOOutput::enableGPIOPin(int pin, bool active_high)
 
 /**
  * @brief Disables the currently active GPIO pin.
- * @details Releases the GPIO line if it was previously enabled and resets the
- *          internal chip and line handles. After calling this function, the
- *          pin must be re-enabled via enableGPIOPin() before use.
+ * @details Releases the previously resolved GPIO line and resets the internal
+ *          libgpiod handles. After calling this function, the pin must be
+ *          re-enabled via enableGPIOPin() before use.
  *
  * This function is safe to call even if no pin is currently enabled.
  */
@@ -160,6 +178,7 @@ void GPIOOutput::stop()
         request_.reset();
 #endif
         chip_.reset();
+        resolved_line_ = ResolvedGPIOLine{};
         return;
     }
 
@@ -168,7 +187,8 @@ void GPIOOutput::stop()
 
 #if GPIOD_API_MAJOR >= 2
     // v2: Destroys the handle, releasing the line
-    if (request_) {
+    if (request_)
+    {
         // optional reset destroys the handle and releases the line
         request_.reset();
     }
@@ -189,6 +209,7 @@ void GPIOOutput::stop()
     request_.reset();
 #endif
     chip_.reset();
+    resolved_line_ = ResolvedGPIOLine{};
 }
 
 /**
@@ -216,15 +237,31 @@ bool GPIOOutput::toggleGPIO(bool state)
         int physical = compute_physical_state(state);
 
 #if GPIOD_API_MAJOR >= 2
-    const gpiod::line::offset off = static_cast<gpiod::line::offset>(pin_);
-    request_->set_value(off,
-        physical ? gpiod::line::value::ACTIVE : gpiod::line::value::INACTIVE);
+        const gpiod::line::offset off = resolved_line_.offset;
+        request_->set_value(
+            off,
+            physical ? gpiod::line::value::ACTIVE : gpiod::line::value::INACTIVE);
 #else
         line_.set_value(physical);
 #endif
+        llog.logS(
+            DEBUG,
+            "GPIOOutput: write success for ",
+            describe_resolved_gpio_line(resolved_line_),
+            ", logical ",
+            state ? "1" : "0",
+            ", physical ",
+            physical,
+            ".");
     }
-    catch (const std::exception&)
+    catch (const std::exception &e)
     {
+        llog.logS(
+            ERROR,
+            "GPIOOutput: write failure for ",
+            describe_resolved_gpio_line(resolved_line_),
+            ": ",
+            e.what());
         return false;
     }
     return true;

--- a/src/gpio_output.hpp
+++ b/src/gpio_output.hpp
@@ -34,10 +34,11 @@
 #include <string>
 
 #include "gpio_include.hpp"
+#include "gpio_line_resolver.hpp"
 
 /**
  * @class GPIOOutput
- * @brief Simple GPIO output controller using libgpiod.
+ * @brief Simple resolver-backed GPIO output controller using libgpiod.
  *
  * This helper acquires one GPIO line, keeps it in a known inactive state
  * when enabled or released, and reports setup failures through
@@ -62,13 +63,12 @@ public:
     ~GPIOOutput();
 
     /**
-     * @brief Configures and enables a GPIO pin for output.
+     * @brief Configures and enables a BCM GPIO pin for output.
      *
-     * Opens the default GPIO chip (/dev/gpiochip0), obtains the specified pin,
-     * and requests it as an output. The pin can be configured as active high or
-     * active low (sink).
+     * Resolves the configured BCM GPIO line at runtime, opens the matching GPIO
+     * chip, and requests the resolved line through libgpiod.
      *
-     * @param pin The GPIO pin number (BCM numbering).
+     * @param pin The GPIO pin number in BCM numbering.
      * @param active_high True for active-high operation (default), false for sink.
      * @return True if the pin was successfully configured; false otherwise.
      */
@@ -102,6 +102,7 @@ private:
     bool active_high_;
     bool enabled_;
     std::string last_error_;
+    ResolvedGPIOLine resolved_line_;
 
     // Using unique_ptr to manage the libgpiod chip.
     std::unique_ptr<gpiod::chip> chip_;

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -264,12 +264,29 @@ static void stop_active_transmission_selectors() noexcept
 {
     if (bandGPIOSelector.currentConfig() != nullptr)
     {
-        bandGPIOSelector.setBandState(false);
+        if (!bandGPIOSelector.setBandState(false))
+        {
+            llog.logS(WARN,
+                      "Band GPIO deassert request did not complete during selector teardown.");
+        }
     }
     bandGPIOSelector.stop();
     active_band_gpio_prepare_status.store(
         BandGPIOPrepareStatus::Inactive,
         std::memory_order_release);
+}
+
+static void set_tx_led_state(bool state, const char *context) noexcept
+{
+    if (!ledControl.toggleGPIO(state))
+    {
+        llog.logS(WARN,
+                  "TX LED ",
+                  (state ? "assert" : "deassert"),
+                  " request did not complete during ",
+                  context,
+                  ".");
+    }
 }
 
 static wsprrypi::BackendKind to_controller_backend(
@@ -1572,7 +1589,7 @@ void transmitter_cb(WsprTransmitter::TransmissionCallbackEvent event,
         }
 
         // Turn on LED.
-        ledControl.toggleGPIO(true);
+        set_tx_led_state(true, "transmission start");
 
         // Notify clients of start.
         send_ws_message("transmit", "starting");
@@ -1684,7 +1701,7 @@ void transmitter_cb(WsprTransmitter::TransmissionCallbackEvent event,
         stop_active_transmission_selectors();
 
         // Turn off LED.
-        ledControl.toggleGPIO(false);
+        set_tx_led_state(false, "transmission completion");
 
         // Notify the websocket clients.
         send_ws_message("transmit", "finished");
@@ -1753,7 +1770,7 @@ void transmitter_cb(WsprTransmitter::TransmissionCallbackEvent event,
                   " seconds.");
 
         stop_active_transmission_selectors();
-        ledControl.toggleGPIO(false);
+        set_tx_led_state(false, "transmission cancellation");
         send_ws_message("transmit", "canceled");
 
         shutdown_after_current_transmission.store(false, std::memory_order_release);
@@ -1777,7 +1794,7 @@ void transmitter_cb(WsprTransmitter::TransmissionCallbackEvent event,
         stop_active_transmission_selectors();
 
         // Turn off LED in case the UI/state expects an idle indication.
-        ledControl.toggleGPIO(false);
+        set_tx_led_state(false, "transmission skip");
 
         if (!msg.empty())
             llog.logS(to_log_level(level), msg, ".");
@@ -1928,10 +1945,10 @@ void shutdown_system()
         // Flash LED three times if configured
         for (int i = 0; i < 3; ++i)
         {
-            ledControl.toggleGPIO(true); // LED ON
+            set_tx_led_state(true, "shutdown blink on");
             std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-            ledControl.toggleGPIO(false); // LED OFF
+            set_tx_led_state(false, "shutdown blink off");
             if (i < 2)
             {
                 std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -1967,10 +1984,10 @@ void reboot_system()
         // Flash LED two times if configured
         for (int i = 0; i < 2; ++i)
         {
-            ledControl.toggleGPIO(true); // LED ON
+            set_tx_led_state(true, "reboot blink on");
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-            ledControl.toggleGPIO(false); // LED OFF
+            set_tx_led_state(false, "reboot blink off");
             if (i < 2)
             {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -2025,7 +2042,7 @@ void start_test_tone()
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
-        ledControl.toggleGPIO(true);
+        set_tx_led_state(true, "test tone start");
         llog.logS(INFO, "Beginning test tone requested by web UI.");
 
         // Switch into tone mode
@@ -2074,7 +2091,7 @@ void end_test_tone()
         wsprTransmitter.stopAndJoin();
         stop_active_transmission_selectors();
         send_ws_message("transmit", "finished");
-        ledControl.toggleGPIO(false);
+        set_tx_led_state(false, "test tone stop");
 
         // Clear the “we’re testing” flag
         web_test_tone.store(false);
@@ -2164,7 +2181,7 @@ StopTransmissionResult stop_transmission_by_user_request()
 
     wsprTransmitter.stopAndJoin();
     stop_active_transmission_selectors();
-    ledControl.toggleGPIO(false);
+    set_tx_led_state(false, "scheduler shutdown");
 
     {
         std::lock_guard<std::mutex> lk(set_config_mtx);

--- a/src/tests/band_gpio_live_monitor.cpp
+++ b/src/tests/band_gpio_live_monitor.cpp
@@ -1,0 +1,161 @@
+#include "gpio_test_utils.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+    std::atomic<bool> g_running{true};
+
+    void signal_handler(int)
+    {
+        g_running.store(false, std::memory_order_release);
+    }
+
+    void print_usage(const char *argv0)
+    {
+        std::cout
+            << "Usage: " << argv0 << " [--chip gpiochipX] [--poll-ms N] BCM [BCM ...]\n"
+            << "   or: " << argv0 << " [--chip gpiochipX] [--poll-ms N] BCM,BCM,...\n"
+            << "BCM numbering is used. Wire monitored inputs to candidate output GPIOs\n"
+            << "through approximately 1 kOhm resistors and run this tool while WsprryPi is active.\n"
+            << "Examples:\n"
+            << "  " << argv0 << " 22 23 24\n"
+            << "  " << argv0 << " --chip gpiochip4 --poll-ms 10 22,23,24\n";
+    }
+} // namespace
+
+int main(int argc, char **argv)
+{
+    try
+    {
+        std::optional<std::string> chip_arg;
+        int poll_ms = 20;
+        std::vector<std::string> bcm_tokens;
+
+        for (int i = 1; i < argc; ++i)
+        {
+            const std::string arg = argv[i];
+            if (arg == "--help" || arg == "-h")
+            {
+                print_usage(argv[0]);
+                return EXIT_SUCCESS;
+            }
+
+            if (arg == "--chip")
+            {
+                if (i + 1 >= argc)
+                {
+                    throw std::invalid_argument("--chip requires an argument.");
+                }
+                chip_arg = argv[++i];
+                continue;
+            }
+
+            if (arg == "--poll-ms")
+            {
+                if (i + 1 >= argc)
+                {
+                    throw std::invalid_argument("--poll-ms requires an argument.");
+                }
+                poll_ms = std::stoi(argv[++i]);
+                if (poll_ms <= 0)
+                {
+                    throw std::invalid_argument("--poll-ms must be positive.");
+                }
+                continue;
+            }
+
+            bcm_tokens.push_back(arg);
+        }
+
+        if (bcm_tokens.empty())
+        {
+            print_usage(argv[0]);
+            return EXIT_FAILURE;
+        }
+
+        const std::vector<int> bcm_lines = gpio_test::parse_bcm_list(bcm_tokens);
+        if (bcm_lines.empty())
+        {
+            throw std::invalid_argument("No BCM input lines were supplied.");
+        }
+
+        const gpio_test::SelectedChip selected =
+            gpio_test::resolve_chip_and_lines(bcm_lines, chip_arg);
+        gpio_test::print_selected_chip(selected);
+
+        std::vector<gpiod::line::offset> input_offsets;
+        input_offsets.reserve(selected.lines.size());
+        for (const auto &line : selected.lines)
+        {
+            input_offsets.push_back(line.offset);
+        }
+
+        gpiod::chip chip(selected.path);
+        gpiod::line_settings input_settings;
+        input_settings.set_direction(gpiod::line::direction::INPUT);
+
+        auto input_builder = chip.prepare_request();
+        input_builder.set_consumer("band_gpio_live_monitor");
+        input_builder.add_line_settings(input_offsets, input_settings);
+        gpiod::line_request input_request = input_builder.do_request();
+
+        std::signal(SIGINT, signal_handler);
+        std::signal(SIGTERM, signal_handler);
+
+        std::vector<gpiod::line::value> previous =
+            input_request.get_values(input_offsets);
+
+        std::cout << gpio_test::timestamp_now()
+                  << " monitor started on " << selected.path
+                  << ". Press Ctrl-C to stop.\n";
+        for (std::size_t i = 0; i < selected.lines.size(); ++i)
+        {
+            std::cout << "  BCM " << selected.lines[i].bcm
+                      << " offset " << static_cast<unsigned int>(selected.lines[i].offset)
+                      << " initial=" << gpio_test::line_value_text(previous[i])
+                      << '\n';
+        }
+
+        while (g_running.load(std::memory_order_acquire))
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(poll_ms));
+
+            const std::vector<gpiod::line::value> current =
+                input_request.get_values(input_offsets);
+
+            for (std::size_t i = 0; i < current.size(); ++i)
+            {
+                if (current[i] == previous[i])
+                {
+                    continue;
+                }
+
+                std::cout << gpio_test::timestamp_now()
+                          << " chip=" << selected.path
+                          << " bcm=" << selected.lines[i].bcm
+                          << " offset=" << static_cast<unsigned int>(selected.lines[i].offset)
+                          << " value=" << gpio_test::line_value_text(current[i])
+                          << '\n';
+            }
+
+            previous = current;
+        }
+
+        std::cout << gpio_test::timestamp_now() << " monitor stopped.\n";
+        return EXIT_SUCCESS;
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "ERROR: " << e.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/src/tests/gpio_loopback_test.cpp
+++ b/src/tests/gpio_loopback_test.cpp
@@ -1,0 +1,258 @@
+#include "gpio_test_utils.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    struct PairSpec
+    {
+        int output_bcm = -1;
+        int input_bcm = -1;
+    };
+
+    void print_usage(const char *argv0)
+    {
+        std::cout
+            << "Usage: " << argv0 << " [--chip gpiochipX] [--settle-ms N] OUT:IN [OUT:IN ...]\n"
+            << "BCM numbering is used. Wire each output BCM line to the matching input BCM line\n"
+            << "through an approximately 1 kOhm resistor.\n"
+            << "Examples:\n"
+            << "  " << argv0 << " 17:22\n"
+            << "  " << argv0 << " --chip gpiochip4 --settle-ms 50 17:22 27:23\n";
+    }
+
+    PairSpec parse_pair(const std::string &token)
+    {
+        const std::size_t colon = token.find(':');
+        if (colon == std::string::npos)
+        {
+            throw std::invalid_argument(
+                "Invalid pair '" + token + "'. Expected OUT:IN.");
+        }
+
+        const std::string out_text = token.substr(0, colon);
+        const std::string in_text = token.substr(colon + 1U);
+        if (out_text.empty() || in_text.empty())
+        {
+            throw std::invalid_argument(
+                "Invalid pair '" + token + "'. Expected OUT:IN.");
+        }
+
+        PairSpec pair;
+        pair.output_bcm = std::stoi(out_text);
+        pair.input_bcm = std::stoi(in_text);
+
+        if (pair.output_bcm < 0 || pair.output_bcm > 27 ||
+            pair.input_bcm < 0 || pair.input_bcm > 27)
+        {
+            throw std::invalid_argument(
+                "BCM lines in pair '" + token + "' must be between 0 and 27.");
+        }
+
+        return pair;
+    }
+
+    void ensure_unique_offsets(
+        const std::vector<gpiod::line::offset> &offsets,
+        const std::string &label)
+    {
+        std::vector<unsigned int> raw;
+        raw.reserve(offsets.size());
+        for (const auto offset : offsets)
+        {
+            raw.push_back(static_cast<unsigned int>(offset));
+        }
+
+        std::sort(raw.begin(), raw.end());
+        for (std::size_t i = 1; i < raw.size(); ++i)
+        {
+            if (raw[i] == raw[i - 1U])
+            {
+                throw std::runtime_error(
+                    "Duplicate " + label + " line offset " +
+                    std::to_string(raw[i]) + " is not supported.");
+            }
+        }
+    }
+
+    void print_pair_mapping(
+        const PairSpec &pair,
+        const gpio_test::LineResolution &out_line,
+        const gpio_test::LineResolution &in_line)
+    {
+        std::cout << "Pair BCM " << pair.output_bcm
+                  << " -> BCM " << pair.input_bcm
+                  << " maps to output offset "
+                  << static_cast<unsigned int>(out_line.offset)
+                  << " and input offset "
+                  << static_cast<unsigned int>(in_line.offset)
+                  << '\n';
+    }
+} // namespace
+
+int main(int argc, char **argv)
+{
+    try
+    {
+        std::optional<std::string> chip_arg;
+        int settle_ms = 20;
+        std::vector<PairSpec> pairs;
+
+        for (int i = 1; i < argc; ++i)
+        {
+            const std::string arg = argv[i];
+            if (arg == "--help" || arg == "-h")
+            {
+                print_usage(argv[0]);
+                return EXIT_SUCCESS;
+            }
+
+            if (arg == "--chip")
+            {
+                if (i + 1 >= argc)
+                {
+                    throw std::invalid_argument("--chip requires an argument.");
+                }
+                chip_arg = argv[++i];
+                continue;
+            }
+
+            if (arg == "--settle-ms")
+            {
+                if (i + 1 >= argc)
+                {
+                    throw std::invalid_argument("--settle-ms requires an argument.");
+                }
+                settle_ms = std::stoi(argv[++i]);
+                if (settle_ms < 0)
+                {
+                    throw std::invalid_argument("--settle-ms must be non-negative.");
+                }
+                continue;
+            }
+
+            pairs.push_back(parse_pair(arg));
+        }
+
+        if (pairs.empty())
+        {
+            print_usage(argv[0]);
+            return EXIT_FAILURE;
+        }
+
+        std::vector<int> requested_lines;
+        requested_lines.reserve(pairs.size() * 2U);
+        for (const PairSpec &pair : pairs)
+        {
+            requested_lines.push_back(pair.output_bcm);
+            requested_lines.push_back(pair.input_bcm);
+        }
+
+        const gpio_test::SelectedChip selected =
+            gpio_test::resolve_chip_and_lines(requested_lines, chip_arg);
+        gpio_test::print_selected_chip(selected);
+
+        std::vector<gpio_test::LineResolution> output_lines;
+        std::vector<gpio_test::LineResolution> input_lines;
+        output_lines.reserve(pairs.size());
+        input_lines.reserve(pairs.size());
+        for (std::size_t i = 0; i < pairs.size(); ++i)
+        {
+            output_lines.push_back(selected.lines[i * 2U]);
+            input_lines.push_back(selected.lines[i * 2U + 1U]);
+            print_pair_mapping(pairs[i], output_lines.back(), input_lines.back());
+        }
+
+        std::vector<gpiod::line::offset> output_offsets;
+        std::vector<gpiod::line::offset> input_offsets;
+        output_offsets.reserve(output_lines.size());
+        input_offsets.reserve(input_lines.size());
+        for (const auto &line : output_lines)
+        {
+            output_offsets.push_back(line.offset);
+        }
+        for (const auto &line : input_lines)
+        {
+            input_offsets.push_back(line.offset);
+        }
+
+        ensure_unique_offsets(output_offsets, "output");
+        ensure_unique_offsets(input_offsets, "input");
+
+        gpiod::chip chip(selected.path);
+
+        gpiod::line_settings output_settings;
+        output_settings.set_direction(gpiod::line::direction::OUTPUT);
+        output_settings.set_output_value(gpiod::line::value::INACTIVE);
+
+        auto output_builder = chip.prepare_request();
+        output_builder.set_consumer("gpio_loopback_test_out");
+        output_builder.add_line_settings(output_offsets, output_settings);
+        gpiod::line_request output_request = output_builder.do_request();
+
+        gpiod::line_settings input_settings;
+        input_settings.set_direction(gpiod::line::direction::INPUT);
+
+        auto input_builder = chip.prepare_request();
+        input_builder.set_consumer("gpio_loopback_test_in");
+        input_builder.add_line_settings(input_offsets, input_settings);
+        gpiod::line_request input_request = input_builder.do_request();
+
+        const std::vector<gpiod::line::value> phases = {
+            gpiod::line::value::INACTIVE,
+            gpiod::line::value::ACTIVE,
+            gpiod::line::value::INACTIVE};
+
+        bool mismatch = false;
+        for (const gpiod::line::value phase : phases)
+        {
+            std::vector<gpiod::line::value> output_values(
+                output_offsets.size(),
+                phase);
+            output_request.set_values(output_offsets, output_values);
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(settle_ms));
+
+            const std::vector<gpiod::line::value> input_values =
+                input_request.get_values(input_offsets);
+
+            for (std::size_t i = 0; i < pairs.size(); ++i)
+            {
+                const bool pair_match = input_values[i] == phase;
+                std::cout
+                    << gpio_test::timestamp_now()
+                    << " chip=" << selected.path
+                    << " requested_output_bcm=" << pairs[i].output_bcm
+                    << " requested_input_bcm=" << pairs[i].input_bcm
+                    << " output_offset=" << static_cast<unsigned int>(output_offsets[i])
+                    << " input_offset=" << static_cast<unsigned int>(input_offsets[i])
+                    << " written=" << gpio_test::line_value_text(phase)
+                    << " read=" << gpio_test::line_value_text(input_values[i])
+                    << " match=" << gpio_test::bool_text(pair_match)
+                    << '\n';
+                mismatch = mismatch || !pair_match;
+            }
+        }
+
+        if (mismatch)
+        {
+            std::cerr << "gpio_loopback_test detected at least one mismatch.\n";
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "gpio_loopback_test passed.\n";
+        return EXIT_SUCCESS;
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "ERROR: " << e.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/src/tests/gpio_test_utils.hpp
+++ b/src/tests/gpio_test_utils.hpp
@@ -1,0 +1,406 @@
+#ifndef GPIO_TEST_UTILS_HPP
+#define GPIO_TEST_UTILS_HPP
+
+#include "gpio_include.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace gpio_test
+{
+    struct ChipEntry
+    {
+        std::filesystem::path path;
+        std::string name;
+        std::string label;
+        std::size_t num_lines = 0;
+    };
+
+    struct LineResolution
+    {
+        int bcm = -1;
+        gpiod::line::offset offset{};
+        bool resolved_by_name = false;
+        std::string kernel_name;
+    };
+
+    struct SelectedChip
+    {
+        std::filesystem::path path;
+        std::string name;
+        std::string label;
+        std::vector<LineResolution> lines;
+        bool used_offset_fallback = false;
+        bool auto_selected = false;
+    };
+
+    inline std::string bool_text(bool value)
+    {
+        return value ? "true" : "false";
+    }
+
+    inline std::string line_value_text(gpiod::line::value value)
+    {
+        return value == gpiod::line::value::ACTIVE ? "1" : "0";
+    }
+
+    inline std::string timestamp_now()
+    {
+        using clock = std::chrono::system_clock;
+        const auto now = clock::now();
+        const auto tt = clock::to_time_t(now);
+        const auto micros =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                now.time_since_epoch()) %
+            std::chrono::seconds(1);
+
+        std::tm tm{};
+        localtime_r(&tt, &tm);
+
+        std::ostringstream oss;
+        oss << std::put_time(&tm, "%F %T")
+            << '.'
+            << std::setfill('0')
+            << std::setw(6)
+            << micros.count();
+        return oss.str();
+    }
+
+    inline std::string normalize_chip_argument(const std::string &chip_arg)
+    {
+        if (chip_arg.empty())
+        {
+            throw std::invalid_argument("GPIO chip argument is empty.");
+        }
+
+        if (chip_arg[0] == '/')
+        {
+            return chip_arg;
+        }
+
+        return "/dev/" + chip_arg;
+    }
+
+    inline std::vector<ChipEntry> enumerate_gpiochips()
+    {
+        std::vector<ChipEntry> entries;
+
+        const std::filesystem::path dev_dir{"/dev"};
+        for (const auto &entry : std::filesystem::directory_iterator(dev_dir))
+        {
+            if (!entry.is_character_file() && !entry.is_symlink())
+            {
+                continue;
+            }
+
+            const std::string filename = entry.path().filename().string();
+            if (filename.rfind("gpiochip", 0) != 0)
+            {
+                continue;
+            }
+
+            try
+            {
+                gpiod::chip chip(entry.path());
+                const gpiod::chip_info info = chip.get_info();
+                entries.push_back(ChipEntry{
+                    entry.path(),
+                    info.name(),
+                    info.label(),
+                    info.num_lines()});
+            }
+            catch (const std::exception &e)
+            {
+                std::cerr << "WARN: failed to open " << entry.path()
+                          << ": " << e.what() << '\n';
+            }
+        }
+
+        std::sort(
+            entries.begin(),
+            entries.end(),
+            [](const ChipEntry &lhs, const ChipEntry &rhs)
+            {
+                return lhs.path < rhs.path;
+            });
+
+        return entries;
+    }
+
+    inline void print_chip_entries(const std::vector<ChipEntry> &entries)
+    {
+        std::cout << "Available GPIO chips:\n";
+        if (entries.empty())
+        {
+            std::cout << "  none found under /dev/gpiochip*\n";
+            return;
+        }
+
+        for (const ChipEntry &entry : entries)
+        {
+            std::cout << "  " << entry.path
+                      << " name=" << entry.name
+                      << " label=\"" << entry.label << "\""
+                      << " lines=" << entry.num_lines
+                      << '\n';
+        }
+    }
+
+    inline std::optional<LineResolution> try_resolve_line(
+        gpiod::chip &chip,
+        int bcm,
+        bool allow_offset_fallback,
+        bool &used_offset_fallback)
+    {
+        const std::string expected_name = "GPIO" + std::to_string(bcm);
+        const int named_offset = chip.get_line_offset_from_name(expected_name);
+        if (named_offset >= 0)
+        {
+            return LineResolution{
+                bcm,
+                gpiod::line::offset(static_cast<unsigned int>(named_offset)),
+                true,
+                expected_name};
+        }
+
+        const gpiod::chip_info info = chip.get_info();
+        if (!allow_offset_fallback ||
+            bcm < 0 ||
+            static_cast<std::size_t>(bcm) >= info.num_lines())
+        {
+            return std::nullopt;
+        }
+
+        used_offset_fallback = true;
+        std::string kernel_name;
+        try
+        {
+            kernel_name = chip.get_line_info(
+                                  gpiod::line::offset(
+                                      static_cast<unsigned int>(bcm)))
+                              .name();
+        }
+        catch (...)
+        {
+            kernel_name.clear();
+        }
+
+        return LineResolution{
+            bcm,
+            gpiod::line::offset(static_cast<unsigned int>(bcm)),
+            false,
+            kernel_name};
+    }
+
+    inline SelectedChip resolve_chip_and_lines(
+        const std::vector<int> &bcm_lines,
+        const std::optional<std::string> &chip_arg)
+    {
+        if (bcm_lines.empty())
+        {
+            throw std::invalid_argument("No BCM lines were supplied.");
+        }
+
+        const std::vector<ChipEntry> entries = enumerate_gpiochips();
+        print_chip_entries(entries);
+        if (entries.empty())
+        {
+            throw std::runtime_error("No GPIO chips found.");
+        }
+
+        auto resolve_on_entry =
+            [&](const ChipEntry &entry, bool auto_selected) -> std::optional<SelectedChip>
+        {
+            gpiod::chip chip(entry.path);
+            SelectedChip selected;
+            selected.path = entry.path;
+            selected.name = entry.name;
+            selected.label = entry.label;
+            selected.auto_selected = auto_selected;
+
+            for (int bcm : bcm_lines)
+            {
+                bool used_offset_fallback = false;
+                std::optional<LineResolution> resolution =
+                    try_resolve_line(chip, bcm, true, used_offset_fallback);
+                if (!resolution.has_value())
+                {
+                    return std::nullopt;
+                }
+
+                selected.used_offset_fallback =
+                    selected.used_offset_fallback || used_offset_fallback;
+                selected.lines.push_back(*resolution);
+            }
+
+            return selected;
+        };
+
+        if (chip_arg.has_value())
+        {
+            const std::filesystem::path chip_path{
+                normalize_chip_argument(*chip_arg)};
+            auto it =
+                std::find_if(
+                    entries.begin(),
+                    entries.end(),
+                    [&](const ChipEntry &entry)
+                    {
+                        return entry.path == chip_path;
+                    });
+            if (it == entries.end())
+            {
+                throw std::runtime_error(
+                    "Requested chip " + chip_path.string() +
+                    " was not found in /dev.");
+            }
+
+            std::optional<SelectedChip> selected = resolve_on_entry(*it, false);
+            if (!selected.has_value())
+            {
+                throw std::runtime_error(
+                    "Requested chip " + chip_path.string() +
+                    " does not expose all requested BCM lines.");
+            }
+            return *selected;
+        }
+
+        std::vector<SelectedChip> by_name;
+        std::vector<SelectedChip> by_fallback;
+
+        for (const ChipEntry &entry : entries)
+        {
+            try
+            {
+                std::optional<SelectedChip> selected = resolve_on_entry(entry, true);
+                if (!selected.has_value())
+                {
+                    continue;
+                }
+
+                if (selected->used_offset_fallback)
+                {
+                    by_fallback.push_back(*selected);
+                }
+                else
+                {
+                    by_name.push_back(*selected);
+                }
+            }
+            catch (const std::exception &e)
+            {
+                std::cerr << "WARN: skipping " << entry.path
+                          << ": " << e.what() << '\n';
+            }
+        }
+
+        if (!by_name.empty())
+        {
+            if (by_name.size() > 1U)
+            {
+                std::cerr
+                    << "WARN: multiple chips expose the requested GPIO line names; "
+                    << "choosing " << by_name.front().path
+                    << ". Use --chip to override.\n";
+            }
+            return by_name.front();
+        }
+
+        if (!by_fallback.empty())
+        {
+            std::cerr
+                << "WARN: no chip exposed GPIO line names for all requested BCM lines; "
+                << "falling back to raw offsets on " << by_fallback.front().path
+                << ". On Raspberry Pi 5 or other multi-chip layouts this may be wrong. "
+                << "Use --chip explicitly if header pins do not match.\n";
+            return by_fallback.front();
+        }
+
+        throw std::runtime_error(
+            "Unable to resolve the requested BCM lines on any detected GPIO chip.");
+    }
+
+    inline void print_selected_chip(const SelectedChip &selected)
+    {
+        std::cout << "Selected chip: " << selected.path
+                  << " name=" << selected.name
+                  << " label=\"" << selected.label << "\""
+                  << " auto_selected=" << bool_text(selected.auto_selected)
+                  << " used_offset_fallback=" << bool_text(selected.used_offset_fallback)
+                  << '\n';
+
+        for (const LineResolution &line : selected.lines)
+        {
+            std::cout << "  BCM " << line.bcm
+                      << " -> offset " << static_cast<unsigned int>(line.offset)
+                      << " resolved_by_name=" << bool_text(line.resolved_by_name);
+            if (!line.kernel_name.empty())
+            {
+                std::cout << " kernel_name=\"" << line.kernel_name << "\"";
+            }
+            std::cout << '\n';
+        }
+    }
+
+    inline std::vector<int> parse_bcm_list(const std::vector<std::string> &tokens)
+    {
+        std::vector<int> lines;
+
+        for (const std::string &token : tokens)
+        {
+            if (token.empty())
+            {
+                continue;
+            }
+
+            std::size_t start = 0U;
+            while (start < token.size())
+            {
+                const std::size_t comma = token.find(',', start);
+                const std::string piece =
+                    token.substr(start, comma == std::string::npos
+                                            ? std::string::npos
+                                            : comma - start);
+                if (!piece.empty())
+                {
+                    int bcm = 0;
+                    try
+                    {
+                        bcm = std::stoi(piece);
+                    }
+                    catch (const std::exception &)
+                    {
+                        throw std::invalid_argument(
+                            "Invalid BCM line '" + piece + "'.");
+                    }
+
+                    if (bcm < 0 || bcm > 27)
+                    {
+                        throw std::invalid_argument(
+                            "BCM line out of range: " + piece + ".");
+                    }
+
+                    lines.push_back(bcm);
+                }
+
+                if (comma == std::string::npos)
+                {
+                    break;
+                }
+                start = comma + 1U;
+            }
+        }
+
+        return lines;
+    }
+} // namespace gpio_test
+
+#endif // GPIO_TEST_UTILS_HPP


### PR DESCRIPTION
## Summary
This PR fixes a regression introduced by the generic GPIO resolver where
systems exposing multiple `/dev/gpiochipX` nodes for the same underlying
controller (e.g. Raspberry Pi 4) were treated as ambiguous and failed.

## Root Cause
The resolver previously assumed a 1:1 mapping between:
- `/dev/gpiochipX`
- `/sys/class/gpio/gpiochipX`

On Raspberry Pi systems, this is not valid. Multiple gpiochip device nodes
(e.g. `gpiochip0` and `gpiochip4`) can represent the same SoC GPIO controller.

As a result, valid configurations were incorrectly rejected as ambiguous.

## Fix

- Derive the backing device using:
  - `stat()` on `/dev/gpiochipX`
  - `/sys/dev/char/<major>:<minor>`
  - canonical sysfs resolution
- Compare candidates by **backing device identity**, not device node name
- Collapse duplicate views when they map to the same controller
- Select the **lowest-numbered gpiochip** deterministically
- Preserve fail-safe behavior when candidates map to different controllers

## Behavior After Fix

Example log:

```
Multiple gpiochips map to the same backing device
'/sys/devices/platform/soc/fe200000.gpio/gpiochip0'.
Using '/dev/gpiochip0' as canonical view.
```

## Impact

- Fixes TX LED initialization
- Fixes shutdown button initialization
- Keeps resolver deterministic and safe
- Maintains libgpiod v1/v2 compatibility
- No changes to RF DMA/GPCLK paths

## Notes

- This resolves false ambiguity on BCM2711-based systems
- True multi-controller ambiguity still fails safely
- Existing override mechanisms remain compatible
