### PR TITLE
Make GPIO Inactive More Deterministic

### DIFF
--- a/src/band_gpio_selector.cpp
+++ b/src/band_gpio_selector.cpp
@@ -79,6 +79,7 @@ bool BandGPIOSelector::prepareBand(
     has_band_ = true;
     current_band_ = band;
     current_config_ = config;
+    band_state_active_ = false;
 
     if (!drive_gpio_)
     {
@@ -170,6 +171,7 @@ bool BandGPIOSelector::setBandState(bool state)
 
     if (!drive_gpio_)
     {
+        band_state_active_ = state;
         llog.logS(DEBUG, tag,
                   "Unified scheduler selector ",
                   (state ? "assert band " : "deassert band "),
@@ -183,6 +185,10 @@ bool BandGPIOSelector::setBandState(bool state)
     }
 
     const bool ok = gpio_ != nullptr && gpio_->toggleGPIO(state);
+    if (ok)
+    {
+        band_state_active_ = state;
+    }
 
     llog.logS(ok ? DEBUG : ERROR,
               tag,
@@ -240,6 +246,7 @@ void BandGPIOSelector::stop()
 
     has_band_ = false;
     current_config_ = BandGPIOConfig{};
+    band_state_active_ = false;
 }
 
 std::unique_ptr<GPIOOutput> BandGPIOSelector::releaseGPIOReservation() noexcept
@@ -261,6 +268,7 @@ std::unique_ptr<GPIOOutput> BandGPIOSelector::releaseGPIOReservation() noexcept
 
     has_band_ = false;
     current_config_ = BandGPIOConfig{};
+    band_state_active_ = false;
     return std::move(gpio_);
 }
 

--- a/src/band_gpio_selector.hpp
+++ b/src/band_gpio_selector.hpp
@@ -112,6 +112,10 @@ public:
      *         selected.
      */
     const BandGPIOConfig *currentConfig() const;
+    bool isBandStateActive() const noexcept
+    {
+        return has_band_ && band_state_active_;
+    }
 
     /**
      * @brief Enable or disable band-based GPIO control.
@@ -149,6 +153,7 @@ private:
     BandGPIOConfig current_config_{};
     bool enabled_ = false;
     bool drive_gpio_ = false;
+    bool band_state_active_ = false;
     static constexpr const char *tag = "[BandGPIO]";
 };
 

--- a/src/gpio_output.cpp
+++ b/src/gpio_output.cpp
@@ -29,6 +29,43 @@
 #include "gpio_output.hpp"
 #include "logging.hpp"
 #include <iostream>
+#include <mutex>
+#include <unordered_map>
+
+namespace
+{
+    std::mutex gpio_output_test_mtx;
+    bool gpio_output_test_mode_enabled = false;
+    std::unordered_map<int, bool> gpio_output_test_states;
+    std::vector<GPIOOutput::TestEvent> gpio_output_test_events;
+
+    void record_gpio_output_test_event(
+        const std::string &action,
+        int pin,
+        bool active_high,
+        bool logical_state)
+    {
+        std::lock_guard<std::mutex> lk(gpio_output_test_mtx);
+        if (!gpio_output_test_mode_enabled)
+        {
+            return;
+        }
+
+        gpio_output_test_events.push_back(GPIOOutput::TestEvent{
+            action,
+            pin,
+            active_high,
+            logical_state});
+
+        if (action == "release")
+        {
+            gpio_output_test_states.erase(pin);
+            return;
+        }
+
+        gpio_output_test_states[pin] = logical_state;
+    }
+}
 
 // Global instance for the optional status LED.
 GPIOOutput ledControl;
@@ -46,6 +83,7 @@ GPIOOutput ledControl;
 GPIOOutput::GPIOOutput() : pin_(-1),
                            active_high_(true),
                            enabled_(false),
+                           last_logical_state_(false),
                            last_error_(),
                            chip_(nullptr)
 {
@@ -84,7 +122,20 @@ bool GPIOOutput::enableGPIOPin(int pin, bool active_high)
     }
     pin_ = pin;
     active_high_ = active_high;
+    last_logical_state_ = false;
     resolved_line_ = ResolvedGPIOLine{};
+
+    bool use_test_mode = false;
+    {
+        std::lock_guard<std::mutex> lk(gpio_output_test_mtx);
+        use_test_mode = gpio_output_test_mode_enabled;
+    }
+    if (use_test_mode)
+    {
+        enabled_ = true;
+        record_gpio_output_test_event("request", pin_, active_high_, false);
+        return true;
+    }
 
     try
     {
@@ -137,6 +188,8 @@ bool GPIOOutput::enableGPIOPin(int pin, bool active_high)
 #endif
 
         enabled_ = true;
+        last_logical_state_ = false;
+        record_gpio_output_test_event("request", pin_, active_high_, false);
         llog.logS(
             DEBUG,
             "GPIOOutput: request success for ",
@@ -210,6 +263,10 @@ void GPIOOutput::stop()
 #endif
     chip_.reset();
     resolved_line_ = ResolvedGPIOLine{};
+    record_gpio_output_test_event("release", pin_, active_high_, false);
+    pin_ = -1;
+    active_high_ = true;
+    last_logical_state_ = false;
 }
 
 /**
@@ -234,6 +291,7 @@ bool GPIOOutput::toggleGPIO(bool state)
 
     try
     {
+        last_logical_state_ = state;
         int physical = compute_physical_state(state);
 
 #if GPIOD_API_MAJOR >= 2
@@ -253,6 +311,7 @@ bool GPIOOutput::toggleGPIO(bool state)
             ", requested line value ",
             physical,
             ".");
+        record_gpio_output_test_event("write", pin_, active_high_, state);
     }
     catch (const std::exception &e)
     {
@@ -279,4 +338,42 @@ bool GPIOOutput::toggleGPIO(bool state)
 int GPIOOutput::compute_physical_state(bool logical_state) const
 {
     return logical_state ? 1 : 0;
+}
+
+void GPIOOutput::setTestMode(bool enabled) noexcept
+{
+    std::lock_guard<std::mutex> lk(gpio_output_test_mtx);
+    gpio_output_test_mode_enabled = enabled;
+    gpio_output_test_states.clear();
+    gpio_output_test_events.clear();
+}
+
+bool GPIOOutput::testModeEnabled() noexcept
+{
+    std::lock_guard<std::mutex> lk(gpio_output_test_mtx);
+    return gpio_output_test_mode_enabled;
+}
+
+void GPIOOutput::clearTestEvents() noexcept
+{
+    std::lock_guard<std::mutex> lk(gpio_output_test_mtx);
+    gpio_output_test_events.clear();
+}
+
+std::vector<GPIOOutput::TestEvent> GPIOOutput::testEvents()
+{
+    std::lock_guard<std::mutex> lk(gpio_output_test_mtx);
+    return gpio_output_test_events;
+}
+
+std::optional<bool> GPIOOutput::testLogicalStateForPin(int pin) noexcept
+{
+    std::lock_guard<std::mutex> lk(gpio_output_test_mtx);
+    const auto it = gpio_output_test_states.find(pin);
+    if (it == gpio_output_test_states.end())
+    {
+        return std::nullopt;
+    }
+
+    return it->second;
 }

--- a/src/gpio_output.hpp
+++ b/src/gpio_output.hpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "gpio_include.hpp"
 #include "gpio_line_resolver.hpp"
@@ -48,6 +49,14 @@
 class GPIOOutput
 {
 public:
+    struct TestEvent
+    {
+        std::string action;
+        int pin = -1;
+        bool active_high = true;
+        bool logical_state = false;
+    };
+
     /**
      * @brief Default constructor.
      *
@@ -97,10 +106,17 @@ public:
      */
     const std::string &lastError() const noexcept { return last_error_; }
 
+    static void setTestMode(bool enabled) noexcept;
+    static bool testModeEnabled() noexcept;
+    static void clearTestEvents() noexcept;
+    static std::vector<TestEvent> testEvents();
+    static std::optional<bool> testLogicalStateForPin(int pin) noexcept;
+
 private:
     int pin_;
     bool active_high_;
     bool enabled_;
+    bool last_logical_state_;
     std::string last_error_;
     ResolvedGPIOLine resolved_line_;
 

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -731,7 +731,7 @@ static BandGPIOPrepareStatus apply_band_gpio_resolution(
 {
     if (suppress_scheduler_execution_for_test)
     {
-        selector_gpio_drive_enabled = false;
+        selector_gpio_drive_enabled = GPIOOutput::testModeEnabled();
     }
     bandGPIOSelector.setEnabled(selector_gpio_control_enabled);
     bandGPIOSelector.setDriveGPIO(selector_gpio_drive_enabled);
@@ -749,6 +749,15 @@ static BandGPIOPrepareStatus apply_band_gpio_resolution(
         *current_band == resolution.band &&
         selector_gpio_config_matches(*current_config, resolution.config))
     {
+        if (bandGPIOSelector.isBandStateActive() &&
+            !bandGPIOSelector.setBandState(false))
+        {
+            active_band_gpio_prepare_status.store(
+                BandGPIOPrepareStatus::Failed,
+                std::memory_order_release);
+            return BandGPIOPrepareStatus::Failed;
+        }
+
         active_band_gpio_prepare_status.store(
             BandGPIOPrepareStatus::Prepared,
             std::memory_order_release);
@@ -3575,8 +3584,8 @@ bool set_config(bool force)
         }
         else
         {
-            selector_gpio_drive_enabled = false;
-            bandGPIOSelector.setDriveGPIO(false);
+            selector_gpio_drive_enabled = GPIOOutput::testModeEnabled();
+            bandGPIOSelector.setDriveGPIO(selector_gpio_drive_enabled);
         }
 
         const bool keep_selector_gpio_initialized =
@@ -3800,8 +3809,8 @@ bool set_config(bool force)
             }
             else
             {
-                selector_gpio_drive_enabled = false;
-                bandGPIOSelector.setDriveGPIO(false);
+                selector_gpio_drive_enabled = GPIOOutput::testModeEnabled();
+                bandGPIOSelector.setDriveGPIO(selector_gpio_drive_enabled);
             }
 
             const bool keep_selector_gpio_initialized =
@@ -4200,6 +4209,33 @@ std::vector<BandGPIOConfig> initialized_selector_gpios_for_test()
         configs.push_back(reservation.config);
     }
     return configs;
+}
+
+bool selector_gpio_logical_state_for_test(
+    int gpio,
+    bool &logical_state_out) noexcept
+{
+    const BandGPIOConfig *current_config = bandGPIOSelector.currentConfig();
+    if (current_config != nullptr && current_config->gpio == gpio)
+    {
+        logical_state_out = bandGPIOSelector.isBandStateActive();
+        return true;
+    }
+
+    const auto it = std::find_if(
+        idle_selector_gpio_reservations.begin(),
+        idle_selector_gpio_reservations.end(),
+        [gpio](const SelectorGPIOReservation &reservation)
+        {
+            return reservation.config.gpio == gpio;
+        });
+    if (it != idle_selector_gpio_reservations.end())
+    {
+        logical_state_out = false;
+        return true;
+    }
+
+    return false;
 }
 
 void stop_active_transmission_selectors_for_test() noexcept

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -320,6 +320,9 @@ bool current_band_gpio_selection_for_test(
     BandGPIOConfig &config_out,
     std::string &band_label_out) noexcept;
 std::vector<BandGPIOConfig> initialized_selector_gpios_for_test();
+bool selector_gpio_logical_state_for_test(
+    int gpio,
+    bool &logical_state_out) noexcept;
 void stop_active_transmission_selectors_for_test() noexcept;
 bool park_active_transmission_selectors_for_test() noexcept;
 bool restore_committed_band_gpio_selection_for_test(bool assert_state) noexcept;

--- a/src/tests/band_gpio_rotation_test.cpp
+++ b/src/tests/band_gpio_rotation_test.cpp
@@ -60,6 +60,7 @@ namespace
         ppm_reload_pending.store(false, std::memory_order_relaxed);
         exiting_wspr.store(false, std::memory_order_relaxed);
         reset_managed_reload_runtime_for_test();
+        reset_current_transmission_request_for_test();
         set_scheduler_execution_suppressed_for_test(true);
         set_band_gpio_selector_for_test(true, false);
     }
