### PR TITLE
Reject QRSS, FSKCW, and DFCW messages that exceed repeat_every

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -116,6 +116,7 @@ MONITOR_FILE_REGRESSION_TEST_OUT := monitor_file_regression_test
 GPIO_LOOPBACK_TEST_OUT := gpio_loopback_test
 BAND_GPIO_LIVE_MONITOR_OUT := band_gpio_live_monitor
 GPIO_LINE_RESOLVER_TEST_OUT := gpio_line_resolver_test
+NON_WSPR_REPEAT_POLICY_TEST_OUT := non_wspr_repeat_policy_test
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Output directories
@@ -162,6 +163,9 @@ GPIO_LINE_RESOLVER_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/gpio_line_resolver_test.o
 GPIO_LINE_RESOLVER_TEST_DEPS := \
 	$(GPIO_LINE_RESOLVER_TEST_OBJ) \
 	$(OBJ_DIR_DEBUG)/./gpio_line_resolver.o
+NON_WSPR_REPEAT_POLICY_TEST_SRC := tests/non_wspr_repeat_policy_test.cpp
+NON_WSPR_REPEAT_POLICY_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/non_wspr_repeat_policy_test.o
+NON_WSPR_REPEAT_POLICY_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Dependency includes
@@ -388,6 +392,17 @@ $(BIN_DIR)/$(GPIO_LINE_RESOLVER_TEST_OUT): $(GPIO_LINE_RESOLVER_TEST_DEPS)
 	$(Q)echo "Linking debug: $(GPIO_LINE_RESOLVER_TEST_OUT)"
 	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
 
+$(NON_WSPR_REPEAT_POLICY_TEST_OBJ): $(NON_WSPR_REPEAT_POLICY_TEST_SRC)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)mkdir -p $(DEP_DIR)/tests
+	$(Q)echo "Compiling (debug) $< into $@"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) -MF $(DEP_DIR)/tests/non_wspr_repeat_policy_test.d -c $< -o $@
+
+$(BIN_DIR)/$(NON_WSPR_REPEAT_POLICY_TEST_OUT): $(NON_WSPR_REPEAT_POLICY_TEST_OBJ) $(NON_WSPR_REPEAT_POLICY_TEST_DEPS)
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)echo "Linking debug: $(NON_WSPR_REPEAT_POLICY_TEST_OUT)"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
+
 ifeq ($(GPIOD_HAS_V2),1)
 $(GPIO_LOOPBACK_TEST_OBJ): $(GPIO_LOOPBACK_TEST_SRC)
 	$(Q)mkdir -p $(dir $@)
@@ -441,7 +456,7 @@ $(BIN_DIR)/$(OUT): $(CPP_OBJECTS)
 # Phony targets
 # ─────────────────────────────────────────────────────────────────────────────
 
-.PHONY: clean release debug test test-tone test-oneshot semantics-test band-gpio-rotation-test monitor-file-regression-test gpio-line-resolver-test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
+.PHONY: clean release debug test test-tone test-oneshot semantics-test band-gpio-rotation-test monitor-file-regression-test gpio-line-resolver-test non-wspr-repeat-policy-test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
 DEBUG: debug
 RELEASE: release
 
@@ -483,6 +498,10 @@ monitor-file-regression-test: $(BIN_DIR)/$(MONITOR_FILE_REGRESSION_TEST_OUT)
 gpio-line-resolver-test: $(BIN_DIR)/$(GPIO_LINE_RESOLVER_TEST_OUT)
 	$(Q)echo "Running GPIO line resolver regression tests."
 	$(Q)./$(BIN_DIR)/$(GPIO_LINE_RESOLVER_TEST_OUT)
