### PR TITLE
UI: Backend Error Messaging Refinement

### DIFF
--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -368,6 +368,27 @@ static std::string transmit_gpio_validation_message()
     return oss.str();
 }
 
+bool backend_ready_for_transmission(
+    const ArgParserConfig &candidate,
+    std::string *error_message)
+{
+    if (candidate.transmit_backend == TransmitBackendKind::GPIO)
+    {
+        return platform_supports_gpio_clock_transmission(error_message);
+    }
+
+    if (candidate.transmit_backend == TransmitBackendKind::SI5351)
+    {
+        return si5351_device_detected(
+            candidate.si5351_i2c_bus,
+            candidate.si5351_i2c_address,
+            candidate.si5351_reference_hz,
+            error_message);
+    }
+
+    return true;
+}
+
 /**
  * @brief Rounds an input power level to the nearest valid WSPR power level.
  *
@@ -1049,7 +1070,8 @@ void print_usage(const std::string &message, int exit_code)
               << "  -i, --ini-file <file>\n"
               << "    Load parameters from an INI file. Provide the path and filename.\n\n"
               << "  --backend <gpio|si5351>\n"
-              << "    Select the RF transmit backend. Default: gpio.\n\n";
+              << "    Select the RF transmit backend. Default: gpio.\n"
+              << "    GPIO transmission is supported only on Raspberry Pi 1 through 4.\n\n";
 
     if (config.transmit_backend == TransmitBackendKind::SI5351)
     {
@@ -1268,29 +1290,35 @@ bool validate_config_candidate(
         return false;
     }
 
-    const bool requires_valid_transmit_gpio =
-        candidate.transmit_backend == TransmitBackendKind::GPIO &&
-        backend_validation_required;
-
-    if (requires_valid_transmit_gpio &&
-        !platform_supports_gpio_clock_transmission(error_message))
+    if (candidate.transmit_backend == TransmitBackendKind::GPIO)
     {
-        return false;
-    }
-
-    if (requires_valid_transmit_gpio &&
-        !is_valid_runtime_transmit_gpio(candidate.gpio_tx_pin))
-    {
-        if (error_message != nullptr)
+        if (!platform_supports_gpio_clock_transmission(error_message))
         {
-            *error_message = transmit_gpio_validation_message();
+            return false;
         }
 
-        return false;
-    }
+        if (!is_valid_runtime_transmit_gpio(candidate.gpio_tx_pin))
+        {
+            if (error_message != nullptr)
+            {
+                *error_message = transmit_gpio_validation_message();
+            }
 
-    if (candidate.transmit_backend == TransmitBackendKind::SI5351 &&
-        backend_validation_required)
+            return false;
+        }
+
+        if (candidate.gpio_power_level < 0 || candidate.gpio_power_level > 7)
+        {
+            if (error_message != nullptr)
+            {
+                *error_message =
+                    "Invalid GPIO power level. Expected 0 through 7.";
+            }
+
+            return false;
+        }
+    }
+    else if (candidate.transmit_backend == TransmitBackendKind::SI5351)
     {
         if (candidate.si5351_i2c_bus < 0)
         {
@@ -1348,18 +1376,12 @@ bool validate_config_candidate(
 
             return false;
         }
-    }
-    else if (candidate.transmit_backend == TransmitBackendKind::GPIO &&
-             backend_validation_required &&
-             (candidate.gpio_power_level < 0 || candidate.gpio_power_level > 7))
-    {
-        if (error_message != nullptr)
-        {
-            *error_message =
-                "Invalid GPIO power level. Expected 0 through 7.";
-        }
 
-        return false;
+        if (backend_validation_required &&
+            !backend_ready_for_transmission(candidate, error_message))
+        {
+            return false;
+        }
     }
 
     if (candidate.mode == ModeType::TONE)
@@ -1871,28 +1893,24 @@ bool validate_config_data()
             (!config.use_ini && config.mode == ModeType::WSPR &&
              !config.loop_tx) ||
             config.transmit;
-        if (backend_validation_required &&
-            config.transmit_backend == TransmitBackendKind::GPIO &&
+        if (config.transmit_backend == TransmitBackendKind::GPIO &&
             !platform_supports_gpio_clock_transmission())
         {
             std::string platform_error;
             (void)platform_supports_gpio_clock_transmission(&platform_error);
             llog.logE(ERROR, " - ", platform_error);
         }
-        if (backend_validation_required &&
-            config.transmit_backend == TransmitBackendKind::GPIO &&
+        if (config.transmit_backend == TransmitBackendKind::GPIO &&
             !is_valid_runtime_transmit_gpio(config.tx_pin))
         {
             llog.logE(ERROR, " - ", transmit_gpio_validation_message());
         }
-        if (backend_validation_required &&
-            config.transmit_backend == TransmitBackendKind::GPIO &&
+        if (config.transmit_backend == TransmitBackendKind::GPIO &&
             (config.gpio_power_level < 0 || config.gpio_power_level > 7))
         {
             llog.logE(ERROR, " - Invalid GPIO power level. Expected 0 through 7.");
         }
-        if (backend_validation_required &&
-            config.transmit_backend == TransmitBackendKind::SI5351)
+        if (config.transmit_backend == TransmitBackendKind::SI5351)
         {
             if (config.si5351_i2c_bus < 0)
             {
@@ -1920,6 +1938,14 @@ bool validate_config_data()
             {
                 llog.logE(ERROR,
                           " - Invalid Si5351 power level. Expected 1 through 4.");
+            }
+            if (backend_validation_required)
+            {
+                std::string si5351_error;
+                if (!backend_ready_for_transmission(config, &si5351_error))
+                {
+                    llog.logE(ERROR, " - ", si5351_error);
+                }
             }
         }
 

--- a/src/arg_parser.hpp
+++ b/src/arg_parser.hpp
@@ -178,6 +178,9 @@ bool validate_config_data_for_test(
 bool validate_config_candidate(
     ArgParserConfig &candidate,
     std::string *error_message = nullptr);
+bool backend_ready_for_transmission(
+    const ArgParserConfig &candidate,
+    std::string *error_message = nullptr);
 
 bool set_frequencies();
 bool set_frequencies(ArgParserConfig &target);

--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -33,6 +33,8 @@
 #include "json.hpp"
 #include "logging.hpp"
 #include "scheduling.hpp"
+#include "si5351_device.hpp"
+#include "version.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -40,6 +42,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -51,6 +54,20 @@ nlohmann::json jConfig;
 namespace
 {
     bool g_patch_all_from_web_runtime_apply_suppressed_for_test = false;
+    std::optional<bool> g_si5351_detection_override;
+
+    std::string si5351_detection_unavailable_message(
+        const std::string &detail = std::string())
+    {
+        std::string message =
+            "Si5351 transmission is unavailable because no Si5351 device was detected on the I2C bus.";
+        if (!detail.empty())
+        {
+            message += " ";
+            message += detail;
+        }
+        return message;
+    }
 
     std::string trim_copy(const std::string &value);
 
@@ -277,6 +294,38 @@ namespace
 
     nlohmann::json public_config_from_internal(const nlohmann::json &source)
     {
+        std::string gpio_support_error;
+        const bool gpio_clock_transmission_supported =
+            platform_supports_gpio_clock_transmission(&gpio_support_error);
+        bool si5351_detected = true;
+        std::string si5351_detection_error;
+        if (source.contains("Si5351") && source.at("Si5351").is_object())
+        {
+            const nlohmann::json &si5351 = source.at("Si5351");
+            const int i2c_bus =
+                si5351.contains("I2C Bus")
+                    ? parse_integer_config_value(si5351.at("I2C Bus"), "Si5351.I2C Bus")
+                    : kDefaultSi5351I2cBus;
+            const int i2c_address =
+                si5351.contains("I2C Address")
+                    ? parse_integer_config_value(
+                          si5351.at("I2C Address"),
+                          "Si5351.I2C Address",
+                          0)
+                    : kDefaultSi5351I2cAddress;
+            const int reference_hz =
+                si5351.contains("Reference Frequency")
+                    ? parse_integer_config_value(
+                          si5351.at("Reference Frequency"),
+                          "Si5351.Reference Frequency")
+                    : kDefaultSi5351ReferenceHz;
+            si5351_detected = si5351_device_detected(
+                i2c_bus,
+                i2c_address,
+                reference_hz,
+                &si5351_detection_error);
+        }
+
         nlohmann::json public_json;
         public_json["Operation"] = source.at("Operation");
         public_json["GPIO"] = source.at("GPIO");
@@ -285,6 +334,17 @@ namespace
         public_json["WSPR"] = source.at("WSPR");
         public_json["CW"] = source.at("CW");
         public_json["Band GPIO"] = source.at("Band GPIO");
+        public_json["Platform"] = {
+            {"Model", get_pi_model()},
+            {"Raspberry Pi Generation", get_raspberry_pi_generation()},
+            {"GPIO Clock Transmission Supported",
+             gpio_clock_transmission_supported},
+            {"GPIO Clock Transmission Error",
+             gpio_clock_transmission_supported ? std::string()
+                                               : gpio_support_error},
+            {"Si5351 Detected", si5351_detected},
+            {"Si5351 Detection Error",
+             si5351_detected ? std::string() : si5351_detection_error}};
         return public_json;
     }
 
@@ -660,6 +720,59 @@ void resolve_backend_specific_config(ArgParserConfig &config) noexcept
 
     config.power_level = config.gpio_power_level;
     config.use_ntp = config.gpio_use_ntp;
+}
+
+bool si5351_device_detected(
+    int i2c_bus,
+    int i2c_address,
+    int reference_hz,
+    std::string *error_message)
+{
+    if (g_si5351_detection_override.has_value())
+    {
+        if (!*g_si5351_detection_override && error_message != nullptr)
+        {
+            *error_message = si5351_detection_unavailable_message();
+        }
+        return *g_si5351_detection_override;
+    }
+
+    Si5351Device::Config device_config;
+    device_config.i2c_bus = i2c_bus;
+    device_config.i2c_address = static_cast<std::uint8_t>(i2c_address);
+    device_config.reference_hz = static_cast<std::uint32_t>(reference_hz);
+
+    Si5351Device device(device_config);
+    if (!device.open())
+    {
+        if (error_message != nullptr)
+        {
+            *error_message =
+                si5351_detection_unavailable_message(device.getLastError());
+        }
+        return false;
+    }
+
+    const bool detected = device.probe();
+    const std::string detail = device.getLastError();
+    device.close();
+
+    if (!detected && error_message != nullptr)
+    {
+        *error_message = si5351_detection_unavailable_message(detail);
+    }
+
+    return detected;
+}
+
+void set_si5351_detection_override_for_test(bool detected) noexcept
+{
+    g_si5351_detection_override = detected;
+}
+
+void clear_si5351_detection_override_for_test() noexcept
+{
+    g_si5351_detection_override.reset();
 }
 
 namespace

--- a/src/config_handler.hpp
+++ b/src/config_handler.hpp
@@ -457,6 +457,13 @@ private:
 
 void init_default_config();
 void resolve_backend_specific_config(ArgParserConfig &config) noexcept;
+bool si5351_device_detected(
+    int i2c_bus,
+    int i2c_address,
+    int reference_hz,
+    std::string *error_message = nullptr);
+void set_si5351_detection_override_for_test(bool detected) noexcept;
+void clear_si5351_detection_override_for_test() noexcept;
 
 /**
  * @brief Initializes the global configuration JSON object.

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -2567,7 +2567,10 @@ void shutdown_machine()
  *
  * @note Requires <nlohmann/json.hpp>, <chrono>, <ctime>, <iomanip>, and <sstream>.
  */