@@ -68,6 +69,38 @@ namespace
     {
         set_band_gpio_selector_for_test(false, false);
         set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    bool apply_scheduler_config_for_test(bool force)
+    {
+        config.transmit = true;
+        config_to_json();
+        return set_config(force);
+    }
+
+    void require_selector_logical_state(
+        int gpio,
+        bool expected_active,
+        const std::string &message)
+    {
+        bool state = false;
+        require(
+            selector_gpio_logical_state_for_test(gpio, state),
+            message + ": GPIO test state must exist");
+        require(
+            state == expected_active,
+            message + ": GPIO logical state must match expected active/inactive state");
+    }
+
+    void require_all_selector_states(
+        std::initializer_list<int> gpios,
+        bool expected_active,
+        const std::string &message)
+    {
+        for (const int gpio : gpios)
+        {
+            require_selector_logical_state(gpio, expected_active, message);
+        }
     }
 
     void require_current_selector(
@@ -167,6 +200,21 @@ namespace
             actual.emplace(active_config.gpio, active_config.active_high);
         }
 
+        if (actual != expected)
+        {
+            std::cerr << "EXPECTED:";
+            for (const auto &[gpio, active_high] : expected)
+            {
+                std::cerr << ' ' << gpio << (active_high ? 'H' : 'L');
+            }
+            std::cerr << "\nACTUAL:";
+            for (const auto &[gpio, active_high] : actual)
+            {
+                std::cerr << ' ' << gpio << (active_high ? 'H' : 'L');
+            }
+            std::cerr << std::endl;
+        }
+
         require(
             actual == expected,
             message + ": initialized selector GPIO set must match expected configured GPIOs");
@@ -229,10 +277,14 @@ int main()
 
     reset_scheduler_test_state();
 
-    require(set_config(true), "scheduler must commit first UI band GPIO entry");
+    require(apply_scheduler_config_for_test(true), "scheduler must commit first UI band GPIO entry");
     require_initialized_selector_set(
         {{17, true}, {27, false}, {22, true}},
         "first UI rotation entry");
+    require_all_selector_states(
+        {17, 27, 22},
+        false,
+        "initial load must drive every configured selector inactive before first TX");
     require_current_selector(
         "80m",
         "80m",
@@ -245,11 +297,37 @@ int main()
         true,
         {{17, true}, {27, false}, {22, true}},
         "first UI rotation entry");
+    require_selector_logical_state(
+        17,
+        true,
+        "selector restore must assert the first configured GPIO for TX start");
+    require(
+        restore_committed_band_gpio_selection_for_test(false),
+        "restoring an already-selected committed request must succeed");
+    require_selector_logical_state(
+        17,
+        false,
+        "committed-request restore must force the reused selector back to inactive before reactivation");
 
-    require(set_config(false), "scheduler must commit second UI band GPIO entry");
+    require(
+        park_active_transmission_selectors_for_test(),
+        "first configured GPIO must park back to idle after its slot");
+    require_all_selector_states(
+        {17, 27, 22},
+        false,
+        "first configured GPIO must be inactive before the next selector is prepared");
+    require(apply_scheduler_config_for_test(false), "scheduler must commit second UI band GPIO entry");
     require_initialized_selector_set(
         {{17, true}, {27, false}, {22, true}},
         "second UI rotation entry");
+    require_selector_logical_state(
+        17,
+        false,
+        "previous active GPIO must remain inactive during next-slot preparation");
+    require_selector_logical_state(
+        27,
+        false,
+        "next selected GPIO must still be inactive until transmission start");
     require_current_selector(
         "40m",
         "40m",
@@ -262,8 +340,27 @@ int main()
         false,
         {{17, true}, {27, false}, {22, true}},
         "second UI rotation entry");
+    require_selector_logical_state(
+        27,
+        true,
+        "second slot activation must assert only the selected GPIO");
+    require_selector_logical_state(
+        17,
+        false,
+        "non-active GPIOs must remain inactive during second slot");
 
-    require(set_config(false), "scheduler must commit third UI band GPIO entry");
+    require(
+        park_active_transmission_selectors_for_test(),
+        "second configured GPIO must park back to idle after its slot");
+    require_all_selector_states(
+        {17, 27, 22},
+        false,
+        "all selectors must be inactive after the second slot completes");
+    require(apply_scheduler_config_for_test(false), "scheduler must commit third UI band GPIO entry");
+    require_all_selector_states(
+        {17, 27, 22},
+        false,
+        "all non-active selectors must stay inactive before third slot activation");
     require_current_selector(
         "30m",
         "30m",
@@ -276,8 +373,31 @@ int main()
         true,
         {{17, true}, {27, false}, {22, true}},
         "third UI rotation entry");
+    require_selector_logical_state(
+        22,
+        true,
+        "third slot activation must assert the selected GPIO");
+    require_selector_logical_state(
+        17,
+        false,
+        "previous selectors must remain inactive during third slot");
+    require_selector_logical_state(
+        27,
+        false,
+        "previous selectors must remain inactive during third slot");
 
-    require(set_config(false), "scheduler must wrap back to first UI band GPIO entry");
+    require(
+        park_active_transmission_selectors_for_test(),
+        "third configured GPIO must park back to idle after its slot");
+    require_all_selector_states(
+        {17, 27, 22},
+        false,
+        "all selectors must be inactive after the third slot completes");
+    require(apply_scheduler_config_for_test(false), "scheduler must wrap back to first UI band GPIO entry");
+    require_all_selector_states(
+        {17, 27, 22},
+        false,
+        "all selectors must still be inactive before the wrapped slot starts");
     require_current_selector(
         "80m",
         "80m",
@@ -296,11 +416,16 @@ int main()
         {"Band GPIO",
          {{"30m", {{"GPIO", 5}, {"Enabled", true}, {"Active High", false}}},
           {"20m", {{"GPIO", 12}, {"Enabled", true}, {"Active High", true}}}}}});