+
+non-wspr-repeat-policy-test: $(BIN_DIR)/$(NON_WSPR_REPEAT_POLICY_TEST_OUT)
+	$(Q)echo "Running non-WSPR repeat policy regression tests."
+	$(Q)./$(BIN_DIR)/$(NON_WSPR_REPEAT_POLICY_TEST_OUT)
 
 ifeq ($(GPIOD_HAS_V2),1)
 gpio-loopback-test: $(BIN_DIR)/$(GPIO_LOOPBACK_TEST_OUT)

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1416,7 +1416,7 @@ bool validate_config_candidate(
             return false;
         }
 
-        return true;
+        return validate_non_wspr_repeat_interval_policy(candidate, error_message);
     }
 
     if (candidate.mode == ModeType::FSKCW)
@@ -1431,7 +1431,7 @@ bool validate_config_candidate(
             return false;
         }
 
-        return true;
+        return validate_non_wspr_repeat_interval_policy(candidate, error_message);
     }
 
     if (candidate.mode == ModeType::DFCW)
@@ -1446,7 +1446,7 @@ bool validate_config_candidate(
             return false;
         }
 
-        return true;
+        return validate_non_wspr_repeat_interval_policy(candidate, error_message);
     }
 
     if (candidate.mode != ModeType::WSPR)

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -51,6 +51,7 @@
 #include "logging.hpp"
 #include "ppm_manager.hpp"
 #include "signal_handler.hpp"
+#include "execution_plan_compiler.hpp"
 #include "wspr_reference_adapter.hpp"
 #include "web_server.hpp"
 #include "web_socket.hpp"
@@ -62,6 +63,7 @@
 #include <cctype>
 #include <cerrno>
 #include <chrono>
+#include <cmath>
 #include <condition_variable>
 #include <cstring>
 #include <ctime>
@@ -985,6 +987,33 @@ static wsprrypi::EnvelopeSettings cw_envelope_from_config(
     return envelope;
 }
 
+static std::string format_policy_duration(
+    std::chrono::nanoseconds duration)
+{
+    const double total_seconds =
+        std::chrono::duration<double>(duration).count();
+    const auto total_whole_seconds =
+        static_cast<long long>(std::llround(total_seconds));
+    if (std::fabs(total_seconds - static_cast<double>(total_whole_seconds)) <
+        0.0005)
+    {
+        const long long minutes = total_whole_seconds / 60;
+        const long long seconds = total_whole_seconds % 60;
+        std::ostringstream oss;
+        oss << minutes << "m " << std::setw(2) << std::setfill('0') << seconds
+            << "s";
+        return oss.str();
+    }
+
+    const long long minutes = static_cast<long long>(total_seconds / 60.0);
+    const double seconds = total_seconds - static_cast<double>(minutes * 60);
+    std::ostringstream oss;
+    oss << minutes << "m "
+        << std::fixed << std::setprecision(3) << std::setw(6)
+        << std::setfill('0') << seconds << "s";
+    return oss.str();
+}
+
 static wsprrypi::TransmissionRequest make_qrss_controller_request(
     const ArgParserConfig &cfg,
     double committed_ppm)
@@ -1108,6 +1137,87 @@ static TransmissionRequest make_dfcw_legacy_request(
     return request;
 }
 
