### PR TITLE
Prevent double persistence during guarded mode changes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -112,6 +112,7 @@ OUT := $(strip $(EXE_NAME))
 TEST_OUT := $(strip $(EXE_NAME)_debug)
 SEMANTICS_TEST_OUT := dial_frequency_semantics_test
 UI_SOURCE_REGRESSION_TEST_OUT := ui_source_regression_test
+GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OUT := guarded_mode_change_persistence_test
 BAND_GPIO_ROTATION_TEST_OUT := band_gpio_rotation_test
 MONITOR_FILE_REGRESSION_TEST_OUT := monitor_file_regression_test
 GPIO_LOOPBACK_TEST_OUT := gpio_loopback_test
@@ -150,6 +151,9 @@ SEMANTICS_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
 UI_SOURCE_REGRESSION_TEST_SRC := tests/ui_source_regression_test.cpp
 UI_SOURCE_REGRESSION_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/ui_source_regression_test.o
 UI_SOURCE_REGRESSION_TEST_DEPS := $(UI_SOURCE_REGRESSION_TEST_OBJ)
+GUARDED_MODE_CHANGE_PERSISTENCE_TEST_SRC := tests/guarded_mode_change_persistence_test.cpp
+GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/guarded_mode_change_persistence_test.o
+GUARDED_MODE_CHANGE_PERSISTENCE_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
 BAND_GPIO_ROTATION_TEST_SRC := tests/band_gpio_rotation_test.cpp
 BAND_GPIO_ROTATION_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/band_gpio_rotation_test.o
 BAND_GPIO_ROTATION_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
@@ -378,6 +382,17 @@ $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT): $(UI_SOURCE_REGRESSION_TEST_DEPS)
 	$(Q)echo "Linking debug: $(UI_SOURCE_REGRESSION_TEST_OUT)"
 	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
 
+$(GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OBJ): $(GUARDED_MODE_CHANGE_PERSISTENCE_TEST_SRC)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)mkdir -p $(DEP_DIR)/tests
+	$(Q)echo "Compiling (debug) $< into $@"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) -MF $(DEP_DIR)/tests/guarded_mode_change_persistence_test.d -c $< -o $@
+
+$(BIN_DIR)/$(GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OUT): $(GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OBJ) $(GUARDED_MODE_CHANGE_PERSISTENCE_TEST_DEPS)
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)echo "Linking debug: $(GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OUT)"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
+
 $(BAND_GPIO_ROTATION_TEST_OBJ): $(BAND_GPIO_ROTATION_TEST_SRC)
 	$(Q)mkdir -p $(dir $@)
 	$(Q)mkdir -p $(DEP_DIR)/tests
@@ -486,7 +501,7 @@ $(BIN_DIR)/$(OUT): $(CPP_OBJECTS)
 # Phony targets
 # ─────────────────────────────────────────────────────────────────────────────
 
-.PHONY: clean release debug test test-tone test-oneshot semantics-test band-gpio-rotation-test selector-shutdown-cleanup-test monitor-file-regression-test gpio-line-resolver-test non-wspr-repeat-policy-test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
+.PHONY: clean release debug test test-tone test-oneshot semantics-test guarded-mode-change-persistence-test band-gpio-rotation-test selector-shutdown-cleanup-test monitor-file-regression-test gpio-line-resolver-test non-wspr-repeat-policy-test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
 DEBUG: debug
 RELEASE: release
 
@@ -518,6 +533,10 @@ semantics-test: $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(UI_SOURCE_REGRESSI
 	$(Q)./$(BIN_DIR)/$(SEMANTICS_TEST_OUT)
 	$(Q)echo "Running UI/source regression tests."
 	$(Q)./$(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT)
+
+guarded-mode-change-persistence-test: $(BIN_DIR)/$(GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OUT)
+	$(Q)echo "Running guarded mode-change persistence regression test."
+	$(Q)./$(BIN_DIR)/$(GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OUT)
 
 band-gpio-rotation-test: $(BIN_DIR)/$(BAND_GPIO_ROTATION_TEST_OUT)
 	$(Q)echo "Running band GPIO rotation regression tests."

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -2900,7 +2900,7 @@ void end_test_tone()
     }
 }
 
-StopTransmissionResult stop_transmission_by_user_request()
+StopTransmissionResult stop_transmission_by_user_request(bool persist_transmit)
 {
     StopTransmissionResult result;
     bool persist_to_ini = false;
@@ -2929,7 +2929,7 @@ StopTransmissionResult stop_transmission_by_user_request()
         config.transmit = false;
         result.transmit_disabled = true;
         config_to_json();
-        persist_to_ini = config.use_ini;
+        persist_to_ini = config.use_ini && persist_transmit;
     }
 
     if (result.transmission_active)