+    reset_scheduler_test_state();
 
-    require(set_config(true), "scheduler must commit first reloaded UI band GPIO entry");
+    require(apply_scheduler_config_for_test(true), "scheduler must commit first reloaded UI band GPIO entry");
     require_initialized_selector_set(
-        {{5, false}, {12, true}},
+        {{5, false}, {12, true}, {17, true}, {27, false}},
         "first reloaded UI rotation entry");
+    require_all_selector_states(
+        {5, 12},
+        false,
+        "mixed-polarity startup must drive every configured selector inactive");
     require_current_selector(
         "30m",
         "30m",
@@ -311,10 +436,13 @@ int main()
         "30m",
         5,
         false,
-        {{5, false}, {12, true}},
+        {{5, false}, {12, true}, {17, true}, {27, false}},
         "first reloaded UI rotation entry");
 
-    require(set_config(false), "scheduler must commit second reloaded UI band GPIO entry");
+    require(apply_scheduler_config_for_test(false), "scheduler must commit second reloaded UI band GPIO entry");
+    require_initialized_selector_set(
+        {{5, false}, {12, true}, {17, true}, {27, false}},
+        "second reloaded UI rotation entry");
     require_current_selector(
         "20m",
         "20m",
@@ -325,14 +453,15 @@ int main()
         "20m",
         12,
         true,
-        {{5, false}, {12, true}},
+        {{5, false}, {12, true}, {17, true}, {27, false}},
         "second reloaded UI rotation entry");
 
     patch_all_from_web({{"WSPR", {{"Frequency", "20m@16H,30m@20H,40m@21H"}}}});