+bool compute_non_wspr_message_duration(
+    const ArgParserConfig &cfg,
+    std::chrono::nanoseconds &duration_out,
+    std::string *error_message)
+{
+    try
+    {
+        wsprrypi::TransmissionRequest request;
+        if (cfg.mode == ModeType::QRSS)
+        {
+            request = make_qrss_controller_request(cfg, cfg.ppm);
+        }
+        else if (cfg.mode == ModeType::FSKCW)
+        {
+            request = make_fskcw_controller_request(cfg, cfg.ppm);
+        }
+        else if (cfg.mode == ModeType::DFCW)
+        {
+            request = make_dfcw_controller_request(cfg, cfg.ppm);
+        }
+        else
+        {
+            if (error_message != nullptr)
+            {
+                *error_message =
+                    "Timed-message duration is only available for QRSS, FSKCW, and DFCW modes.";
+            }
+            return false;
+        }
+
+        const wsprrypi::ExecutionPlanCompiler compiler;
+        duration_out = compiler.compile(request).summary.total_duration;
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        if (error_message != nullptr)
+        {
+            *error_message = e.what();
+        }
+        return false;
+    }
+}
+
+bool validate_non_wspr_repeat_interval_policy(
+    const ArgParserConfig &cfg,
+    std::string *error_message)
+{
+    if (!is_non_wspr_runtime_mode(cfg.mode) || cfg.schedule_repeat_minutes <= 0)
+    {
+        return true;
+    }
+
+    std::chrono::nanoseconds message_duration{};
+    if (!compute_non_wspr_message_duration(cfg, message_duration, error_message))
+    {
+        return false;
+    }
+
+    const auto repeat_interval =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::minutes(cfg.schedule_repeat_minutes));
+    if (message_duration <= repeat_interval)
+    {
+        return true;
+    }
+
+    if (error_message != nullptr)
+    {
+        *error_message =
+            "Configured " +
+            std::string(mode_type_name(cfg.mode)) +
+            " message duration of " +
+            format_policy_duration(message_duration) +
+            " exceeds repeat_every interval of " +
+            format_policy_duration(repeat_interval) +
+            ". Reduce the message length, shorten the unit length, or increase repeat_every.";
+    }
+    return false;
+}
+
 static bool start_non_wspr_transmission_now(const ArgParserConfig &cfg)
 {
     if (!runtime_transmit_requested(cfg))
@@ -1117,6 +1227,12 @@ static bool start_non_wspr_transmission_now(const ArgParserConfig &cfg)
     }
 
     const double committed_ppm = cfg.ppm;
