### PR TITLE
Deterministic LPF Selector GPIO Lifecycle Management

### DIFF
--- a/config/wsprrypi.ini
+++ b/config/wsprrypi.ini
@@ -2,7 +2,7 @@
 ; Copyright (C) 2023 - 2026 Lee C. Bussy (@LBussy)
 
 [Meta]
-debug_logging = false
+debug_logging = False
 
 [Operation]
 ; Mode:
@@ -211,46 +211,46 @@ Repeat Minutes = 10
 ; The same GPIO may be assigned to multiple bands.
 ; "<band> Active High" controls polarity (default = false).
 
-2200m = 17
+2200m = 
 2200m Active High = false
 
-630m = 27
+630m = 
 630m Active High = false
 
-160m = 22
+160m = 
 160m Active High = false
 
-80m = 23
+80m = 
 80m Active High = false
 
-60m = 24
+60m = 
 60m Active High = false
 
-40m = 25
+40m = 
 40m Active High = false
 
-30m = 5
+30m = 
 30m Active High = false
 
-22m = 6
+22m = 
 22m Active High = false
 
-20m = 12
+20m = 
 20m Active High = false
 
-17m = 13
+17m = 
 17m Active High = false
 
-15m = 16
+15m = 
 15m Active High = false
 
-12m = 26
+12m = 
 12m Active High = false
 
-10m = 20
+10m = 
 10m Active High = false
 