+    reset_scheduler_test_state();
 
-    require(set_config(true), "scheduler must commit first explicit selector entry");
+    require(apply_scheduler_config_for_test(true), "scheduler must commit first explicit selector entry");
     require_initialized_selector_set(
-        {{16, true}, {20, true}, {21, true}},
+        {{5, false}, {12, true}, {16, true}, {17, true}, {20, true}, {21, true}, {27, false}},
         "first explicit selector rotation entry");
     require_current_selector(
         "20m",
@@ -344,12 +473,12 @@ int main()
         "20m",
         16,
         true,
-        {{16, true}, {20, true}, {21, true}},
+        {{5, false}, {12, true}, {16, true}, {17, true}, {20, true}, {21, true}, {27, false}},
         "first explicit selector rotation entry");
 
-    require(set_config(false), "scheduler must commit second explicit selector entry");
+    require(apply_scheduler_config_for_test(false), "scheduler must commit second explicit selector entry");
     require_initialized_selector_set(
-        {{16, true}, {20, true}, {21, true}},
+        {{5, false}, {12, true}, {16, true}, {17, true}, {20, true}, {21, true}, {27, false}},
         "second explicit selector rotation entry");
     require_current_selector(
         "30m",
@@ -361,12 +490,12 @@ int main()
         "30m",
         20,
         true,
-        {{16, true}, {20, true}, {21, true}},
+        {{5, false}, {12, true}, {16, true}, {17, true}, {20, true}, {21, true}, {27, false}},
         "second explicit selector rotation entry");
 