+    std::string policy_error;
+    if (!validate_non_wspr_repeat_interval_policy(cfg, &policy_error))
+    {
+        llog.logE(ERROR, policy_error);
+        return false;
+    }
 
     if (cfg.mode == ModeType::QRSS)
     {
@@ -2861,6 +2977,36 @@ bool set_config(bool force)
 
         if (is_non_wspr_runtime_mode(working_config.mode))
         {
+            std::string policy_error;
+            if (!validate_non_wspr_repeat_interval_policy(
+                    working_config,
+                    &policy_error))
+            {
+                llog.logS(ERROR, policy_error);
+
+                if (working_config.use_ini)
+                {
+                    send_ws_message(
+                        "configuration",
+                        "reload_failed",
+                        policy_error);
+                    set_managed_reload_tx_inhibited(
+                        true,
+                        policy_error);
+                    wsprTransmitter.stopAndJoin();
+                    stop_active_transmission_selectors();
+                    current_transmission_request = TransmissionRequest{};
+                    current_dial_frequency = 0.0;
+                    current_frequency_entry = WsprFrequencyEntry{};
+                }
+
+                if (!finalize_reload_pending())
+                {
+                    continue;
+                }
+                return working_config.use_ini;
+            }
+
             if (candidate_ready_to_commit)
             {
                 prepared_candidate.normalized_config.ppm = working_config.ppm;

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -46,6 +46,7 @@
 
 // Standard library headers
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <condition_variable>
 #include <string>
@@ -294,6 +295,13 @@ WsprRuntimeStatusSnapshot current_tx_runtime_status_snapshot();
  *         `configure()`.
  */
 bool set_config(bool force = false);
+bool compute_non_wspr_message_duration(
+    const ArgParserConfig &cfg,
+    std::chrono::nanoseconds &duration_out,
+    std::string *error_message = nullptr);
+bool validate_non_wspr_repeat_interval_policy(
+    const ArgParserConfig &cfg,
+    std::string *error_message = nullptr);
 bool transmitter_reload_should_defer() noexcept;
 void transmitter_cb(WsprTransmissionCallbackEvent event,
                     WsprTransmitLogLevel level,

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -300,6 +300,55 @@ namespace
                 config.wspr_planner_preference == original_planner_preference,
             message + " must not mutate live config after rejection");
     }
+
+    ArgParserConfig make_qrss_policy_config(
+        const std::string &message,
+        double dot_seconds,
+        int repeat_minutes)
+    {
+        ArgParserConfig candidate;
+        candidate.use_ini = false;
+        candidate.mode = ModeType::QRSS;
+        candidate.transmit = true;
+        candidate.transmit_backend = TransmitBackendKind::GPIO;
+        candidate.gpio_tx_pin = 4;
+        candidate.gpio_power_level = 7;
+        candidate.qrss.message = message;
+        candidate.qrss.frequency_hz = 10140100.0;
+        candidate.qrss.dot_seconds = dot_seconds;
+        candidate.modulation_dot_seconds = dot_seconds;
+        candidate.schedule_repeat_minutes = repeat_minutes;
+        resolve_backend_specific_config(candidate);
+        return candidate;
+    }
+
+    ArgParserConfig make_fskcw_policy_config(
+        const std::string &message,
+        double dot_seconds,
+        int repeat_minutes)
+    {
+        ArgParserConfig candidate = make_qrss_policy_config(message, dot_seconds, repeat_minutes);
+        candidate.mode = ModeType::FSKCW;
+        candidate.fskcw.message = message;
+        candidate.fskcw.mark_frequency_hz = 10140120.0;
+        candidate.fskcw.space_frequency_hz = 10140100.0;
+        candidate.fskcw.dot_seconds = dot_seconds;
+        return candidate;
+    }
+
+    ArgParserConfig make_dfcw_policy_config(
+        const std::string &message,
+        double dot_seconds,
+        int repeat_minutes)
+    {
+        ArgParserConfig candidate = make_qrss_policy_config(message, dot_seconds, repeat_minutes);
+        candidate.mode = ModeType::DFCW;
+        candidate.dfcw.message = message;
+        candidate.dfcw.dot_frequency_hz = 10140100.0;
+        candidate.dfcw.dash_frequency_hz = 10140120.0;
+        candidate.dfcw.dot_seconds = dot_seconds;
+        return candidate;
+    }
 } // namespace
 
 int main()
@@ -2180,6 +2229,175 @@ int main()
         require(
             config.dfcw.message == "CQ DX",
             "DFCW CLI parsing must trim CW message edges and preserve internal spaces");
+    }
+
+    {
+        std::chrono::nanoseconds qrss_duration{};
+        std::string validation_error;
+
+        ArgParserConfig qrss_short =
+            make_qrss_policy_config("E", 59.0, 1);
+        require(
+            compute_non_wspr_message_duration(
+                qrss_short,
+                qrss_duration,
+                &validation_error),
+            "QRSS duration helper must succeed for a valid short message");
+        require(
+            qrss_duration == std::chrono::seconds(59),
+            "QRSS duration helper must include the dot length for a one-symbol message");
+        require(
+            validate_non_wspr_repeat_interval_policy(
+                qrss_short,
+                &validation_error),
+            "QRSS duration shorter than repeat_every must validate");
+
+        ArgParserConfig qrss_equal =
+            make_qrss_policy_config("E", 60.0, 1);
+        require(
+            compute_non_wspr_message_duration(
+                qrss_equal,
+                qrss_duration,
+                &validation_error) &&
+                qrss_duration == std::chrono::minutes(1),
+            "QRSS duration helper must allow equality with repeat_every");
+        require(
+            validate_non_wspr_repeat_interval_policy(
+                qrss_equal,
+                &validation_error),
+            "QRSS duration equal to repeat_every must validate");
+
+        ArgParserConfig qrss_long =
+            make_qrss_policy_config("E", 61.0, 1);
+        require(
+            !validate_non_wspr_repeat_interval_policy(
+                qrss_long,
+                &validation_error) &&
+                validation_error.find(
+                    "Configured QRSS message duration of 1m 01s exceeds repeat_every interval of 1m 00s.") !=
+                    std::string::npos,
+            "QRSS duration longer than repeat_every must be rejected with a clear error");
+
+        ArgParserConfig fskcw_long =
+            make_fskcw_policy_config("E", 61.0, 1);
+        validation_error.clear();
+        require(
+            !validate_non_wspr_repeat_interval_policy(
+                fskcw_long,
+                &validation_error) &&
+                validation_error.find("Configured FSKCW message duration") !=
+                    std::string::npos,
+            "FSKCW duration longer than repeat_every must be rejected");
+
+        ArgParserConfig dfcw_long =
+            make_dfcw_policy_config("E", 61.0, 1);
+        validation_error.clear();
+        require(
+            !validate_non_wspr_repeat_interval_policy(
+                dfcw_long,
+                &validation_error) &&
+                validation_error.find("Configured DFCW message duration") !=
+                    std::string::npos,
+            "DFCW duration longer than repeat_every must be rejected");
+
+        std::chrono::nanoseconds with_word_gap{};
+        std::chrono::nanoseconds without_word_gap{};
+        validation_error.clear();
+        require(
+            compute_non_wspr_message_duration(
+                make_qrss_policy_config("E E", 1.0, 10),
+                with_word_gap,
+                &validation_error) &&
+                compute_non_wspr_message_duration(
+                    make_qrss_policy_config("EE", 1.0, 10),
+                    without_word_gap,
+                    &validation_error) &&
+                with_word_gap > without_word_gap,
+            "QRSS duration helper must include inter-word spacing");
+
+        std::chrono::nanoseconds dash_heavy{};
+        std::chrono::nanoseconds dit_heavy{};
+        require(
+            compute_non_wspr_message_duration(
+                make_qrss_policy_config("TTT", 1.0, 10),
+                dash_heavy,
+                &validation_error) &&
+                compute_non_wspr_message_duration(
+                    make_qrss_policy_config("EEE", 1.0, 10),
+                    dit_heavy,
+                    &validation_error) &&
+                dash_heavy > dit_heavy,
+            "QRSS duration helper must include dash timing");
+
+        validation_error.clear();
+        require(
+            validate_non_wspr_repeat_interval_policy(
+                make_qrss_policy_config("SOS", 2.0, 1),
+                &validation_error) &&
+                !validate_non_wspr_repeat_interval_policy(
+                    make_qrss_policy_config("SOS", 5.0, 1),
+                    &validation_error),
+            "different unit lengths must change whether the same QRSS message passes the repeat_every policy");
+
+        clear_qrss_startup_request();
+        reset_current_transmission_request_for_test();
+        set_scheduler_execution_suppressed_for_test(true);
+        {
+            const ArgParserConfig candidate = make_qrss_policy_config("E", 61.0, 1);
+            copy_runtime_config(candidate, config);
+        }
+        require(
+            !set_config(true),
+            "scheduler must reject an overlong QRSS configuration before committing execution");
+        require(
+            current_transmission_request_for_test().actual_rf_frequency_hz == 0.0 &&
+                current_transmission_request_for_test().payload.frames.empty(),
+            "scheduler rejection must leave the committed execution request untouched");
+        set_scheduler_execution_suppressed_for_test(false);
+
+        {
+            const ArgParserConfig candidate = make_qrss_policy_config("E", 61.0, 1);
+            copy_runtime_config(candidate, config);
+        }
+        validation_error.clear();
+        require(
+            !validate_config_data_for_test(&validation_error) &&
+                validation_error.find("Configured QRSS message duration") !=
+                    std::string::npos,
+            "CLI validation must surface the repeat_every policy error");
+
+        clear_qrss_startup_request();
+        clear_fskcw_startup_request();
+        clear_dfcw_startup_request();
+        prime_valid_runtime_identity_config();
+        const ModeType original_mode = config.mode;
+        bool threw_patch_error = false;
+        try
+        {
+            patch_all_from_web({
+                {"Operation",
+                 {{"Mode", "QRSS"},
+                  {"Transmit", true}}},
+                {"CW",
+                 {{"Message", "E"},
+                  {"Base Frequency", 10140100.0},
+                  {"Dot Seconds", 61.0},
+                  {"Repeat Minutes", 1}}}});
+        }
+        catch (const std::exception &e)
+        {
+            threw_patch_error = true;
+            require(
+                std::string(e.what()).find("Configured QRSS message duration") !=
+                    std::string::npos,
+                "web patch validation must expose the repeat_every policy error");
+        }
+        require(
+            threw_patch_error,
+            "web patch validation must reject an overlong QRSS configuration");
+        require(
+            config.mode == original_mode,
+            "web patch rejection must not mutate the live mode");
     }
 
     {

--- a/src/tests/non_wspr_repeat_policy_test.cpp
+++ b/src/tests/non_wspr_repeat_policy_test.cpp
@@ -1,0 +1,298 @@
+#include "arg_parser.hpp"
+#include "config_handler.hpp"
+#include "scheduling.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace
+{
+    void require(bool condition, const std::string &message)
+    {
+        if (!condition)
+        {
+            std::cerr << "FAIL: " << message << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+
+    void prime_valid_runtime_identity_config()
+    {
+        init_default_config();
+        config.use_ini = false;
+        config.mode = ModeType::WSPR;
+        config.transmit = true;
+        config.callsign = "AA0NT";
+        config.grid_square = "EM18";
+        config.power_dbm = 20;
+        config.frequencies = "20m";
+        config.transmit_backend = TransmitBackendKind::GPIO;
+        config.gpio_tx_pin = 4;
+        config.gpio_power_level = 7;
+        config.gpio_use_ntp = false;
+        config.wspr_planner_preference = WsprPlannerPreference::Auto;
+        config.wspr.callsign = config.callsign;
+        config.wspr.grid_square = config.grid_square;
+        config.wspr.power_dbm = config.power_dbm;
+        config.wspr.frequencies = config.frequencies;
+        config.wspr.audio_offset_hz = WSPR_AUDIO_OFFSET_HZ;
+        config.wspr.planner_preference = config.wspr_planner_preference;
+        resolve_backend_specific_config(config);
+        set_frequencies(config);
+        config_to_json();
+    }
+
+    void reset_scheduler_test_state()
+    {
+        ini_reload_pending.store(false, std::memory_order_relaxed);
+        ppm_reload_pending.store(false, std::memory_order_relaxed);
+        exiting_wspr.store(false, std::memory_order_relaxed);
+        reset_managed_reload_runtime_for_test();
+        reset_current_transmission_request_for_test();
+        set_scheduler_execution_suppressed_for_test(true);
+    }
+
+    void finish_scheduler_test_state()
+    {
+        set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    ArgParserConfig make_qrss_policy_config(
+        const std::string &message,
+        double dot_seconds,
+        int repeat_minutes)
+    {
+        ArgParserConfig candidate;
+        candidate.use_ini = false;
+        candidate.mode = ModeType::QRSS;
+        candidate.transmit = true;
+        candidate.transmit_backend = TransmitBackendKind::GPIO;
+        candidate.gpio_tx_pin = 4;
+        candidate.gpio_power_level = 7;
+        candidate.qrss.message = message;
+        candidate.qrss.frequency_hz = 10140100.0;
+        candidate.qrss.dot_seconds = dot_seconds;
+        candidate.modulation_dot_seconds = dot_seconds;
+        candidate.schedule_repeat_minutes = repeat_minutes;
+        resolve_backend_specific_config(candidate);
+        return candidate;
+    }
+
+    ArgParserConfig make_fskcw_policy_config(
+        const std::string &message,
+        double dot_seconds,
+        int repeat_minutes)
+    {
+        ArgParserConfig candidate =
+            make_qrss_policy_config(message, dot_seconds, repeat_minutes);
+        candidate.mode = ModeType::FSKCW;
+        candidate.fskcw.message = message;
+        candidate.fskcw.mark_frequency_hz = 10140120.0;
+        candidate.fskcw.space_frequency_hz = 10140100.0;
+        candidate.fskcw.dot_seconds = dot_seconds;
+        return candidate;
+    }
+
+    ArgParserConfig make_dfcw_policy_config(
+        const std::string &message,
+        double dot_seconds,
+        int repeat_minutes)
+    {
+        ArgParserConfig candidate =
+            make_qrss_policy_config(message, dot_seconds, repeat_minutes);
+        candidate.mode = ModeType::DFCW;
+        candidate.dfcw.message = message;
+        candidate.dfcw.dot_frequency_hz = 10140100.0;
+        candidate.dfcw.dash_frequency_hz = 10140120.0;
+        candidate.dfcw.dot_seconds = dot_seconds;
+        return candidate;
+    }
+} // namespace
+
+int main()
+{
+    set_patch_all_from_web_runtime_apply_suppressed_for_test(true);
+    set_si5351_detection_override_for_test(true);
+
+    {
+        std::chrono::nanoseconds qrss_duration{};
+        std::string validation_error;
+
+        ArgParserConfig qrss_short =
+            make_qrss_policy_config("E", 59.0, 1);
+        require(
+            compute_non_wspr_message_duration(
+                qrss_short,
+                qrss_duration,
+                &validation_error),
+            "QRSS duration helper must succeed for a valid short message");
+        require(
+            qrss_duration == std::chrono::seconds(59),
+            "QRSS duration helper must include the dot length for a one-symbol message");
+        require(
+            validate_non_wspr_repeat_interval_policy(
+                qrss_short,
+                &validation_error),
+            "QRSS duration shorter than repeat_every must validate");
+
+        ArgParserConfig qrss_equal =
+            make_qrss_policy_config("E", 60.0, 1);
+        require(
+            compute_non_wspr_message_duration(
+                qrss_equal,
+                qrss_duration,
+                &validation_error) &&
+                qrss_duration == std::chrono::minutes(1),
+            "QRSS duration helper must allow equality with repeat_every");
+        require(
+            validate_non_wspr_repeat_interval_policy(
+                qrss_equal,
+                &validation_error),
+            "QRSS duration equal to repeat_every must validate");
+
+        ArgParserConfig qrss_long =
+            make_qrss_policy_config("E", 61.0, 1);
+        require(
+            !validate_non_wspr_repeat_interval_policy(
+                qrss_long,
+                &validation_error) &&
+                validation_error.find(
+                    "Configured QRSS message duration of 1m 01s exceeds repeat_every interval of 1m 00s.") !=
+                    std::string::npos,
+            "QRSS duration longer than repeat_every must be rejected with a clear error");
+
+        ArgParserConfig fskcw_long =
+            make_fskcw_policy_config("E", 61.0, 1);
+        validation_error.clear();
+        require(
+            !validate_non_wspr_repeat_interval_policy(
+                fskcw_long,
+                &validation_error) &&
+                validation_error.find("Configured FSKCW message duration") !=
+                    std::string::npos,
+            "FSKCW duration longer than repeat_every must be rejected");
+
+        ArgParserConfig dfcw_long =
+            make_dfcw_policy_config("E", 61.0, 1);
+        validation_error.clear();
+        require(
+            !validate_non_wspr_repeat_interval_policy(
+                dfcw_long,
+                &validation_error) &&
+                validation_error.find("Configured DFCW message duration") !=
+                    std::string::npos,
+            "DFCW duration longer than repeat_every must be rejected");
+
+        std::chrono::nanoseconds with_word_gap{};
+        std::chrono::nanoseconds without_word_gap{};
+        validation_error.clear();
+        require(
+            compute_non_wspr_message_duration(
+                make_qrss_policy_config("E E", 1.0, 10),
+                with_word_gap,
+                &validation_error) &&
+                compute_non_wspr_message_duration(
+                    make_qrss_policy_config("EE", 1.0, 10),
+                    without_word_gap,
+                    &validation_error) &&
+                with_word_gap > without_word_gap,
+            "QRSS duration helper must include inter-word spacing");
+
+        std::chrono::nanoseconds dash_heavy{};
+        std::chrono::nanoseconds dit_heavy{};
+        require(
+            compute_non_wspr_message_duration(
+                make_qrss_policy_config("TTT", 1.0, 10),
+                dash_heavy,
+                &validation_error) &&
+                compute_non_wspr_message_duration(
+                    make_qrss_policy_config("EEE", 1.0, 10),
+                    dit_heavy,
+                    &validation_error) &&
+                dash_heavy > dit_heavy,
+            "QRSS duration helper must include dash timing");
+
+        validation_error.clear();
+        require(
+            validate_non_wspr_repeat_interval_policy(
+                make_qrss_policy_config("SOS", 2.0, 1),
+                &validation_error) &&
+                !validate_non_wspr_repeat_interval_policy(
+                    make_qrss_policy_config("SOS", 5.0, 1),
+                    &validation_error),
+            "different unit lengths must change whether the same QRSS message passes the repeat_every policy");
+    }
+
+    {
+        clear_qrss_startup_request();
+        reset_scheduler_test_state();
+
+        const ArgParserConfig candidate = make_qrss_policy_config("E", 61.0, 1);
+        copy_runtime_config(candidate, config);
+
+        require(
+            !set_config(true),
+            "scheduler must reject an overlong QRSS configuration before committing execution");
+        require(
+            current_transmission_request_for_test().actual_rf_frequency_hz == 0.0 &&
+                current_transmission_request_for_test().payload.frames.empty(),
+            "scheduler rejection must leave the committed execution request untouched");
+
+        finish_scheduler_test_state();
+    }
+
+    {
+        const ArgParserConfig candidate = make_qrss_policy_config("E", 61.0, 1);
+        copy_runtime_config(candidate, config);
+
+        std::string validation_error;
+        require(
+            !validate_config_data_for_test(&validation_error) &&
+                validation_error.find("Configured QRSS message duration") !=
+                    std::string::npos,
+            "CLI validation must surface the repeat_every policy error");
+    }
+
+    {
+        clear_qrss_startup_request();
+        clear_fskcw_startup_request();
+        clear_dfcw_startup_request();
+        prime_valid_runtime_identity_config();
+        const ModeType original_mode = config.mode;
+        bool threw_patch_error = false;
+
+        try
+        {
+            patch_all_from_web({
+                {"Operation",
+                 {{"Mode", "QRSS"},
+                  {"Transmit", true}}},
+                {"CW",
+                 {{"Message", "E"},
+                  {"Base Frequency", 10140100.0},
+                  {"Dot Seconds", 61.0},
+                  {"Repeat Minutes", 1}}}});
+        }
+        catch (const std::exception &e)
+        {
+            threw_patch_error = true;
+            require(
+                std::string(e.what()).find("Configured QRSS message duration") !=
+                    std::string::npos,
+                "web patch validation must expose the repeat_every policy error");
+        }
+
+        require(
+            threw_patch_error,
+            "web patch validation must reject an overlong QRSS configuration");
+        require(
+            config.mode == original_mode,
+            "web patch rejection must not mutate the live mode");
+    }
+
+    std::cout << "Non-WSPR repeat policy regression tests passed." << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Add scheduler-owned validation to reject QRSS, FSKCW, and DFCW
configurations whose compiled message duration exceeds repeat_every.

## What changed

- Added scheduler-side duration and repeat interval validation for
  QRSS, FSKCW, and DFCW
- Reused ExecutionPlanCompiler so policy matches actual execution timing
- Enforced validation in candidate/config validation and again before
  non-WSPR execution can be committed
- Added a focused non-WSPR repeat policy regression test binary

## Verification

Ran:

make -C src non-wspr-repeat-policy-test

Result:

Non-WSPR repeat policy regression tests passed.