### PR TITLE
Preserve deterministic selector GPIO lifecycle across merge resolution

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -117,6 +117,7 @@ GPIO_LOOPBACK_TEST_OUT := gpio_loopback_test
 BAND_GPIO_LIVE_MONITOR_OUT := band_gpio_live_monitor
 GPIO_LINE_RESOLVER_TEST_OUT := gpio_line_resolver_test
 NON_WSPR_REPEAT_POLICY_TEST_OUT := non_wspr_repeat_policy_test
+SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT := selector_shutdown_cleanup_test
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Output directories
@@ -166,6 +167,9 @@ GPIO_LINE_RESOLVER_TEST_DEPS := \
 NON_WSPR_REPEAT_POLICY_TEST_SRC := tests/non_wspr_repeat_policy_test.cpp
 NON_WSPR_REPEAT_POLICY_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/non_wspr_repeat_policy_test.o
 NON_WSPR_REPEAT_POLICY_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
+SELECTOR_SHUTDOWN_CLEANUP_TEST_SRC := tests/selector_shutdown_cleanup_test.cpp
+SELECTOR_SHUTDOWN_CLEANUP_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/selector_shutdown_cleanup_test.o
+SELECTOR_SHUTDOWN_CLEANUP_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Dependency includes
@@ -403,6 +407,17 @@ $(BIN_DIR)/$(NON_WSPR_REPEAT_POLICY_TEST_OUT): $(NON_WSPR_REPEAT_POLICY_TEST_OBJ
 	$(Q)echo "Linking debug: $(NON_WSPR_REPEAT_POLICY_TEST_OUT)"
 	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
 
+$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OBJ): $(SELECTOR_SHUTDOWN_CLEANUP_TEST_SRC)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)mkdir -p $(DEP_DIR)/tests
+	$(Q)echo "Compiling (debug) $< into $@"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) -MF $(DEP_DIR)/tests/selector_shutdown_cleanup_test.d -c $< -o $@
+
+$(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT): $(SELECTOR_SHUTDOWN_CLEANUP_TEST_OBJ) $(SELECTOR_SHUTDOWN_CLEANUP_TEST_DEPS)
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)echo "Linking debug: $(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
+
 ifeq ($(GPIOD_HAS_V2),1)
 $(GPIO_LOOPBACK_TEST_OBJ): $(GPIO_LOOPBACK_TEST_SRC)
 	$(Q)mkdir -p $(dir $@)
@@ -456,7 +471,7 @@ $(BIN_DIR)/$(OUT): $(CPP_OBJECTS)
 # Phony targets
 # ─────────────────────────────────────────────────────────────────────────────
 
-.PHONY: clean release debug test test-tone test-oneshot semantics-test band-gpio-rotation-test monitor-file-regression-test gpio-line-resolver-test non-wspr-repeat-policy-test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
+.PHONY: clean release debug test test-tone test-oneshot semantics-test band-gpio-rotation-test selector-shutdown-cleanup-test monitor-file-regression-test gpio-line-resolver-test non-wspr-repeat-policy-test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
 DEBUG: debug
 RELEASE: release
 
@@ -490,6 +505,10 @@ semantics-test: $(BIN_DIR)/$(SEMANTICS_TEST_OUT)
 band-gpio-rotation-test: $(BIN_DIR)/$(BAND_GPIO_ROTATION_TEST_OUT)
 	$(Q)echo "Running band GPIO rotation regression tests."
 	$(Q)./$(BIN_DIR)/$(BAND_GPIO_ROTATION_TEST_OUT)
+
+selector-shutdown-cleanup-test: $(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)
+	$(Q)echo "Running selector shutdown cleanup regression tests."
+	$(Q)./$(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)
 
 monitor-file-regression-test: $(BIN_DIR)/$(MONITOR_FILE_REGRESSION_TEST_OUT)
 	$(Q)echo "Running MonitorFile regression tests."

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -71,6 +71,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <random>
 #include <string>
 #include <thread>
@@ -108,9 +109,6 @@ struct SelectorGPIOReservation
 };
 
 static BandGPIOSelector bandGPIOSelector;