-    require(set_config(false), "scheduler must commit third explicit selector entry");
+    require(apply_scheduler_config_for_test(false), "scheduler must commit third explicit selector entry");
     require_initialized_selector_set(
-        {{16, true}, {20, true}, {21, true}},
+        {{5, false}, {12, true}, {16, true}, {17, true}, {20, true}, {21, true}, {27, false}},
         "third explicit selector rotation entry");
     require_current_selector(
         "40m",
@@ -378,15 +507,8 @@ int main()
         "40m",
         21,
         true,
-        {{16, true}, {20, true}, {21, true}},
+        {{5, false}, {12, true}, {16, true}, {17, true}, {20, true}, {21, true}, {27, false}},
         "third explicit selector rotation entry");
-
-    patch_all_from_web({{"Operation", {{"Transmit", false}}}});
-    require(
-        set_config(true),
-        "scheduler must accept disabling transmit while selector GPIOs are configured");
-    require_all_selector_gpios_released(
-        "disabled transmit");
 
     finish_scheduler_test_state();
 
@@ -427,10 +549,10 @@ int main()
           {"40m", {{"GPIO", 13}, {"Enabled", true}, {"Active High", false}}}}}});
     reset_scheduler_test_state();
 
-    require(set_config(true), "scheduler must commit first explicit selector entry");
+    require(apply_scheduler_config_for_test(true), "scheduler must commit first explicit selector entry");
     require_current_selector("20m@16H", "20m", 16, true, "first explicit selector entry");
 