@@ -2976,8 +2976,9 @@ StopTransmissionResult stop_transmission_by_user_request()
     else
     {
         result.persisted = false;
-        result.message =
-            "Transmission stopped and runtime transmit disabled; no INI file is active.";
+        result.message = persist_transmit
+                             ? "Transmission stopped and runtime transmit disabled; no INI file is active."
+                             : "Transmission stopped and runtime transmit disabled without persisting.";
         llog.logS(INFO, result.message);
         send_ws_message("transmit", "stopped");
         return result;

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -272,7 +272,7 @@ struct StopTransmissionResult
     std::string message;
 };
 
-StopTransmissionResult stop_transmission_by_user_request();
+StopTransmissionResult stop_transmission_by_user_request(bool persist_transmit = true);
 
 struct WsprRuntimeStatusSnapshot
 {

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <getopt.h>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <optional>
 #include <string>
@@ -38,6 +39,15 @@ namespace
         std::ofstream out(path, std::ios::trunc);
         require(out.is_open(), "test helper must write " + path);
         out << contents;
+    }
+
+    std::string read_text_file(const std::string &path)
+    {
+        std::ifstream in(path);
+        require(in.is_open(), "test helper must read " + path);
+        return std::string(
+            std::istreambuf_iterator<char>(in),
+            std::istreambuf_iterator<char>());
     }
 
     bool nearly_equal(double lhs, double rhs, double epsilon = 0.01)
@@ -2526,6 +2536,76 @@ int main()
         require(
             wsprTransmitter.getState() != WsprTransmitter::State::TRANSMITTING,
             "user stop helper must leave the transmitter out of TRANSMITTING state");
+
+        set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    {
+        init_default_config();
+        ini_reload_pending.store(false, std::memory_order_relaxed);
+        ini_reload_generation.store(0, std::memory_order_relaxed);
+        exiting_wspr.store(false, std::memory_order_relaxed);
+        reset_current_transmission_request_for_test();
+        set_scheduler_execution_suppressed_for_test(true);
+
+        config.use_ini = true;
+        config.ini_filename = "/tmp/guarded_mode_change_single_persist.ini";
+        config.mode = ModeType::WSPR;
+        config.transmit = true;
+        config.callsign = "AA0NT";
+        config.grid_square = "EM18";
+        config.power_dbm = 20;
+        config.frequencies = "20m";
+        config.gpio_tx_pin = 4;
+        resolve_backend_specific_config(config);
+        config_to_json();
+        write_text_file(config.ini_filename, "");
+        iniFile.set_filename(config.ini_filename);
+        json_to_ini();
+
+        const std::string ini_before_guard = read_text_file(config.ini_filename);
+        const std::uint64_t generation_before_guard =
+            ini_reload_generation.load(std::memory_order_relaxed);
+
+        const StopTransmissionResult guard_stop_result =
+            stop_transmission_by_user_request(false);
+
+        require(
+            guard_stop_result.transmit_disabled && !guard_stop_result.persisted,
+            "guarded mode-change stop must disable runtime transmit without persisting");
+        require(
+            read_text_file(config.ini_filename) == ini_before_guard,
+            "guarded mode-change stop must not rewrite the INI before the final save");
+        require(
+            ini_reload_generation.load(std::memory_order_relaxed) == generation_before_guard,
+            "guarded mode-change stop must not publish an extra persistence generation");
+
+        patch_all_from_web({
+            {"Operation", {{"Mode", "QRSS"}, {"Transmit", false}}},
+            {"CW",
+             {{"Message", "CQ"},
+              {"Base Frequency", 14096900.0},
+              {"Shift Hz", 5.0},
+              {"Dot Seconds", 3.0},
+              {"Intra Element Gap", 1.0},
+              {"Inter Character Gap", 3.0},
+              {"Inter Word Gap", 7.0},
+              {"Start Minute", 0},
+              {"Repeat Minutes", 10}}}
+        });
+
+        const std::string ini_after_guard = read_text_file(config.ini_filename);
+        require(
+            ini_after_guard != ini_before_guard,
+            "guarded mode-change final save must persist the updated mode once");
+        require(
+            ini_reload_generation.load(std::memory_order_relaxed) ==
+                generation_before_guard + 1U,
+            "guarded mode change must produce exactly one persistence generation");
+        require(
+            iniFile.getData().at("Operation").at("Mode") == "QRSS" &&
+                iniFile.getData().at("Operation").at("Transmit") == "false",
+            "guarded mode-change final save must persist the final mode and disabled transmit state");
 
         set_scheduler_execution_suppressed_for_test(false);
     }