-6m = 21
+6m = 
 6m Active High = false
 
 4m =

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -95,6 +95,7 @@ static BandGPIOSelector bandGPIOSelector;
 
 struct BandGPIOResolution
 {
+    HamBand band = HamBand::BAND_2200M;
     BandGPIOConfig config{};
     bool selector_enabled = false;
     bool from_band_config = false;
@@ -129,7 +130,11 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
     double source_frequency_hz,
     const WsprFrequencyEntry &entry,
     const ArgParserConfig &cfg,
-    int frequency_entry_index = -1);
+    int frequency_entry_index = -1,
+    BandGPIOResolution *resolution_out = nullptr);
+static BandGPIOPrepareStatus apply_band_gpio_resolution(
+    const BandGPIOResolution &resolution) noexcept;
+static bool refresh_committed_band_gpio_selection() noexcept;
 
 /**
  * @brief Mutex to protect access to the shutdown flag for the WSPR loop.
@@ -276,6 +281,53 @@ static void stop_active_transmission_selectors() noexcept
     active_band_gpio_prepare_status.store(
         BandGPIOPrepareStatus::Inactive,
         std::memory_order_release);
+}
+
+static BandGPIOPrepareStatus apply_band_gpio_resolution(
+    const BandGPIOResolution &resolution) noexcept
+{
+    if (!resolution.selector_enabled)
+    {
+        stop_active_transmission_selectors();
+        return BandGPIOPrepareStatus::Inactive;
+    }
+
+    if (!bandGPIOSelector.prepareBand(resolution.band, resolution.config))
+    {
+        llog.logS(
+            WARN,
+            "Unable to prepare unified scheduler band GPIO for band ",
+            ham_band_to_string(resolution.band),
+            ", GPIO ",
+            resolution.config.gpio,
+            ".");
+        active_band_gpio_prepare_status.store(
+            BandGPIOPrepareStatus::Failed,
+            std::memory_order_release);
+        return BandGPIOPrepareStatus::Failed;
+    }
+
+    active_band_gpio_prepare_status.store(
+        BandGPIOPrepareStatus::Prepared,
+        std::memory_order_release);
+    return BandGPIOPrepareStatus::Prepared;
+}
+
+static bool refresh_committed_band_gpio_selection() noexcept
+{
+    if (!current_transmission_request.hasSelectorGPIO())
+    {
+        active_band_gpio_prepare_status.store(
+            BandGPIOPrepareStatus::Inactive,
+            std::memory_order_release);
+        return true;
+    }
+    return apply_band_gpio_resolution(BandGPIOResolution{
+               current_transmission_request.selector_band,
+               current_transmission_request.selector_gpio_config,
+               true,
+               false,
+               "committed request"}) == BandGPIOPrepareStatus::Prepared;
 }
 
 static void set_tx_led_state(bool state, const char *context) noexcept
@@ -748,8 +800,14 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
     double source_frequency_hz,
     const WsprFrequencyEntry &entry,
     const ArgParserConfig &cfg,
-    int frequency_entry_index)
+    int frequency_entry_index,
+    BandGPIOResolution *resolution_out)
 {
+    if (resolution_out != nullptr)
+    {
+        *resolution_out = BandGPIOResolution{};
+    }
+
     const auto band = lookup.lookup_ham_band(source_frequency_hz);
     if (!band.has_value())
     {
@@ -765,6 +823,7 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
     }
 
     BandGPIOResolution resolution;
+    resolution.band = *band;
     resolution.selector_source = "frequency entry";
     if (entry.selector_gpio != kSelectorGpioUnset)
     {
@@ -782,6 +841,10 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
             resolution.config.enabled && resolution.config.gpio >= 0;
         if (!resolution.selector_enabled)
         {
+            if (resolution_out != nullptr)
+            {
+                *resolution_out = resolution;
+            }
             stop_active_transmission_selectors();
             llog.logS(
                 DEBUG,
@@ -806,6 +869,10 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
     }
     else
     {
+        if (resolution_out != nullptr)
+        {
+            *resolution_out = resolution;
+        }
         stop_active_transmission_selectors();
         llog.logS(
             DEBUG,
@@ -850,23 +917,11 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
         "; committed request token ",
         entry.token,
         ".");
-    if (!bandGPIOSelector.prepareBand(*band, resolution.config))
+    if (resolution_out != nullptr)
     {
-        llog.logS(
-            WARN,
-            "Unable to prepare unified scheduler band GPIO for ",
-            wsprTransmitter.formatFrequencyMHz(source_frequency_hz),
-            " MHz.");
-        active_band_gpio_prepare_status.store(
-            BandGPIOPrepareStatus::Failed,
-            std::memory_order_release);
-        return BandGPIOPrepareStatus::Failed;
+        *resolution_out = resolution;
     }
-
-    active_band_gpio_prepare_status.store(
-        BandGPIOPrepareStatus::Prepared,
-        std::memory_order_release);
-    return BandGPIOPrepareStatus::Prepared;
+    return apply_band_gpio_resolution(resolution);
 }
 
 static double maybe_apply_wspr_random_offset(
@@ -1426,6 +1481,31 @@ static TransmissionRequest make_wspr_request(
     return request;
 }
 
+static void commit_band_gpio_snapshot_to_request(
+    TransmissionRequest &request,
+    const BandGPIOResolution &resolution,
+    BandGPIOPrepareStatus prepare_status) noexcept
+{
+    request.selector_gpio_enabled = false;
+    request.selector_band = HamBand::BAND_2200M;
+    request.selector_gpio_config = BandGPIOConfig{};
+
+    if (prepare_status != BandGPIOPrepareStatus::Prepared)
+    {
+        return;
+    }
+
+    if (!resolution.selector_enabled)
+    {
+        return;
+    }
+
+    request.selector_gpio_enabled =
+        resolution.config.enabled && resolution.config.gpio >= 0;
+    request.selector_band = resolution.band;
+    request.selector_gpio_config = resolution.config;
+}
+
 static std::string format_elapsed(double elapsed)
 {
     if (elapsed == 0.0)
@@ -1695,9 +1775,14 @@ void transmitter_cb(WsprTransmitter::TransmissionCallbackEvent event,
             consume_tx_iteration_if_needed();
         }
 
-        // Assert the scheduler-selected band GPIO when one was prepared.
-        if (active_band_gpio_prepare_status.load(std::memory_order_acquire) ==
-                BandGPIOPrepareStatus::Prepared &&
+        if (!refresh_committed_band_gpio_selection())
+        {
+            llog.logS(DEBUG,
+                      "Band GPIO refresh from committed request did not complete.");
+        }
+
+        // Assert the scheduler-selected band GPIO when one was committed.
+        if (current_transmission_request.hasSelectorGPIO() &&
             !bandGPIOSelector.setBandState(true))
         {
             llog.logS(DEBUG,
@@ -2177,10 +2262,18 @@ void start_test_tone()
         const double committed_ppm = config.ppm;
         TransmissionRequest request =
             make_tone_request(config, committed_ppm, actual_rf_freq, dial_freq, entry);
-        (void)prepare_band_gpio_for_frequency_or_log(
-            dial_freq,
-            entry,
-            config);
+        BandGPIOResolution selector_resolution;
+        const BandGPIOPrepareStatus selector_status =
+            prepare_band_gpio_for_frequency_or_log(
+                dial_freq,
+                entry,
+                config,
+                -1,
+                &selector_resolution);
+        commit_band_gpio_snapshot_to_request(
+            request,
+            selector_resolution,
+            selector_status);
         commit_execution_request(request);
 
         wsprTransmitter.startAsync();
@@ -2251,10 +2344,18 @@ void end_test_tone()
                     config,
                     committed_ppm,
                     actual_rf_frequency_hz);
-            (void)prepare_band_gpio_for_frequency_or_log(
-                entry.dial_frequency_hz,
-                entry,
-                config);
+            BandGPIOResolution selector_resolution;
+            const BandGPIOPrepareStatus selector_status =
+                prepare_band_gpio_for_frequency_or_log(
+                    entry.dial_frequency_hz,
+                    entry,
+                    config,
+                    -1,
+                    &selector_resolution);
+            commit_band_gpio_snapshot_to_request(
+                request,
+                selector_resolution,
+                selector_status);
             commit_execution_request(request);
             wsprTransmitter.startAsync();
 
@@ -3295,11 +3396,15 @@ bool set_config(bool force)
 
             next_transmission_request.applied_offset_hz = applied_offset_hz;
 
-            if (prepare_band_gpio_for_frequency_or_log(
+            BandGPIOResolution selector_resolution;
+            const BandGPIOPrepareStatus selector_status =
+                prepare_band_gpio_for_frequency_or_log(
                     next_current_dial_frequency,
                     next_current_frequency_entry,
                     working_config,
-                    next_frequency_entry_index) == BandGPIOPrepareStatus::Failed)
+                    next_frequency_entry_index,
+                    &selector_resolution);
+            if (selector_status == BandGPIOPrepareStatus::Failed)
             {
                 stop_active_transmission_selectors();
 
@@ -3329,6 +3434,11 @@ bool set_config(bool force)
                 config_to_json();
                 return false;
             }
+
+            commit_band_gpio_snapshot_to_request(
+                next_transmission_request,
+                selector_resolution,
+                selector_status);
 
             if (newer_reload_arrived())
             {
@@ -3464,6 +3574,26 @@ bool current_band_gpio_selection_for_test(
     config_out = *current_config;
     band_label_out = ham_band_to_string(*current_band);
     return true;
+}
+
+void stop_active_transmission_selectors_for_test() noexcept
+{
+    stop_active_transmission_selectors();
+}
+
+bool restore_committed_band_gpio_selection_for_test(bool assert_state) noexcept
+{
+    if (!refresh_committed_band_gpio_selection())
+    {
+        return false;
+    }
+
+    if (!assert_state || !current_transmission_request.hasSelectorGPIO())
+    {
+        return true;
+    }
+
+    return bandGPIOSelector.setBandState(true);
 }
 
 TransmissionRequest current_transmission_request_for_test()

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -74,6 +74,7 @@
 #include <random>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 #include <mutex>
 
@@ -91,8 +92,6 @@
  * correct GPIO when transmission begins and to release it when the
  * transmission completes, is skipped, or is cancelled.
  */