-void send_ws_message(std::string type, std::string state)
+void send_ws_message(
+    std::string type,
+    std::string state,
+    std::string message)
 {
     // Build JSON payload
     nlohmann::json j;
@@ -2589,6 +2592,11 @@ void send_ws_message(std::string type, std::string state)
         j["frame_locator"] = snapshot.frame_locator;
     }
 
+    if (!message.empty())
+    {
+        j["message"] = message;
+    }
+
     // Capture current UTC time and format as ISO 8601 (YYYY-MM-DDThh:mm:ssZ)
     auto now = std::chrono::system_clock::now();
     auto now_t = std::chrono::system_clock::to_time_t(now);
@@ -2600,8 +2608,8 @@ void send_ws_message(std::string type, std::string state)
     j["timestamp"] = oss.str();
 
     // Serialize and send to all WebSocket clients
-    const std::string message = j.dump();
-    socketServer.sendAllClients(message);
+    const std::string payload = j.dump();
+    socketServer.sendAllClients(payload);
 }
 
 WsprRuntimeStatusSnapshot current_tx_runtime_status_snapshot()
@@ -2745,7 +2753,10 @@ bool set_config(bool force)
                 llog.logS(ERROR,
                           "Invalid configuration reload rejected; previous valid configuration remains loaded:",
                           prepared_candidate.error_reason);