-    require(set_config(false), "scheduler must commit second explicit selector entry");
+    require(apply_scheduler_config_for_test(false), "scheduler must commit second explicit selector entry");
     require_current_selector("30m@20H", "30m", 20, true, "second explicit selector entry");
     run_final_selector_gpio_shutdown_cleanup_for_test();
     require_shutdown_cleanup_targets(
@@ -444,7 +566,7 @@ int main()
         {"Band GPIO",
          {{"20m", {{"GPIO", 17}, {"Enabled", true}, {"Active High", true}}},
           {"30m", {{"GPIO", 18}, {"Enabled", true}, {"Active High", false}}}}}});
-    require(set_config(true), "scheduler must reload band GPIO selector set");
+    require(apply_scheduler_config_for_test(true), "scheduler must reload band GPIO selector set");
     require_current_selector("20m", "20m", 17, true, "reloaded band GPIO selector set");
     run_final_selector_gpio_shutdown_cleanup_for_test();
     require_shutdown_cleanup_targets(
@@ -458,7 +580,7 @@ int main()
         {"Band GPIO",
          {{"20m", {{"GPIO", -1}, {"Enabled", false}, {"Active High", true}}},
           {"30m", {{"GPIO", -1}, {"Enabled", false}, {"Active High", true}}}}}});
-    require(!set_config(true), "conflicting selector polarity on the same GPIO must be rejected");
+    require(!apply_scheduler_config_for_test(true), "conflicting selector polarity on the same GPIO must be rejected");
 
     finish_scheduler_test_state();
 

--- a/src/tests/selector_shutdown_cleanup_test.cpp
+++ b/src/tests/selector_shutdown_cleanup_test.cpp
@@ -99,8 +99,8 @@ int main()
     {
         BandGPIOConfig active_config;
         std::string active_band;
-        require(
-            !current_band_gpio_selection_for_test(active_config, active_band),
+    require(
+        !current_band_gpio_selection_for_test(active_config, active_band),
             "runtime selector teardown must clear the active selector after parking");
     }
     set_band_gpio_selector_for_test(false, false);


### PR DESCRIPTION
 GPIO could remain activated in between transmissions; this PR makes the processing deterministic.