-static BandGPIOSelector bandGPIOSelector;
-
 struct BandGPIOResolution
 {
     HamBand band = HamBand::BAND_2200M;
@@ -101,6 +100,17 @@ struct BandGPIOResolution
     bool from_band_config = false;
     const char *selector_source = "none";
 };
+
+struct SelectorGPIOReservation
+{
+    BandGPIOConfig config{};
+    std::unique_ptr<GPIOOutput> gpio;
+};
+
+static BandGPIOSelector bandGPIOSelector;
+static std::vector<SelectorGPIOReservation> idleSelectorGPIOs;
+static bool selectorGPIOControlEnabled = false;
+static bool selectorGPIODriveEnabled = false;
 
 enum class BandGPIOPrepareStatus
 {
@@ -132,6 +142,10 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
     const ArgParserConfig &cfg,
     int frequency_entry_index = -1,
     BandGPIOResolution *resolution_out = nullptr);
+static bool sync_configured_selector_gpio_idle_state(
+    const ArgParserConfig &cfg,
+    bool keep_initialized,
+    std::string *error_message = nullptr);
 static BandGPIOPrepareStatus apply_band_gpio_resolution(
     const BandGPIOResolution &resolution) noexcept;
 static bool refresh_committed_band_gpio_selection() noexcept;
@@ -283,6 +297,181 @@ static void stop_active_transmission_selectors() noexcept
         std::memory_order_release);
 }
 