-                send_ws_message("configuration", "reload_failed");
+                send_ws_message(
+                    "configuration",
+                    "reload_failed",
+                    prepared_candidate.error_reason);
                 set_managed_reload_tx_inhibited(
                     true,
                     "Transmit is blocked until a valid configuration is loaded.");
@@ -2771,23 +2782,27 @@ bool set_config(bool force)
         bool do_config = force;
         bool do_random = false;
 
-        std::string backend_platform_error;
-        const bool backend_platform_supported =
+        std::string backend_runtime_error;
+        const bool backend_runtime_ready =
             !(working_config.mode == ModeType::TONE ||
               runtime_transmit_requested(working_config))
-            || working_config.transmit_backend != TransmitBackendKind::GPIO
-            || platform_supports_gpio_clock_transmission(
-                &backend_platform_error);
+            || backend_ready_for_transmission(
+                working_config,
+                &backend_runtime_error);
 
-        if (!backend_platform_supported)
+        if (!backend_runtime_ready)
         {
-            llog.logS(ERROR, backend_platform_error);
+            llog.logS(ERROR, backend_runtime_error);
 
             if (working_config.use_ini)
             {
+                send_ws_message(
+                    "configuration",
+                    "reload_failed",
+                    backend_runtime_error);
                 set_managed_reload_tx_inhibited(
                     true,
-                    "No transmit due to invalid backend/platform combination.");
+                    backend_runtime_error);
                 wsprTransmitter.stopAndJoin();
                 stop_active_transmission_selectors();
                 current_transmission_request = TransmissionRequest{};
@@ -3112,7 +3127,10 @@ bool set_config(bool force)
                     set_managed_reload_tx_inhibited(
                         true,
                         "Managed reload planning failed; previous valid configuration remains loaded. Transmit is blocked until a valid configuration is loaded.");
-                    send_ws_message("configuration", "reload_failed");
+                    send_ws_message(
+                        "configuration",
+                        "reload_failed",
+                        "Managed reload planning failed; previous valid configuration remains loaded. Transmit is blocked until a valid configuration is loaded.");
                     wsprTransmitter.stopAndJoin();
                     stop_active_transmission_selectors();
                     current_transmission_request = TransmissionRequest{};
@@ -3149,7 +3167,10 @@ bool set_config(bool force)
                     set_managed_reload_tx_inhibited(
                         true,
                         "Managed reload could not prepare band GPIO; previous valid configuration remains loaded. Transmit is blocked until a valid configuration is loaded.");
-                    send_ws_message("configuration", "reload_failed");
+                    send_ws_message(
+                        "configuration",
+                        "reload_failed",
+                        "Managed reload could not prepare band GPIO; previous valid configuration remains loaded. Transmit is blocked until a valid configuration is loaded.");
                     if (!finalize_reload_pending())
                     {
                         continue;

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -249,7 +249,10 @@ void shutdown_machine();
  *
  * @note Requires <nlohmann/json.hpp>, <chrono>, <ctime>, <iomanip>, and <sstream>.
  */
-void send_ws_message(std::string type, std::string state);
+void send_ws_message(
+    std::string type,
+    std::string state,
+    std::string message = std::string());
 
 struct StopTransmissionResult
 {

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -202,6 +202,11 @@ namespace
         clear_raspberry_pi_generation_override_for_test();
     }
 
+    void clear_si5351_detection_override_for_scope() noexcept
+    {
+        set_si5351_detection_override_for_test(true);
+    }
+
     void require_patch_accepts_and_runtime_plans(
         const nlohmann::json &patch,
         const std::string &expected_plan_type,
@@ -291,6 +296,7 @@ namespace
 int main()
 {
     set_patch_all_from_web_runtime_apply_suppressed_for_test(true);
+    set_si5351_detection_override_for_test(true);
 
     WSPRBandLookup lookup;
 
@@ -364,6 +370,24 @@ int main()
 
     {
         set_raspberry_pi_generation_override_for_test(5);
+        prime_valid_runtime_identity_config();
+        config.transmit = false;
+
+        std::string validation_error;
+        require(
+            !validate_config_candidate(config, &validation_error),
+            "GPIO backend must remain invalid on Raspberry Pi 5 even when transmit is off");
+        require(
+            validation_error.find(
+                "GPIO transmission mode is unsupported on Raspberry Pi 5 and newer.") !=
+                std::string::npos,
+            "GPIO backend invalidity on Raspberry Pi 5 must not depend on transmit state");
+
+        clear_pi_generation_override_for_scope();
+    }
+
+    {
+        set_raspberry_pi_generation_override_for_test(5);
         reset_current_transmission_request_for_test();
         reset_getopt_state();
 
@@ -407,13 +431,60 @@ int main()
         config.si5351_tx_output = 0;
         config.si5351_power_level = 1;
         resolve_backend_specific_config(config);
+        set_si5351_detection_override_for_test(true);
 
         std::string validation_error;
         require(
             validate_config_candidate(config, &validation_error),
             "non-GPIO backends must remain allowed on Raspberry Pi 5");
 
+        clear_si5351_detection_override_for_scope();
         clear_pi_generation_override_for_scope();
+    }
+
+    {
+        prime_valid_runtime_identity_config();
+        config.transmit_backend = TransmitBackendKind::SI5351;
+        config.si5351_i2c_bus = 1;
+        config.si5351_i2c_address = 0x60;
+        config.si5351_reference_hz = 27000000;
+        config.si5351_tx_output = 0;
+        config.si5351_power_level = 1;
+        resolve_backend_specific_config(config);
+        set_si5351_detection_override_for_test(false);
+
+        std::string validation_error;
+        require(
+            !validate_config_candidate(config, &validation_error),
+            "Si5351 backend must reject transmit-enabled validation when no device is detected");
+        require(
+            validation_error.find(
+                "Si5351 transmission is unavailable because no Si5351 device was detected on the I2C bus.") !=
+                std::string::npos,
+            "Si5351 missing-device validation must explain why transmission is unavailable");
+
+        config.transmit = false;
+        config.use_ini = true;
+        validation_error.clear();
+        require(
+            validate_config_candidate(config, &validation_error),
+            "Si5351 backend must remain config-valid for editing when no device is detected and transmit is off");
+
+        PreparedConfigCandidate candidate;
+        auto managed_ini = make_managed_ini_data("AA0NT", "EM18", "20m", true);
+        managed_ini["Operation"]["Transmit Backend"] = "si5351";
+        iniFile.setData(managed_ini);
+        prepare_ini_config_candidate("/tmp/si5351_missing.ini", candidate);
+        require(
+            !candidate.valid,
+            "managed Si5351 configuration must be rejected when transmit is enabled but no device is detected");
+        require(
+            candidate.error_reason.find(
+                "Si5351 transmission is unavailable because no Si5351 device was detected on the I2C bus.") !=
+                std::string::npos,
+            "managed Si5351 rejection must preserve the missing-device error");
+
+        clear_si5351_detection_override_for_scope();
     }
 
     {
@@ -1539,6 +1610,7 @@ int main()
 
     {
         init_default_config();
+        set_si5351_detection_override_for_test(false);
         config.si5351_tx_output = 2;
         config_to_json();
 
@@ -1552,6 +1624,17 @@ int main()
             public_config["Si5351"].contains("TX Output") &&
                 public_config["Si5351"]["TX Output"].get<std::string>() == "CLK2",
             "public config JSON must include Si5351 TX Output");
+        require(
+            public_config["Platform"].contains("Si5351 Detected") &&
+                public_config["Platform"]["Si5351 Detected"].get<bool>() == false,
+            "public config JSON must surface Si5351 detection state");
+        require(
+            public_config["Platform"].contains("Si5351 Detection Error") &&
+                public_config["Platform"]["Si5351 Detection Error"]
+                        .get<std::string>()
+                        .find("Si5351 transmission is unavailable because no Si5351 device was detected on the I2C bus.") !=
+                    std::string::npos,
+            "public config JSON must surface the Si5351 missing-device message");
 
         jConfig["Si5351"]["TX Output"] = "CLK1";
         json_to_config();
@@ -1570,6 +1653,7 @@ int main()
         require(
             si5351_it->second.at("TX Output") == "CLK2",
             "json_to_ini must persist Si5351 TX Output");
+        clear_si5351_detection_override_for_scope();
     }
 
     {


### PR DESCRIPTION
## Summary

This PR refines how backend and platform errors are presented in the UI, making them clearer and more actionable for users while preserving all existing backend logic and validation behavior.

The backend remains the authoritative source of truth. The UI now formats those messages based on context to improve usability.

---

## What Changed

### UI Messaging Layer

- Added formatter helpers in `index.js` to adapt backend reason strings for:
  - Inline hints
  - Backend status banners
  - Transmit toggle failures
  - `reload_failed` websocket events

- Updated UI surfaces to use context-aware wording:
  - Action-first phrasing for blocking actions
  - State + guidance phrasing for banners
  - Concise descriptive phrasing for inline hints

- Updated `site.js` websocket handling to format `reload_failed` messages before displaying them

---

## Behavior Improvements

### Before

- UI displayed raw backend error messages directly
- Messaging felt technical and inconsistent across surfaces
- Some actions failed with minimal user guidance

### After

- UI adapts backend messages depending on context:
  - Inline hints explain constraints
  - Banners describe state and next steps
  - Transmit failures clearly state what failed and why
- Unknown errors still pass through unchanged

---

## Examples

### GPIO unsupported on current platform

- Inline hint:
  - GPIO transmission is supported only on Raspberry Pi 1 through 4.

- Banner:
  - Transmission is unavailable with the GPIO backend on this Raspberry Pi.
  - Use the Si5351 backend to enable transmission.

- Transmit failure:
  - Transmit cannot be enabled with the GPIO backend on this Raspberry Pi.

- Reload failure:
  - Configuration rejected: GPIO transmission is not supported on this Raspberry Pi.

---

### Si5351 not detected

- Inline hint:
  - No Si5351 detected on the configured I2C bus.

- Banner:
  - Transmission is unavailable because no Si5351 was detected on the configured I2C bus.
  - Check I2C bus, address, wiring, and power, or select a different backend.

- Transmit failure:
  - Transmit cannot be enabled because no Si5351 was detected on the configured I2C bus.

- Reload failure:
  - Configuration rejected: no Si5351 device was detected on the configured I2C bus.

---

## Scope

- UI-only change
- No backend logic changes
- No API changes
- No validation or policy changes

---

## Notes

- Backend error messages remain the source of truth
- UI formatting layer improves clarity without altering behavior
- Unknown or unexpected backend messages are preserved and displayed as-is