--- a/src/tests/guarded_mode_change_persistence_test.cpp
+++ b/src/tests/guarded_mode_change_persistence_test.cpp
@@ -1,0 +1,110 @@
+#include "arg_parser.hpp"
+#include "config_handler.hpp"
+#include "scheduling.hpp"
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+
+namespace
+{
+    void require(bool condition, const std::string &message)
+    {
+        if (!condition)
+        {
+            std::cerr << "FAIL: " << message << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+
+    std::string read_text_file(const std::string &path)
+    {
+        std::ifstream in(path);
+        require(in.is_open(), "test helper must read " + path);
+        return std::string(
+            std::istreambuf_iterator<char>(in),
+            std::istreambuf_iterator<char>());
+    }
+
+    void write_text_file(const std::string &path, const std::string &contents)
+    {
+        std::ofstream out(path, std::ios::trunc);
+        require(out.is_open(), "test helper must write " + path);
+        out << contents;
+    }
+} // namespace
+
+int main()
+{
+    init_default_config();
+    ini_reload_pending.store(false, std::memory_order_relaxed);
+    ini_reload_generation.store(0, std::memory_order_relaxed);
+    exiting_wspr.store(false, std::memory_order_relaxed);
+    reset_current_transmission_request_for_test();
+    set_scheduler_execution_suppressed_for_test(true);
+
+    config.use_ini = true;
+    config.ini_filename = "/tmp/guarded_mode_change_single_persist.ini";
+    config.mode = ModeType::WSPR;
+    config.transmit = true;
+    config.callsign = "AA0NT";
+    config.grid_square = "EM18";
+    config.power_dbm = 20;
+    config.frequencies = "20m";
+    config.gpio_tx_pin = 4;
+    resolve_backend_specific_config(config);
+    config_to_json();
+    write_text_file(config.ini_filename, "");
+    iniFile.set_filename(config.ini_filename);
+    json_to_ini();
+
+    const std::string ini_before_guard = read_text_file(config.ini_filename);
+    const std::uint64_t generation_before_guard =
+        ini_reload_generation.load(std::memory_order_relaxed);
+
+    const StopTransmissionResult guard_stop_result =
+        stop_transmission_by_user_request(false);
+
+    require(
+        guard_stop_result.transmit_disabled && !guard_stop_result.persisted,
+        "guarded mode-change stop must disable runtime transmit without persisting");
+    require(
+        read_text_file(config.ini_filename) == ini_before_guard,
+        "guarded mode-change stop must not rewrite the INI before the final save");
+    require(
+        ini_reload_generation.load(std::memory_order_relaxed) == generation_before_guard,
+        "guarded mode-change stop must not publish an extra persistence generation");
+
+    patch_all_from_web({
+        {"Operation", {{"Mode", "QRSS"}, {"Transmit", false}}},
+        {"CW",
+         {{"Message", "CQ"},
+          {"Base Frequency", 14096900.0},
+          {"Shift Hz", 5.0},
+          {"Dot Seconds", 3.0},
+          {"Intra Element Gap", 1.0},
+          {"Inter Character Gap", 3.0},
+          {"Inter Word Gap", 7.0},
+          {"Start Minute", 0},
+          {"Repeat Minutes", 10}}}
+    });
+
+    const std::string ini_after_guard = read_text_file(config.ini_filename);
+    require(
+        ini_after_guard != ini_before_guard,
+        "guarded mode-change final save must persist the updated mode");
+    require(
+        ini_reload_generation.load(std::memory_order_relaxed) ==
+            generation_before_guard + 1U,
+        "guarded mode change must produce exactly one persistence generation");
+    require(
+        iniFile.getData().at("Operation").at("Mode") == "QRSS" &&
+            iniFile.getData().at("Operation").at("Transmit") == "false",
+        "guarded mode-change final save must persist the final mode and disabled transmit state");
+
+    set_scheduler_execution_suppressed_for_test(false);
+    std::cout << "guarded_mode_change_persistence_test passed" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -52,9 +52,9 @@ int main()
         read_text_file("/home/pi/WsprryPi/src/web_socket.cpp");
     require(
         websocket_source.find("else if (cmd == \"stop\")") != std::string::npos &&
-            websocket_source.find("stop_transmission_by_user_request();") !=
+            websocket_source.find("stop_transmission_by_user_request(persist_transmit);") !=
                 std::string::npos,
-        "websocket stop command must route through stop_transmission_by_user_request()");
+        "websocket stop command must route through stop_transmission_by_user_request() with persistence control");
 
     const std::string scheduling_source =
         read_text_file("/home/pi/WsprryPi/src/scheduling.cpp");
@@ -77,27 +77,27 @@ int main()
     const std::string ui_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/index.js");
     require(
-        ui_source.find("ws.send(JSON.stringify({ command: \"stop\" }))") !=
+        ui_source.find("persist_transmit: persistTransmit") !=
                 std::string::npos,
-        "UI Stop button must send the explicit stop command over the websocket");
+        "UI Stop button must send the explicit stop command over the websocket with persistence control");
     require(
         ui_source.find("let pendingModeChange = null;") != std::string::npos &&
             ui_source.find("let pendingPersistedMode = \"\";") != std::string::npos &&
             ui_source.find("function requestConfigModeChange(targetMode)") != std::string::npos &&
             ui_source.find("title: \"Stop transmission to change mode\"") != std::string::npos &&
             ui_source.find("title: \"Disable transmissions to change mode\"") != std::string::npos &&
-            ui_source.find("requestTransmitEnabledChange(false, true") != std::string::npos &&
+            ui_source.find("requestTransmitEnabledChange(false, true") == std::string::npos &&
             ui_source.find("const requestedMode = normalizedTargetMode;") != std::string::npos &&
             ui_source.find("finalizePendingModeChange(requestedMode);") != std::string::npos &&
-            ui_source.find("syncAutosaveBaselineOnSuccess: false,") != std::string::npos &&
-            ui_source.find("if (!stopTransmission()) {") != std::string::npos &&
+            ui_source.find("setTransmitFromBackend(false);") != std::string::npos &&
+            ui_source.find("if (!stopTransmission({ persistTransmit: false })) {") != std::string::npos &&
             ui_source.find("suspendConfigAutosave(true);") != std::string::npos &&
             ui_source.find("input:not(#transmit, [name=\"mode_toggle\"], [name=\"qrss_type\"])") != std::string::npos &&
             ui_source.find("configAutosaveNeedsRuntimeRefresh = true;") != std::string::npos &&
             ui_source.find("pendingPersistedMode = currentConfigModeSelection;") != std::string::npos &&
             ui_source.find("flushAutosave();") != std::string::npos &&
             ui_source.find("if (configAutosaveNeedsRuntimeRefresh && typeof getTxState === \"function\") {") != std::string::npos,
-        "mode changes must be guarded behind stop/disable confirmation, preserve the unsaved target mode through the disable step, exclude mode toggles from generic autosave scheduling, and refresh runtime state after the committed mode save lands");
+        "mode changes must be guarded behind stop/disable confirmation, collapse the guarded disable-plus-mode flow into one persisted save, exclude mode toggles from generic autosave scheduling, and refresh runtime state after the committed mode save lands");
     require(
         ui_source.find("if (enabled && pendingPersistedMode) {") != std::string::npos &&
             ui_source.find("Wait for the mode change to save before enabling transmissions.") != std::string::npos,

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -345,8 +345,10 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
         else if (cmd == "stop")
         {
             llog.logS(INFO, "Received websocket stop command.");
+            const bool persist_transmit =
+                !j.contains("persist_transmit") || j["persist_transmit"].get<bool>();
             const StopTransmissionResult stop_result =
-                stop_transmission_by_user_request();
+                stop_transmission_by_user_request(persist_transmit);
             const bool stop_request_succeeded = stop_result.transmit_disabled;
             reply["command"] = "stop";
             reply["status"] = stop_request_succeeded ? "ok" : "error";
@@ -354,6 +356,7 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
             reply["stop_performed"] = stop_result.stop_performed;
             reply["transmit_disabled"] = stop_result.transmit_disabled;
             reply["persisted"] = stop_result.persisted;
+            reply["persist_transmit"] = persist_transmit;
             reply["message"] = stop_result.message;
         }
         else if (cmd == "get_tx_state")


### PR DESCRIPTION
- Stop persisting the intermediate transmit-disable step during guarded mode changes
- Add persistence control to websocket stop handling
- Keep explicit stop requests persisted by default
- Add dedicated guarded_mode_change_persistence_test
- Verify guarded stop leaves INI unchanged and final mode save advances reload generation once