+static void release_idle_selector_gpio_reservations() noexcept
+{
+    for (SelectorGPIOReservation &reservation : idleSelectorGPIOs)
+    {
+        if (reservation.gpio != nullptr)
+        {
+            reservation.gpio->stop();
+        }
+    }
+    idleSelectorGPIOs.clear();
+}
+
+static void release_idle_selector_gpio_reservation(int gpio) noexcept
+{
+    idleSelectorGPIOs.erase(
+        std::remove_if(
+            idleSelectorGPIOs.begin(),
+            idleSelectorGPIOs.end(),
+            [gpio](SelectorGPIOReservation &reservation)
+            {
+                if (reservation.config.gpio != gpio)
+                {
+                    return false;
+                }
+
+                if (reservation.gpio != nullptr)
+                {
+                    reservation.gpio->stop();
+                }
+                return true;
+            }),
+        idleSelectorGPIOs.end());
+}
+
+static bool collect_configured_selector_gpios(
+    const ArgParserConfig &cfg,
+    std::vector<BandGPIOConfig> &configs_out,
+    std::string *error_message = nullptr)
+{
+    configs_out.clear();
+
+    std::unordered_map<int, bool> polarity_by_gpio;
+    auto add_configured_gpio =
+        [&](int gpio, bool active_high, const std::string &source) -> bool
+    {
+        if (gpio < 0)
+        {
+            return true;
+        }
+
+        const auto existing = polarity_by_gpio.find(gpio);
+        if (existing != polarity_by_gpio.end())
+        {
+            if (existing->second != active_high)
+            {
+                if (error_message != nullptr)
+                {
+                    *error_message =
+                        "Selector GPIO " + std::to_string(gpio) +
+                        " has conflicting active polarity definitions in " +
+                        source + ".";
+                }
+                return false;
+            }
+            return true;
+        }
+
+        polarity_by_gpio.emplace(gpio, active_high);
+        configs_out.push_back(BandGPIOConfig{gpio, true, active_high});
+        return true;
+    };
+
+    for (const BandGPIOConfig &band_config : cfg.band_gpio)
+    {
+        if (band_config.enabled && band_config.gpio >= 0 &&
+            !add_configured_gpio(band_config.gpio,
+                                 band_config.active_high,
+                                 "[Band GPIO]"))
+        {
+            return false;
+        }
+    }
+
+    for (const WsprFrequencyEntry &entry : cfg.wspr_frequency_entries)
+    {
+        if (entry.selector_gpio != kSelectorGpioUnset &&
+            !add_configured_gpio(entry.selector_gpio,
+                                 entry.selector_gpio_active_high,
+                                 "frequency entries"))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool has_configured_selector_gpios(const ArgParserConfig &cfg) noexcept
+{
+    std::vector<BandGPIOConfig> configured_gpios;
+    std::string error_message;
+    return collect_configured_selector_gpios(
+               cfg,
+               configured_gpios,
+               &error_message) &&
+           !configured_gpios.empty();
+}
+
+static bool sync_configured_selector_gpio_idle_state(
+    const ArgParserConfig &cfg,
+    bool keep_initialized,
+    std::string *error_message)
+{
+    stop_active_transmission_selectors();
+    release_idle_selector_gpio_reservations();
+
+    if (!selectorGPIOControlEnabled || !keep_initialized)
+    {
+        return true;
+    }
+
+    std::vector<BandGPIOConfig> configured_gpios;
+    if (!collect_configured_selector_gpios(cfg, configured_gpios, error_message))
+    {
+        return false;
+    }
+
+    for (const BandGPIOConfig &configured_gpio : configured_gpios)
+    {
+        SelectorGPIOReservation reservation;
+        reservation.config = configured_gpio;
+
+        if (!selectorGPIODriveEnabled)
+        {
+            idleSelectorGPIOs.push_back(std::move(reservation));
+            continue;
+        }
+
+        reservation.gpio = std::make_unique<GPIOOutput>();
+        if (!reservation.gpio->enableGPIOPin(
+                configured_gpio.gpio,
+                configured_gpio.active_high))
+        {
+            if (error_message != nullptr)
+            {
+                *error_message =
+                    "Failed to initialize selector GPIO " +
+                    std::to_string(configured_gpio.gpio) + ": " +
+                    reservation.gpio->lastError();
+            }
+            release_idle_selector_gpio_reservations();
+            return false;
+        }
+
+        // False drives the configured output to its inactive level:
+        // LOW for active-high and HIGH for active-low.
+        if (!reservation.gpio->toggleGPIO(false))
+        {
+            if (error_message != nullptr)
+            {
+                *error_message =
+                    "Failed to drive selector GPIO " +
+                    std::to_string(configured_gpio.gpio) +
+                    " to its inactive level.";
+            }
+            release_idle_selector_gpio_reservations();
+            return false;
+        }
+
+        idleSelectorGPIOs.push_back(std::move(reservation));
+    }
+
+    return true;
+}
+
 static BandGPIOPrepareStatus apply_band_gpio_resolution(
     const BandGPIOResolution &resolution) noexcept
 {
@@ -291,6 +480,8 @@ static BandGPIOPrepareStatus apply_band_gpio_resolution(
         stop_active_transmission_selectors();
         return BandGPIOPrepareStatus::Inactive;
     }
+
+    release_idle_selector_gpio_reservation(resolution.config.gpio);
 
     if (!bandGPIOSelector.prepareBand(resolution.band, resolution.config))
     {
@@ -2398,6 +2589,7 @@ StopTransmissionResult stop_transmission_by_user_request()
 
     wsprTransmitter.stopAndJoin();
     stop_active_transmission_selectors();
+    release_idle_selector_gpio_reservations();
     set_tx_led_state(false, "scheduler shutdown");
 
     {
@@ -2464,6 +2656,7 @@ static void stop_runtime_components_for_process_exit() noexcept
     ppmManager.stop();
     wsprTransmitter.shutdownForProcessExit();
     stop_active_transmission_selectors();
+    release_idle_selector_gpio_reservations();
     ledControl.stop();
 }
 
@@ -2480,18 +2673,12 @@ static void stop_runtime_components_for_process_exit() noexcept
  */
 bool wspr_loop()
 {
-    bool any_band_gpio_enabled = false;
-    for (int i = 0; i < HAM_BAND_COUNT; ++i)
-    {
-        if (config.band_gpio[i].enabled && config.band_gpio[i].gpio >= 0)
-        {
-            any_band_gpio_enabled = true;
-            break;
-        }
-    }
-
-    bandGPIOSelector.setEnabled(any_band_gpio_enabled);
-    bandGPIOSelector.setDriveGPIO(any_band_gpio_enabled);
+    const bool any_selector_gpio_configured =
+        has_configured_selector_gpios(config);
+    selectorGPIOControlEnabled = any_selector_gpio_configured;
+    selectorGPIODriveEnabled = any_selector_gpio_configured;
+    bandGPIOSelector.setEnabled(selectorGPIOControlEnabled);
+    bandGPIOSelector.setDriveGPIO(selectorGPIODriveEnabled);
 
     // Display the final configuration after parsing arguments and INI file.
     show_config_values();
@@ -3243,6 +3430,45 @@ bool set_config(bool force)
         {
             log_scheduler_path_selection(working_config.mode);
 
+            if (!suppress_scheduler_execution_for_test)
+            {
+                selectorGPIOControlEnabled =
+                    has_configured_selector_gpios(working_config);
+                selectorGPIODriveEnabled = selectorGPIOControlEnabled;
+                bandGPIOSelector.setEnabled(selectorGPIOControlEnabled);
+                bandGPIOSelector.setDriveGPIO(selectorGPIODriveEnabled);
+            }
+
+            std::string selector_idle_error;
+            if (!sync_configured_selector_gpio_idle_state(
+                    working_config,
+                    runtime_transmit_enabled(working_config),
+                    &selector_idle_error))
+            {
+                llog.logS(ERROR, "Failed to synchronize selector GPIO idle state: ",
+                          selector_idle_error);
+                if (is_managed_persistent_mode())
+                {
+                    set_managed_reload_tx_inhibited(
+                        true,
+                        "Managed reload could not initialize selector GPIO idle state; previous valid configuration remains loaded. Transmit is blocked until a valid configuration is loaded.");
+                    send_ws_message(
+                        "configuration",
+                        "reload_failed",
+                        "Managed reload could not initialize selector GPIO idle state; previous valid configuration remains loaded. Transmit is blocked until a valid configuration is loaded.");
+                    if (!finalize_reload_pending())
+                    {
+                        continue;
+                    }
+                    return true;
+                }
+
+                ini_reload_pending.store(false, std::memory_order_relaxed);
+                config.transmit = false;
+                config_to_json();
+                return false;
+            }
+
             if (working_config.mode == ModeType::WSPR && do_config)
             {
                 non_wspr_schedule_generation.fetch_add(1, std::memory_order_acq_rel);
@@ -3554,8 +3780,18 @@ void set_scheduler_execution_suppressed_for_test(bool suppressed) noexcept
 
 void set_band_gpio_selector_for_test(bool enabled, bool drive_gpio) noexcept
 {
+    selectorGPIOControlEnabled = enabled;
+    selectorGPIODriveEnabled = drive_gpio;
+    if (!enabled)
+    {
+        stop_active_transmission_selectors();
+    }
     bandGPIOSelector.setEnabled(enabled);
     bandGPIOSelector.setDriveGPIO(drive_gpio);
+    if (!enabled)
+    {
+        release_idle_selector_gpio_reservations();
+    }
 }
 
 bool current_band_gpio_selection_for_test(
@@ -3574,6 +3810,17 @@ bool current_band_gpio_selection_for_test(
     config_out = *current_config;
     band_label_out = ham_band_to_string(*current_band);
     return true;
+}
+
+std::vector<BandGPIOConfig> initialized_selector_gpios_for_test()
+{
+    std::vector<BandGPIOConfig> configs;
+    configs.reserve(idleSelectorGPIOs.size());
+    for (const SelectorGPIOReservation &reservation : idleSelectorGPIOs)
+    {
+        configs.push_back(reservation.config);
+    }
+    return configs;
 }
 
 void stop_active_transmission_selectors_for_test() noexcept

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -318,6 +318,8 @@ void set_band_gpio_selector_for_test(bool enabled, bool drive_gpio) noexcept;
 bool current_band_gpio_selection_for_test(
     BandGPIOConfig &config_out,
     std::string &band_label_out) noexcept;
+void stop_active_transmission_selectors_for_test() noexcept;
+bool restore_committed_band_gpio_selection_for_test(bool assert_state) noexcept;
 TransmissionRequest current_transmission_request_for_test();
 void reset_current_transmission_request_for_test() noexcept;
 

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -52,6 +52,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 /**
  * @brief Mutex to protect access to the shutdown flag for the WSPR loop.
@@ -318,6 +319,7 @@ void set_band_gpio_selector_for_test(bool enabled, bool drive_gpio) noexcept;
 bool current_band_gpio_selection_for_test(
     BandGPIOConfig &config_out,
     std::string &band_label_out) noexcept;
+std::vector<BandGPIOConfig> initialized_selector_gpios_for_test();
 void stop_active_transmission_selectors_for_test() noexcept;
 bool restore_committed_band_gpio_selection_for_test(bool assert_state) noexcept;
 TransmissionRequest current_transmission_request_for_test();

--- a/src/tests/band_gpio_rotation_test.cpp
+++ b/src/tests/band_gpio_rotation_test.cpp
@@ -76,6 +76,18 @@ namespace
             request.frequency_entry_label == expected_token,
             message + ": committed request token must match the selected entry");
         require(
+            request.hasSelectorGPIO(),
+            message + ": committed request must carry selector GPIO snapshot");
+        require(
+            std::string(band_to_string(request.selector_band)) == expected_band,
+            message + ": committed request selector band must match the selected entry");
+        require(
+            request.selector_gpio_config.gpio == expected_gpio,
+            message + ": committed request selector GPIO must match the selected band");
+        require(
+            request.selector_gpio_config.active_high == expected_active_high,
+            message + ": committed request selector polarity must match the selected band");
+        require(
             current_band_gpio_selection_for_test(selector_config, selector_band),
             message + ": scheduler must prepare a band GPIO selector");
         require(
@@ -90,6 +102,37 @@ namespace
         require(
             selector_config.active_high == expected_active_high,
             message + ": selector polarity must match the selected band");
+    }
+
+    void require_selector_rehydrates_from_committed_request(
+        const std::string &expected_band,
+        int expected_gpio,
+        bool expected_active_high,
+        const std::string &message)
+    {
+        BandGPIOConfig selector_config;
+        std::string selector_band;
+
+        stop_active_transmission_selectors_for_test();
+        require(
+            !current_band_gpio_selection_for_test(selector_config, selector_band),
+            message + ": selector teardown precondition must clear live selector state");
+
+        require(
+            restore_committed_band_gpio_selection_for_test(true),
+            message + ": committed request snapshot must restore selector state");
+        require(
+            current_band_gpio_selection_for_test(selector_config, selector_band),
+            message + ": execution restore must recover selector from committed request snapshot");
+        require(
+            selector_band == expected_band,
+            message + ": restored selector band must match committed request");
+        require(
+            selector_config.gpio == expected_gpio,
+            message + ": restored selector GPIO must match committed request");
+        require(
+            selector_config.active_high == expected_active_high,
+            message + ": restored selector polarity must match committed request");
     }
 }
 
@@ -129,10 +172,20 @@ int main()
         17,
         true,
         "first UI rotation entry");
+    require_selector_rehydrates_from_committed_request(
+        "80m",
+        17,
+        true,
+        "first UI rotation entry");
 
     require(set_config(false), "scheduler must commit second UI band GPIO entry");
     require_current_selector(
         "40m",
+        "40m",
+        27,
+        false,
+        "second UI rotation entry");
+    require_selector_rehydrates_from_committed_request(
         "40m",
         27,
         false,
@@ -145,6 +198,11 @@ int main()
         22,
         true,
         "third UI rotation entry");
+    require_selector_rehydrates_from_committed_request(
+        "30m",
+        22,
+        true,
+        "third UI rotation entry");
 
     require(set_config(false), "scheduler must wrap back to first UI band GPIO entry");
     require_current_selector(
@@ -153,6 +211,84 @@ int main()
         17,
         true,
         "wrapped UI rotation entry");
+    require_selector_rehydrates_from_committed_request(
+        "80m",
+        17,
+        true,
+        "wrapped UI rotation entry");
+
+    patch_all_from_web({
+        {"WSPR", {{"Frequency", "30m,20m"}}},
+        {"Band GPIO",
+         {{"30m", {{"GPIO", 5}, {"Enabled", true}, {"Active High", false}}},
+          {"20m", {{"GPIO", 12}, {"Enabled", true}, {"Active High", true}}}}}});
+
+    require(set_config(true), "scheduler must commit first reloaded UI band GPIO entry");
+    require_current_selector(
+        "30m",
+        "30m",
+        5,
+        false,
+        "first reloaded UI rotation entry");
+    require_selector_rehydrates_from_committed_request(
+        "30m",
+        5,
+        false,
+        "first reloaded UI rotation entry");
+
+    require(set_config(false), "scheduler must commit second reloaded UI band GPIO entry");
+    require_current_selector(
+        "20m",
+        "20m",
+        12,
+        true,
+        "second reloaded UI rotation entry");
+    require_selector_rehydrates_from_committed_request(
+        "20m",
+        12,
+        true,
+        "second reloaded UI rotation entry");
+
+    patch_all_from_web({{"WSPR", {{"Frequency", "20m@16H,30m@20H,40m@21H"}}}});
+
+    require(set_config(true), "scheduler must commit first explicit selector entry");
+    require_current_selector(
+        "20m",
+        "20m",
+        16,
+        true,
+        "first explicit selector rotation entry");
+    require_selector_rehydrates_from_committed_request(
+        "20m",
+        16,
+        true,
+        "first explicit selector rotation entry");
+
+    require(set_config(false), "scheduler must commit second explicit selector entry");
+    require_current_selector(
+        "30m",
+        "30m",
+        20,
+        true,
+        "second explicit selector rotation entry");
+    require_selector_rehydrates_from_committed_request(
+        "30m",
+        20,
+        true,
+        "second explicit selector rotation entry");
+
+    require(set_config(false), "scheduler must commit third explicit selector entry");
+    require_current_selector(
+        "40m",
+        "40m",
+        21,
+        true,
+        "third explicit selector rotation entry");
+    require_selector_rehydrates_from_committed_request(
+        "40m",
+        21,
+        true,
+        "third explicit selector rotation entry");
 
     finish_scheduler_test_state();
 

--- a/src/tests/band_gpio_rotation_test.cpp
+++ b/src/tests/band_gpio_rotation_test.cpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <iostream>
+#include <set>
 #include <string>
 
 namespace
@@ -134,6 +135,40 @@ namespace
             selector_config.active_high == expected_active_high,
             message + ": restored selector polarity must match committed request");
     }
+
+    void require_initialized_selector_set(
+        const std::set<std::pair<int, bool>> &expected,
+        const std::string &message)
+    {
+        std::set<std::pair<int, bool>> actual;
+        for (const BandGPIOConfig &config_entry : initialized_selector_gpios_for_test())
+        {
+            actual.emplace(config_entry.gpio, config_entry.active_high);
+        }
+
+        BandGPIOConfig active_config;
+        std::string active_band;
+        if (current_band_gpio_selection_for_test(active_config, active_band))
+        {
+            actual.emplace(active_config.gpio, active_config.active_high);
+        }
+
+        require(
+            actual == expected,
+            message + ": initialized selector GPIO set must match expected configured GPIOs");
+    }
+
+    void require_all_selector_gpios_released(const std::string &message)
+    {
+        BandGPIOConfig active_config;
+        std::string active_band;
+        require(
+            initialized_selector_gpios_for_test().empty(),
+            message + ": idle selector GPIO reservations must be empty");
+        require(
+            !current_band_gpio_selection_for_test(active_config, active_band),
+            message + ": no active selector GPIO may remain prepared");
+    }
 }
 
 int main()
@@ -166,6 +201,9 @@ int main()
     reset_scheduler_test_state();
 
     require(set_config(true), "scheduler must commit first UI band GPIO entry");
+    require_initialized_selector_set(
+        {{17, true}, {27, false}, {22, true}},
+        "first UI rotation entry");
     require_current_selector(
         "80m",
         "80m",
@@ -179,6 +217,9 @@ int main()
         "first UI rotation entry");
 
     require(set_config(false), "scheduler must commit second UI band GPIO entry");
+    require_initialized_selector_set(
+        {{17, true}, {27, false}, {22, true}},
+        "second UI rotation entry");
     require_current_selector(
         "40m",
         "40m",
@@ -224,6 +265,9 @@ int main()
           {"20m", {{"GPIO", 12}, {"Enabled", true}, {"Active High", true}}}}}});
 
     require(set_config(true), "scheduler must commit first reloaded UI band GPIO entry");
+    require_initialized_selector_set(
+        {{5, false}, {12, true}},
+        "first reloaded UI rotation entry");
     require_current_selector(
         "30m",
         "30m",
@@ -252,6 +296,9 @@ int main()
     patch_all_from_web({{"WSPR", {{"Frequency", "20m@16H,30m@20H,40m@21H"}}}});
 
     require(set_config(true), "scheduler must commit first explicit selector entry");
+    require_initialized_selector_set(
+        {{16, true}, {20, true}, {21, true}},
+        "first explicit selector rotation entry");
     require_current_selector(
         "20m",
         "20m",
@@ -265,6 +312,9 @@ int main()
         "first explicit selector rotation entry");
 
     require(set_config(false), "scheduler must commit second explicit selector entry");
+    require_initialized_selector_set(
+        {{16, true}, {20, true}, {21, true}},
+        "second explicit selector rotation entry");
     require_current_selector(
         "30m",
         "30m",
@@ -278,6 +328,9 @@ int main()
         "second explicit selector rotation entry");
 
     require(set_config(false), "scheduler must commit third explicit selector entry");
+    require_initialized_selector_set(
+        {{16, true}, {20, true}, {21, true}},
+        "third explicit selector rotation entry");
     require_current_selector(
         "40m",
         "40m",
@@ -289,6 +342,13 @@ int main()
         21,
         true,
         "third explicit selector rotation entry");
+
+    patch_all_from_web({{"Operation", {{"Transmit", false}}}});
+    require(
+        set_config(true),
+        "scheduler must accept disabling transmit while selector GPIOs are configured");
+    require_all_selector_gpios_released(
+        "disabled transmit");
 
     finish_scheduler_test_state();
 


### PR DESCRIPTION
## Summary

This PR implements a scheduler-owned lifecycle for all LPF selector GPIOs to ensure deterministic behavior across:

- System startup
- Configuration load/reload
- Transmission rotation
- Transmit disable and shutdown

Previously, only the *active selector GPIO* was managed, which led to:

- Non-deterministic GPIO states at startup
- Only the first frequency in a rotation asserting correctly
- Stale or partially-applied selector state across transmissions

This PR resolves those issues by separating **configuration lifecycle management** from **per-transmission selector assertion**.

---

## Key Changes

### 1. Scheduler-Owned Selector GPIO Initialization

On config load/reload, the scheduler now:

- Collects all configured selector GPIOs from:
  - Explicit `@GPIO` frequency entries
  - `[Band GPIO]` configuration
- Deduplicates GPIOs
- Rejects conflicting polarity definitions for the same GPIO
- Initializes each GPIO to its **inactive state**:
  - Active-high → driven LOW
  - Active-low → driven HIGH

This ensures deterministic hardware state after OS boot or config reload.

---

### 2. Idle Reservation Pool

Introduced a scheduler-managed idle reservation pool:

- Holds all configured selector GPIOs in their inactive state
- Maintains ownership separate from the active selector path
- Prevents undefined or floating GPIO states

---

### 3. Active Selector Handling (Unchanged Behavior)

During transmission:

- Scheduler resolves the active selector (band/GPIO)
- Selector snapshot is committed into `TransmissionRequest`
- At `STARTING`, selector is rehydrated from the committed snapshot
- Active GPIO is asserted normally

Additionally:

- The active GPIO is temporarily removed from the idle pool before assertion
- Prevents double-driving conflicts

---

### 4. Full Release on Disable / Shutdown

When transmissions are disabled or system shuts down:

- Active selector is released
- All idle selector GPIO reservations are released
- No configured GPIO remains driven or reserved

---

### 5. Explicit `@GPIO` Support

Selector lifecycle now correctly includes:

- Explicit `@GPIO` entries
- `[Band GPIO]` mappings

Previously, only `[Band GPIO]` affected selector enablement.

---

## Root Cause (Previous Bug)

Two issues combined:

1. **Selector state was not fully re-applied per transmission**
   - Only first frequency reliably asserted GPIO

2. **GPIO lifecycle was incomplete**
   - Only active selector was managed
   - Other configured GPIOs remained uninitialized

Result:
- First slot worked
- Subsequent slots failed to assert correct GPIO
- Startup state depended on OS defaults

---

## New Lifecycle Model

### Config Load / Reload
- Initialize all configured selector GPIOs to inactive state

### Transmission Start
- Remove selected GPIO from idle pool
- Prepare selector
- Commit into request
- Rehydrate at `STARTING`
- Assert active GPIO

### Between Transmissions
- Previously active GPIO returns to idle state

### Transmit Disabled / Shutdown
- Release all selector GPIOs
- Clear idle pool

---

## Tests

Extended `band_gpio_rotation_test.cpp` to verify:

- All configured selector GPIOs are initialized on load/reload
- Explicit `@GPIO` and `[Band GPIO]` paths both covered
- Multi-frequency rotation works for all entries
- Reload correctly replaces selector set
- Disabling transmit releases all GPIOs

---

## Build / Runtime Notes

- Build: Successful
- Runtime:
  - Some tests require `/dev/vcio` and cannot run in non-Pi environments
  - Existing unrelated runtime failures remain (e.g., ConfigValidationError)

---

## Files Changed

- `src/scheduling.cpp`
- `src/scheduling.hpp`
- `src/tests/band_gpio_rotation_test.cpp`
- (Previous work retained in `wspr_transmit_types.hpp`)

---

## Why This Belongs in the Scheduler

The scheduler is the only layer that:

- Sees the full configured selector set
- Owns config lifecycle
- Controls reload behavior

Backend remains responsible only for execution, not policy.

---

## Result

- Deterministic GPIO state at startup
- Correct selector switching across all transmission slots
- Clean release of all GPIO resources when disabled
- Unified handling of all selector configuration sources