-static std::vector<SelectorGPIOReservation> idleSelectorGPIOs;
-static bool selectorGPIOControlEnabled = false;
-static bool selectorGPIODriveEnabled = false;
 
 enum class BandGPIOPrepareStatus
 {
@@ -260,6 +258,10 @@ static bool suppress_scheduler_execution_for_test = false;
 static std::atomic<std::uint64_t> non_wspr_schedule_generation{0};
 static std::atomic<BandGPIOPrepareStatus> active_band_gpio_prepare_status{
     BandGPIOPrepareStatus::Inactive};
+static std::vector<SelectorGPIOReservation> idle_selector_gpio_reservations{};
+static bool selector_gpio_control_enabled = false;
+static bool selector_gpio_drive_enabled = false;
+static std::vector<BandGPIOConfig> last_selector_shutdown_cleanup_targets{};
 /**
  * @brief Scheduler-owned paired WSPR plan being continued across slots.
  *
@@ -299,36 +301,134 @@ static void stop_active_transmission_selectors() noexcept
 
 static void release_idle_selector_gpio_reservations() noexcept
 {
-    for (SelectorGPIOReservation &reservation : idleSelectorGPIOs)
-    {
-        if (reservation.gpio != nullptr)
-        {
-            reservation.gpio->stop();
-        }
-    }
-    idleSelectorGPIOs.clear();
+    idle_selector_gpio_reservations.clear();
 }
 
 static void release_idle_selector_gpio_reservation(int gpio) noexcept
 {
-    idleSelectorGPIOs.erase(
+    idle_selector_gpio_reservations.erase(
         std::remove_if(
-            idleSelectorGPIOs.begin(),
-            idleSelectorGPIOs.end(),
-            [gpio](SelectorGPIOReservation &reservation)
+            idle_selector_gpio_reservations.begin(),
+            idle_selector_gpio_reservations.end(),
+            [gpio](const SelectorGPIOReservation &reservation)
             {
-                if (reservation.config.gpio != gpio)
-                {
-                    return false;
-                }
-
-                if (reservation.gpio != nullptr)
-                {
-                    reservation.gpio->stop();
-                }
-                return true;
+                return reservation.config.gpio == gpio;
             }),
-        idleSelectorGPIOs.end());
+        idle_selector_gpio_reservations.end());
+}
+
+static void append_unique_selector_gpio_config(
+    std::vector<BandGPIOConfig> &configs,
+    const BandGPIOConfig &config) noexcept
+{
+    if (!config.enabled || config.gpio < 0)
+    {
+        return;
+    }
+
+    const auto existing = std::find_if(
+        configs.begin(),
+        configs.end(),
+        [&config](const BandGPIOConfig &candidate)
+        {
+            return candidate.gpio == config.gpio;
+        });
+    if (existing == configs.end())
+    {
+        configs.push_back(config);
+        return;
+    }
+
+    if (existing->active_high != config.active_high)
+    {
+        llog.logS(
+            WARN,
+            "Selector shutdown cleanup saw conflicting polarity for GPIO ",
+            config.gpio,
+            "; keeping the first configured polarity.");
+    }
+}
+
+static std::vector<BandGPIOConfig> collect_selector_gpio_shutdown_targets(
+    const ArgParserConfig &cfg) noexcept
+{
+    std::vector<BandGPIOConfig> targets;
+
+    for (int band_index = 0; band_index < HAM_BAND_COUNT; ++band_index)
+    {
+        append_unique_selector_gpio_config(targets, cfg.band_gpio[band_index]);
+    }
+
+    for (const WsprFrequencyEntry &entry : cfg.wspr_frequency_entries)
+    {
+        if (entry.selector_gpio == kSelectorGpioUnset)
+        {
+            continue;
+        }
+
+        BandGPIOConfig selector_config;
+        selector_config.gpio = entry.selector_gpio;
+        selector_config.enabled = true;
+        selector_config.active_high = entry.selector_gpio_active_high;
+        append_unique_selector_gpio_config(targets, selector_config);
+    }
+
+    const BandGPIOConfig *active_config = bandGPIOSelector.currentConfig();
+    if (active_config != nullptr)
+    {
+        append_unique_selector_gpio_config(targets, *active_config);
+    }
+
+    for (const SelectorGPIOReservation &reservation : idle_selector_gpio_reservations)
+    {
+        append_unique_selector_gpio_config(targets, reservation.config);
+    }
+
+    return targets;
+}
+
+static void shutdown_all_configured_selector_gpios(
+    const ArgParserConfig &cfg) noexcept
+{
+    std::vector<BandGPIOConfig> targets =
+        collect_selector_gpio_shutdown_targets(cfg);
+    last_selector_shutdown_cleanup_targets = targets;
+
+    stop_active_transmission_selectors();
+    release_idle_selector_gpio_reservations();
+
+    if (!selector_gpio_drive_enabled)
+    {
+        return;
+    }
+
+    for (const BandGPIOConfig &selector_config : targets)
+    {
+        GPIOOutput gpio;
+        if (!gpio.enableGPIOPin(
+                selector_config.gpio,
+                selector_config.active_high))
+        {
+            llog.logS(
+                WARN,
+                "Selector shutdown cleanup could not request GPIO ",
+                selector_config.gpio,
+                ": ",
+                gpio.lastError());
+            continue;
+        }
+
+        if (!gpio.toggleGPIO(false))
+        {
+            llog.logS(
+                WARN,
+                "Selector shutdown cleanup could not drive GPIO ",
+                selector_config.gpio,
+                " inactive before release.");
+        }
+
+        gpio.stop();
+    }
 }
 
 static bool collect_configured_selector_gpios(
@@ -336,45 +436,44 @@ static bool collect_configured_selector_gpios(
     std::vector<BandGPIOConfig> &configs_out,
     std::string *error_message = nullptr)
 {
-    configs_out.clear();
-
     std::unordered_map<int, bool> polarity_by_gpio;
-    auto add_configured_gpio =
-        [&](int gpio, bool active_high, const std::string &source) -> bool
+
+    auto append_config = [&](const BandGPIOConfig &config,
+                             std::string_view source_label) -> bool
     {
-        if (gpio < 0)
+        if (!config.enabled || config.gpio < 0)
         {
             return true;
         }
 
-        const auto existing = polarity_by_gpio.find(gpio);
+        const auto existing = polarity_by_gpio.find(config.gpio);
         if (existing != polarity_by_gpio.end())
         {
-            if (existing->second != active_high)
+            if (existing->second != config.active_high)
             {
                 if (error_message != nullptr)
                 {
                     *error_message =
-                        "Selector GPIO " + std::to_string(gpio) +
-                        " has conflicting active polarity definitions in " +
-                        source + ".";
+                        "Conflicting LPF selector polarity configured for GPIO " +
+                        std::to_string(config.gpio) +
+                        " while collecting scheduler selector GPIOs from " +
+                        std::string(source_label) + ".";
                 }
                 return false;
             }
             return true;
         }
 
-        polarity_by_gpio.emplace(gpio, active_high);
-        configs_out.push_back(BandGPIOConfig{gpio, true, active_high});
+        polarity_by_gpio.emplace(config.gpio, config.active_high);
+        configs_out.push_back(config);
         return true;
     };
 
-    for (const BandGPIOConfig &band_config : cfg.band_gpio)
+    configs_out.clear();
+
+    for (int band_index = 0; band_index < HAM_BAND_COUNT; ++band_index)
     {
-        if (band_config.enabled && band_config.gpio >= 0 &&
-            !add_configured_gpio(band_config.gpio,
-                                 band_config.active_high,
-                                 "[Band GPIO]"))
+        if (!append_config(cfg.band_gpio[band_index], "[Band GPIO]"))
         {
             return false;
         }
@@ -382,10 +481,16 @@ static bool collect_configured_selector_gpios(
 
     for (const WsprFrequencyEntry &entry : cfg.wspr_frequency_entries)
     {
-        if (entry.selector_gpio != kSelectorGpioUnset &&
-            !add_configured_gpio(entry.selector_gpio,
-                                 entry.selector_gpio_active_high,
-                                 "frequency entries"))
+        if (entry.selector_gpio == kSelectorGpioUnset)
+        {
+            continue;
+        }
+
+        BandGPIOConfig config;
+        config.gpio = entry.selector_gpio;
+        config.enabled = true;
+        config.active_high = entry.selector_gpio_active_high;
+        if (!append_config(config, "frequency entries"))
         {
             return false;
         }
@@ -396,13 +501,24 @@ static bool collect_configured_selector_gpios(
 
 static bool has_configured_selector_gpios(const ArgParserConfig &cfg) noexcept
 {
-    std::vector<BandGPIOConfig> configured_gpios;
-    std::string error_message;
-    return collect_configured_selector_gpios(
-               cfg,
-               configured_gpios,
-               &error_message) &&
-           !configured_gpios.empty();
+    for (int band_index = 0; band_index < HAM_BAND_COUNT; ++band_index)
+    {
+        const BandGPIOConfig &config = cfg.band_gpio[band_index];
+        if (config.enabled && config.gpio >= 0)
+        {
+            return true;
+        }
+    }
+
+    for (const WsprFrequencyEntry &entry : cfg.wspr_frequency_entries)
+    {
+        if (entry.selector_gpio != kSelectorGpioUnset)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 static bool sync_configured_selector_gpio_idle_state(
@@ -413,60 +529,56 @@ static bool sync_configured_selector_gpio_idle_state(
     stop_active_transmission_selectors();
     release_idle_selector_gpio_reservations();
 
-    if (!selectorGPIOControlEnabled || !keep_initialized)
+    if (!keep_initialized || !selector_gpio_control_enabled)
     {
         return true;
     }
 
-    std::vector<BandGPIOConfig> configured_gpios;
-    if (!collect_configured_selector_gpios(cfg, configured_gpios, error_message))
+    std::vector<BandGPIOConfig> selector_configs;
+    if (!collect_configured_selector_gpios(cfg, selector_configs, error_message))
     {
         return false;
     }
 
-    for (const BandGPIOConfig &configured_gpio : configured_gpios)
+    for (const BandGPIOConfig &selector_config : selector_configs)
     {
         SelectorGPIOReservation reservation;
-        reservation.config = configured_gpio;
+        reservation.config = selector_config;
 
-        if (!selectorGPIODriveEnabled)
+        if (selector_gpio_drive_enabled)
         {
-            idleSelectorGPIOs.push_back(std::move(reservation));
-            continue;
-        }
-
-        reservation.gpio = std::make_unique<GPIOOutput>();
-        if (!reservation.gpio->enableGPIOPin(
-                configured_gpio.gpio,
-                configured_gpio.active_high))
-        {
-            if (error_message != nullptr)
+            reservation.gpio = std::make_unique<GPIOOutput>();
+            if (!reservation.gpio->enableGPIOPin(
+                    selector_config.gpio,
+                    selector_config.active_high))
             {
-                *error_message =
-                    "Failed to initialize selector GPIO " +
-                    std::to_string(configured_gpio.gpio) + ": " +
-                    reservation.gpio->lastError();
+                if (error_message != nullptr)
+                {
+                    *error_message =
+                        "Unable to initialize LPF selector GPIO " +
+                        std::to_string(selector_config.gpio) +
+                        " inactive: " +
+                        reservation.gpio->lastError();
+                }
+                release_idle_selector_gpio_reservations();
+                return false;
             }
-            release_idle_selector_gpio_reservations();
-            return false;
-        }
 
-        // False drives the configured output to its inactive level:
-        // LOW for active-high and HIGH for active-low.
-        if (!reservation.gpio->toggleGPIO(false))
-        {
-            if (error_message != nullptr)
+            if (!reservation.gpio->toggleGPIO(false))
             {
-                *error_message =
-                    "Failed to drive selector GPIO " +
-                    std::to_string(configured_gpio.gpio) +
-                    " to its inactive level.";
+                if (error_message != nullptr)
+                {
+                    *error_message =
+                        "Unable to drive LPF selector GPIO " +
+                        std::to_string(selector_config.gpio) +
+                        " inactive.";
+                }
+                release_idle_selector_gpio_reservations();
+                return false;
             }
-            release_idle_selector_gpio_reservations();
-            return false;
         }
 
-        idleSelectorGPIOs.push_back(std::move(reservation));
+        idle_selector_gpio_reservations.push_back(std::move(reservation));
     }
 
     return true;
@@ -2655,8 +2767,7 @@ static void stop_runtime_components_for_process_exit() noexcept
     shutdownMonitor.stop();
     ppmManager.stop();
     wsprTransmitter.shutdownForProcessExit();
-    stop_active_transmission_selectors();
-    release_idle_selector_gpio_reservations();
+    shutdown_all_configured_selector_gpios(config);
     ledControl.stop();
 }
 
@@ -2675,10 +2786,11 @@ bool wspr_loop()
 {
     const bool any_selector_gpio_configured =
         has_configured_selector_gpios(config);
-    selectorGPIOControlEnabled = any_selector_gpio_configured;
-    selectorGPIODriveEnabled = any_selector_gpio_configured;
-    bandGPIOSelector.setEnabled(selectorGPIOControlEnabled);
-    bandGPIOSelector.setDriveGPIO(selectorGPIODriveEnabled);
+
+    selector_gpio_control_enabled = any_selector_gpio_configured;
+    selector_gpio_drive_enabled = any_selector_gpio_configured;
+    bandGPIOSelector.setEnabled(selector_gpio_control_enabled);
+    bandGPIOSelector.setDriveGPIO(selector_gpio_drive_enabled);
 
     // Display the final configuration after parsing arguments and INI file.
     show_config_values();
@@ -2905,7 +3017,7 @@ bool wspr_loop()
     llog.logS(DEBUG, "Transmitter stopped.");
 
     llog.logS(DEBUG, "Stopping band GPIO selector.");
-    stop_active_transmission_selectors();
+    shutdown_all_configured_selector_gpios(config);
     llog.logS(DEBUG, "Band GPIO selector stopped.");
 
     llog.logS(DEBUG, "Stopping LED driver.");
@@ -3169,6 +3281,7 @@ bool set_config(bool force)
                 {
                     wsprTransmitter.stopAndJoin();
                     stop_active_transmission_selectors();
+                    release_idle_selector_gpio_reservations();
                     current_transmission_request = TransmissionRequest{};
                 }
 
@@ -3209,6 +3322,7 @@ bool set_config(bool force)
                     backend_runtime_error);
                 wsprTransmitter.stopAndJoin();
                 stop_active_transmission_selectors();
+                release_idle_selector_gpio_reservations();
                 current_transmission_request = TransmissionRequest{};
                 current_dial_frequency = 0.0;
                 current_frequency_entry = WsprFrequencyEntry{};
@@ -3263,6 +3377,62 @@ bool set_config(bool force)
             do_config = true;
         }
 
+        if (!suppress_scheduler_execution_for_test)
+        {
+            const bool any_selector_gpio_configured =
+                has_configured_selector_gpios(working_config);
+            selector_gpio_control_enabled = any_selector_gpio_configured;
+            selector_gpio_drive_enabled = any_selector_gpio_configured;
+            bandGPIOSelector.setEnabled(selector_gpio_control_enabled);
+            bandGPIOSelector.setDriveGPIO(selector_gpio_drive_enabled);
+        }
+        else
+        {
+            selector_gpio_drive_enabled = false;
+            bandGPIOSelector.setDriveGPIO(false);
+        }
+
+        const bool keep_selector_gpio_initialized =
+            working_config.transmit &&
+            runtime_transmit_enabled(working_config);
+
+        std::string selector_gpio_error;
+        if (!sync_configured_selector_gpio_idle_state(
+                working_config,
+                keep_selector_gpio_initialized,
+                &selector_gpio_error))
+        {
+            llog.logS(ERROR, selector_gpio_error);
+
+            if (working_config.use_ini)
+            {
+                send_ws_message(
+                    "configuration",
+                    "reload_failed",
+                    selector_gpio_error);
+                set_managed_reload_tx_inhibited(
+                    true,
+                    selector_gpio_error);
+                wsprTransmitter.stopAndJoin();
+                stop_active_transmission_selectors();
+                release_idle_selector_gpio_reservations();
+                current_transmission_request = TransmissionRequest{};
+                current_dial_frequency = 0.0;
+                current_frequency_entry = WsprFrequencyEntry{};
+
+                if (!finalize_reload_pending())
+                {
+                    continue;
+                }
+                return true;
+            }
+
+            ini_reload_pending.store(false, std::memory_order_relaxed);
+            config.transmit = false;
+            config_to_json();
+            return false;
+        }
+
         if (is_non_wspr_runtime_mode(working_config.mode))
         {
             std::string policy_error;
@@ -3283,6 +3453,7 @@ bool set_config(bool force)
                         policy_error);
                     wsprTransmitter.stopAndJoin();
                     stop_active_transmission_selectors();
+                    release_idle_selector_gpio_reservations();
                     current_transmission_request = TransmissionRequest{};
                     current_dial_frequency = 0.0;
                     current_frequency_entry = WsprFrequencyEntry{};
@@ -3334,6 +3505,7 @@ bool set_config(bool force)
 
             wsprTransmitter.stopAndJoin();
             stop_active_transmission_selectors();
+            release_idle_selector_gpio_reservations();
             current_transmission_request = TransmissionRequest{};
             current_dial_frequency = 0.0;
             current_frequency_entry = WsprFrequencyEntry{};
@@ -3432,17 +3604,26 @@ bool set_config(bool force)
 
             if (!suppress_scheduler_execution_for_test)
             {
-                selectorGPIOControlEnabled =
+                const bool any_selector_gpio_configured =
                     has_configured_selector_gpios(working_config);
-                selectorGPIODriveEnabled = selectorGPIOControlEnabled;
-                bandGPIOSelector.setEnabled(selectorGPIOControlEnabled);
-                bandGPIOSelector.setDriveGPIO(selectorGPIODriveEnabled);
+                selector_gpio_control_enabled = any_selector_gpio_configured;
+                selector_gpio_drive_enabled = any_selector_gpio_configured;
+                bandGPIOSelector.setEnabled(selector_gpio_control_enabled);
+                bandGPIOSelector.setDriveGPIO(selector_gpio_drive_enabled);
+            }
+            else
+            {
+                selector_gpio_drive_enabled = false;
+                bandGPIOSelector.setDriveGPIO(false);
             }
 
+            const bool keep_selector_gpio_initialized =
+                working_config.transmit &&
+                runtime_transmit_enabled(working_config);
             std::string selector_idle_error;
             if (!sync_configured_selector_gpio_idle_state(
                     working_config,
-                    runtime_transmit_enabled(working_config),
+                    keep_selector_gpio_initialized,
                     &selector_idle_error))
             {
                 llog.logS(ERROR, "Failed to synchronize selector GPIO idle state: ",
@@ -3521,6 +3702,7 @@ bool set_config(bool force)
 
                 wsprTransmitter.stopAndJoin();
                 stop_active_transmission_selectors();
+                release_idle_selector_gpio_reservations();
                 current_transmission_request = TransmissionRequest{};
                 current_dial_frequency = 0.0;
                 current_frequency_entry = WsprFrequencyEntry{};
@@ -3606,6 +3788,7 @@ bool set_config(bool force)
                         "Managed reload planning failed; previous valid configuration remains loaded. Transmit is blocked until a valid configuration is loaded.");
                     wsprTransmitter.stopAndJoin();
                     stop_active_transmission_selectors();
+                    release_idle_selector_gpio_reservations();
                     current_transmission_request = TransmissionRequest{};
                     if (!finalize_reload_pending())
                     {
@@ -3669,6 +3852,7 @@ bool set_config(bool force)
             if (newer_reload_arrived())
             {
                 stop_active_transmission_selectors();
+                release_idle_selector_gpio_reservations();
                 continue;
             }
 
@@ -3728,6 +3912,7 @@ bool set_config(bool force)
                 if (!finalize_reload_pending())
                 {
                     stop_active_transmission_selectors();
+                    release_idle_selector_gpio_reservations();
                     continue;
                 }
                 return true;
@@ -3776,20 +3961,26 @@ void reset_managed_reload_runtime_for_test() noexcept
 void set_scheduler_execution_suppressed_for_test(bool suppressed) noexcept
 {
     suppress_scheduler_execution_for_test = suppressed;
+    if (suppressed)
+    {
+        selector_gpio_control_enabled = false;
+        selector_gpio_drive_enabled = false;
+        bandGPIOSelector.setEnabled(false);
+        bandGPIOSelector.setDriveGPIO(false);
+        stop_active_transmission_selectors();
+        release_idle_selector_gpio_reservations();
+    }
 }
 
 void set_band_gpio_selector_for_test(bool enabled, bool drive_gpio) noexcept
 {
-    selectorGPIOControlEnabled = enabled;
-    selectorGPIODriveEnabled = drive_gpio;
-    if (!enabled)
-    {
-        stop_active_transmission_selectors();
-    }
+    selector_gpio_control_enabled = enabled;
+    selector_gpio_drive_enabled = drive_gpio;
     bandGPIOSelector.setEnabled(enabled);
     bandGPIOSelector.setDriveGPIO(drive_gpio);
     if (!enabled)
     {
+        stop_active_transmission_selectors();
         release_idle_selector_gpio_reservations();
     }
 }
@@ -3815,8 +4006,9 @@ bool current_band_gpio_selection_for_test(
 std::vector<BandGPIOConfig> initialized_selector_gpios_for_test()
 {
     std::vector<BandGPIOConfig> configs;
-    configs.reserve(idleSelectorGPIOs.size());
-    for (const SelectorGPIOReservation &reservation : idleSelectorGPIOs)
+    configs.reserve(idle_selector_gpio_reservations.size());
+    for (const SelectorGPIOReservation &reservation :
+         idle_selector_gpio_reservations)
     {
         configs.push_back(reservation.config);
     }
@@ -3846,6 +4038,49 @@ bool restore_committed_band_gpio_selection_for_test(bool assert_state) noexcept
 TransmissionRequest current_transmission_request_for_test()
 {
     return current_transmission_request;
+}
+
+std::vector<BandGPIOConfig> selector_shutdown_cleanup_targets_for_test()
+{
+    return last_selector_shutdown_cleanup_targets;
+}
+
+void seed_selector_shutdown_state_for_test(
+    const BandGPIOConfig &active_config,
+    const std::vector<BandGPIOConfig> &idle_configs) noexcept
+{
+    stop_active_transmission_selectors();
+    release_idle_selector_gpio_reservations();
+
+    bandGPIOSelector.setEnabled(true);
+    bandGPIOSelector.setDriveGPIO(false);
+    selector_gpio_control_enabled = true;
+    selector_gpio_drive_enabled = false;
+
+    if (active_config.enabled && active_config.gpio >= 0)
+    {
+        (void)bandGPIOSelector.prepareBand(HamBand::BAND_20M, active_config);
+        active_band_gpio_prepare_status.store(
+            BandGPIOPrepareStatus::Prepared,
+            std::memory_order_release);
+    }
+
+    for (const BandGPIOConfig &idle_config : idle_configs)
+    {
+        if (!idle_config.enabled || idle_config.gpio < 0)
+        {
+            continue;
+        }
+
+        SelectorGPIOReservation reservation;
+        reservation.config = idle_config;
+        idle_selector_gpio_reservations.push_back(std::move(reservation));
+    }
+}
+
+void run_final_selector_gpio_shutdown_cleanup_for_test() noexcept
+{
+    shutdown_all_configured_selector_gpios(config);
 }
 
 void reset_current_transmission_request_for_test() noexcept

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -322,6 +322,11 @@ bool current_band_gpio_selection_for_test(
 std::vector<BandGPIOConfig> initialized_selector_gpios_for_test();
 void stop_active_transmission_selectors_for_test() noexcept;
 bool restore_committed_band_gpio_selection_for_test(bool assert_state) noexcept;
+std::vector<BandGPIOConfig> selector_shutdown_cleanup_targets_for_test();
+void seed_selector_shutdown_state_for_test(
+    const BandGPIOConfig &active_config,
+    const std::vector<BandGPIOConfig> &idle_configs) noexcept;
+void run_final_selector_gpio_shutdown_cleanup_for_test() noexcept;
 TransmissionRequest current_transmission_request_for_test();
 void reset_current_transmission_request_for_test() noexcept;
 

--- a/src/tests/band_gpio_rotation_test.cpp
+++ b/src/tests/band_gpio_rotation_test.cpp
@@ -42,6 +42,10 @@ namespace
         config.wspr.audio_offset_hz = WSPR_AUDIO_OFFSET_HZ;
         config.wspr.planner_preference = WsprPlannerPreference::Auto;
         config.wspr_planner_preference = WsprPlannerPreference::Auto;
+        for (int band_index = 0; band_index < HAM_BAND_COUNT; ++band_index)
+        {
+            config.band_gpio[band_index] = BandGPIOConfig{};
+        }
 
         config_to_json();
     }
@@ -156,6 +160,21 @@ namespace
         require(
             actual == expected,
             message + ": initialized selector GPIO set must match expected configured GPIOs");
+    }
+
+    void require_shutdown_cleanup_targets(
+        const std::set<std::pair<int, bool>> &expected,
+        const std::string &message)
+    {
+        std::set<std::pair<int, bool>> actual;
+        for (const BandGPIOConfig &config : selector_shutdown_cleanup_targets_for_test())
+        {
+            actual.emplace(config.gpio, config.active_high);
+        }
+
+        require(
+            actual == expected,
+            message + ": shutdown cleanup must cover the full configured selector GPIO set");
     }
 
     void require_all_selector_gpios_released(const std::string &message)
@@ -379,6 +398,50 @@ int main()
             config.wspr_frequency_entries[1].selector_gpio == kSelectorGpioUnset &&
             !config.wspr_frequency_entries[1].allow_band_gpio_fallback,
         "CLI @GPIO selectors must stay explicit and must not enable band-config fallback");
+
+    prime_valid_ui_config();
+    patch_all_from_web({
+        {"WSPR", {{"Frequency", "20m@16H,30m@20H,40m@21H"}}},
+        {"Band GPIO",
+         {{"20m", {{"GPIO", 5}, {"Enabled", true}, {"Active High", true}}},
+          {"30m", {{"GPIO", 6}, {"Enabled", true}, {"Active High", true}}},
+          {"40m", {{"GPIO", 13}, {"Enabled", true}, {"Active High", false}}}}}});
+    reset_scheduler_test_state();
+
+    require(set_config(true), "scheduler must commit first explicit selector entry");
+    require_current_selector("20m@16H", "20m", 16, true, "first explicit selector entry");
+
+    require(set_config(false), "scheduler must commit second explicit selector entry");
+    require_current_selector("30m@20H", "30m", 20, true, "second explicit selector entry");
+    run_final_selector_gpio_shutdown_cleanup_for_test();
+    require_shutdown_cleanup_targets(
+        {{16, true}, {20, true}, {21, true}, {5, true}, {6, true}, {13, false}},
+        "final shutdown cleanup with explicit and band-config selectors");
+    require_all_selector_gpios_released(
+        "final shutdown cleanup with explicit and band-config selectors");
+
+    patch_all_from_web({
+        {"WSPR", {{"Frequency", "20m,30m"}}},
+        {"Band GPIO",
+         {{"20m", {{"GPIO", 17}, {"Enabled", true}, {"Active High", true}}},
+          {"30m", {{"GPIO", 18}, {"Enabled", true}, {"Active High", false}}}}}});
+    require(set_config(true), "scheduler must reload band GPIO selector set");
+    require_current_selector("20m", "20m", 17, true, "reloaded band GPIO selector set");
+    run_final_selector_gpio_shutdown_cleanup_for_test();
+    require_shutdown_cleanup_targets(
+        {{17, true}, {18, false}},
+        "final shutdown cleanup with band-config-only selectors");
+    require_all_selector_gpios_released(
+        "final shutdown cleanup with band-config-only selectors");
+
+    patch_all_from_web({
+        {"WSPR", {{"Frequency", "20m@17H,30m@17L"}}},
+        {"Band GPIO",
+         {{"20m", {{"GPIO", -1}, {"Enabled", false}, {"Active High", true}}},
+          {"30m", {{"GPIO", -1}, {"Enabled", false}, {"Active High", true}}}}}});
+    require(!set_config(true), "conflicting selector polarity on the same GPIO must be rejected");
+
+    finish_scheduler_test_state();
 
     std::cout << "Band GPIO rotation regression tests passed." << std::endl;
     return EXIT_SUCCESS;

--- a/src/tests/selector_shutdown_cleanup_test.cpp
+++ b/src/tests/selector_shutdown_cleanup_test.cpp
@@ -1,0 +1,127 @@
+#include "arg_parser.hpp"
+#include "config_handler.hpp"
+#include "scheduling.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace
+{
+    void require(bool condition, const std::string &message)
+    {
+        if (!condition)
+        {
+            std::cerr << "FAIL: " << message << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+
+    std::set<std::pair<int, bool>> selector_set(
+        const std::vector<BandGPIOConfig> &configs)
+    {
+        std::set<std::pair<int, bool>> result;
+        for (const BandGPIOConfig &config : configs)
+        {
+            result.emplace(config.gpio, config.active_high);
+        }
+        return result;
+    }
+
+    void require_no_active_or_idle_selectors(const std::string &message)
+    {
+        BandGPIOConfig active_config;
+        std::string active_band;
+        require(
+            initialized_selector_gpios_for_test().empty(),
+            message + ": idle selector reservations must be empty");
+        require(
+            !current_band_gpio_selection_for_test(active_config, active_band),
+            message + ": active selector must be cleared");
+    }
+
+    void prime_base_config()
+    {
+        init_config_json();
+        json_to_config();
+
+        config.use_ini = false;
+        config.mode = ModeType::WSPR;
+        config.transmit = true;
+        config.callsign = "AA0NT";
+        config.grid_square = "EM18";
+        config.power_dbm = 20;
+        config.frequencies = "20m";
+        config.tx_pin = 4;
+        config.ppm = 0.0;
+        config.use_ntp = false;
+        config.use_offset = false;
+        config.wspr.callsign = config.callsign;
+        config.wspr.grid_square = config.grid_square;
+        config.wspr.power_dbm = config.power_dbm;
+        config.wspr.frequencies = config.frequencies;
+        config.wspr.audio_offset_hz = WSPR_AUDIO_OFFSET_HZ;
+        config.wspr.planner_preference = WsprPlannerPreference::Auto;
+        config.wspr_planner_preference = WsprPlannerPreference::Auto;
+        for (int band_index = 0; band_index < HAM_BAND_COUNT; ++band_index)
+        {
+            config.band_gpio[band_index] = BandGPIOConfig{};
+        }
+
+        config_to_json();
+        set_band_gpio_selector_for_test(false, false);
+    }
+}
+
+int main()
+{
+    prime_base_config();
+    patch_all_from_web({
+        {"WSPR", {{"Frequency", "20m@16H,30m@20H,40m"}}},
+        {"Band GPIO",
+         {{"20m", {{"GPIO", 5}, {"Enabled", true}, {"Active High", true}}},
+          {"30m", {{"GPIO", 6}, {"Enabled", true}, {"Active High", true}}},
+          {"40m", {{"GPIO", 13}, {"Enabled", true}, {"Active High", false}}}}}});
+
+    seed_selector_shutdown_state_for_test(
+        BandGPIOConfig{.gpio = 21, .enabled = true, .active_high = true},
+        std::vector<BandGPIOConfig>{
+            BandGPIOConfig{.gpio = 22, .enabled = true, .active_high = false}});
+    run_final_selector_gpio_shutdown_cleanup_for_test();
+
+    require(
+        selector_set(selector_shutdown_cleanup_targets_for_test()) ==
+            std::set<std::pair<int, bool>>{
+                {5, true},
+                {6, true},
+                {13, false},
+                {16, true},
+                {20, true},
+                {21, true},
+                {22, false}},
+        "shutdown cleanup must cover band-config selectors, explicit @GPIO selectors, active selector, and idle selectors");
+    require_no_active_or_idle_selectors(
+        "shutdown cleanup after mixed selector sources");
+
+    prime_base_config();
+    patch_all_from_web({
+        {"WSPR", {{"Frequency", "20m,30m"}}},
+        {"Band GPIO",
+         {{"20m", {{"GPIO", 17}, {"Enabled", true}, {"Active High", true}}},
+          {"30m", {{"GPIO", 18}, {"Enabled", true}, {"Active High", false}}}}}});
+
+    seed_selector_shutdown_state_for_test(BandGPIOConfig{}, {});
+    run_final_selector_gpio_shutdown_cleanup_for_test();
+
+    require(
+        selector_set(selector_shutdown_cleanup_targets_for_test()) ==
+            std::set<std::pair<int, bool>>{{17, true}, {18, false}},
+        "shutdown cleanup must cover band-config-only selectors");
+    require_no_active_or_idle_selectors(
+        "shutdown cleanup after band-config-only selectors");
+
+    std::cout << "Selector shutdown cleanup regression tests passed." << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

This PR resolves the recent merge conflicts while preserving and completing the
scheduler-owned LPF selector GPIO lifecycle work.

The merged result keeps the newer committed-request selector restore behavior
from upstream and combines it with the scheduler-managed selector idle pool,
deterministic initialization, stricter transmit gating, and full shutdown
cleanup.

The final behavior is:

- all configured selector GPIOs are initialized to their inactive state on
  config load or reload when transmit is enabled
- only the active selector GPIO is asserted during transmission
- the selected GPIO is removed from the idle pool before active prepare
- the selector idle pool is not rebuilt when transmit is disabled
- all configured selector GPIOs are driven inactive and released during
  shutdown cleanup
- both explicit `@GPIO` entries and `[Band GPIO]` mappings participate in the
  same lifecycle

---

## What this fixes

This work addresses several related problems:

- only the first selector GPIO in a rotation would reliably assert
- non-selected configured selector GPIOs were not initialized
  deterministically on config apply
- transmit-disabled paths could clear and then immediately rebuild the idle
  selector pool in the same `set_config()` pass
- shutdown cleanup did not consistently cover the full configured selector set
- merge conflicts risked splitting selector behavior across multiple lifecycle
  paths

---

## Final behavior

### Config load or reload

When transmit is enabled, the scheduler now:

- collects all configured selector GPIOs from:
  - explicit `@GPIO` frequency entries
  - `[Band GPIO]` mappings
- deduplicates them
- rejects conflicting polarity definitions on the same GPIO
- initializes each GPIO to its inactive state:
  - active-high -> LOW
  - active-low -> HIGH

### Active transmission

During transmit:

- scheduler resolves the selected band or selector GPIO
- selector snapshot is committed into `TransmissionRequest`
- STARTING restores selector state from the committed request snapshot
- restore routes through the same active handoff path as normal selector
  preparation
- the selected GPIO is removed from the idle pool before active prepare
- only the selected GPIO is asserted

### Transmit disabled

When transmit is disabled:

- no active selector remains prepared
- no idle selector reservations remain
- the selector idle pool is not rebuilt

### Shutdown

On normal process exit, shutdown cleanup now:

- stops the active selector path
- releases the idle selector pool
- performs a final cleanup sweep across all configured selector GPIOs
- drives each configured selector GPIO inactive
- releases it

This gives the strongest possible software-controlled shutdown behavior.

---

## Merge resolution notes

Three files had direct merge conflicts:

- `src/scheduling.cpp`
- `src/scheduling.hpp`
- `src/tests/band_gpio_rotation_test.cpp`

The resolved merge keeps both important sides of the change set.

### Preserved from upstream

- committed-request selector restore at transmit start
- test helpers that validate selector restore from committed request
- `TransmissionRequest` selector snapshot fields and `hasSelectorGPIO()`

### Preserved from local work

- scheduler-owned selector idle pool
- deterministic inactive initialization of all configured selector GPIOs
- explicit `@GPIO` inclusion in full selector lifecycle
- stricter idle-pool gating:
  - `working_config.transmit && runtime_transmit_enabled(...)`
- final selector shutdown cleanup coverage
- shutdown cleanup regression coverage

### Important integration decision

Committed-request restore is preserved, but it now routes through the same
`apply_band_gpio_resolution()` path used by normal active selector preparation.

This avoids maintaining two different selector activation paths and keeps
ownership transitions centralized.

---

## Key implementation details

### Scheduler-owned idle pool

The scheduler maintains an idle reservation pool for configured selector GPIOs.
Those GPIOs are held in their inactive state while transmit is enabled and
they are not actively selected.

### Direct selector snapshot commit

Selector metadata is committed directly into `TransmissionRequest`, including:

- `selector_gpio_enabled`
- `selector_band`
- `selector_gpio_config`

This lets the runtime restore selector state from the committed request
without re-running policy resolution.

### Stricter idle initialization gating

Idle-pool initialization is now gated by:

```cpp
working_config.transmit && runtime_transmit_enabled(working_config)
```

This prevents disabled-transmit config updates from clearing and then
rebuilding the selector idle pool in the same pass.

### Final shutdown cleanup

Shutdown now uses a final cleanup helper that covers:

- configured band-mapped selector GPIOs
- configured explicit `@GPIO` selector GPIOs
- the currently active selector
- idle selector reservations

Each target is driven inactive before release.

---

## Files changed

Top-level repo:

- `src/scheduling.cpp`
- `src/scheduling.hpp`
- `src/tests/band_gpio_rotation_test.cpp`
- `src/tests/selector_shutdown_cleanup_test.cpp`
- `src/Makefile`

Submodule:

- `src/WSPR-Transmitter/src/wspr_transmit_types.hpp`

---

## Tests

### Added

- `selector_shutdown_cleanup_test.cpp`

### Extended

- `band_gpio_rotation_test.cpp`

### Coverage now includes

- committed selector snapshot restore
- selector rotation across multiple entries
- deterministic initialization of configured selector GPIOs
- explicit `@GPIO` and `[Band GPIO]` participation
- reload to a different configured selector set
- conflicting polarity rejection on the same GPIO
- shutdown cleanup target coverage
- transmit-disabled behavior leaving:
  - no active selector
  - no idle selector reservations

---

## Build verification

Built successfully:

- `make build/bin/wsprrypi_debug`
- `make build/bin/band_gpio_rotation_test`
- `make build/bin/selector_shutdown_cleanup_test`
- `make build/bin/dial_frequency_semantics_test`

Ran successfully in this environment:

- `./build/bin/selector_shutdown_cleanup_test`

Notes:

- some broader runtime tests still hit existing non-Pi environment limitations
- visible OFF after process exit can still depend on board-level pull resistors
  or external biasing after GPIO release

---

## Why this belongs in the scheduler

This is scheduler policy and lifecycle work, not backend policy.

The scheduler is the only layer that knows:

- the full configured selector GPIO set
- when config is loaded or reloaded
- when transmit becomes enabled or disabled
- when shutdown cleanup must cover the full selector set

The backend remains focused on execution.

---

## Result

This merged change set preserves the intended selector behavior and avoids
regressions introduced by the conflict resolution process.

The scheduler now owns a coherent selector GPIO lifecycle across:

- config load
- reload
- transmit rotation
- transmit disable
- shutdown
