### PR TITLE
Fix paired WSPR frame crash by enforcing slot-local request contract

### DIFF
--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -1228,11 +1228,8 @@ static PreparedWsprTransmission slot_plan_for_frame(
     slot_plan.locator_raw = plan.locator_raw;
     slot_plan.callsign_normalized = plan.callsign_normalized;
     slot_plan.locator_normalized = plan.locator_normalized;
-    slot_plan.frame_callsigns = plan.frame_callsigns;
-    slot_plan.frame_locators = plan.frame_locators;
-    slot_plan.total_frame_count =
-        plan.total_frame_count != 0U ? plan.total_frame_count : plan.frameCount();
-    slot_plan.current_frame = frame_index + 1U;
+    slot_plan.total_frame_count = 1U;
+    slot_plan.current_frame = 1U;
     if (frame_index < plan.frame_callsigns.size())
     {
         slot_plan.frame_callsign = plan.frame_callsigns.at(frame_index);
@@ -3495,15 +3492,45 @@ WsprRuntimeStatusSnapshot current_tx_runtime_status_snapshot()
 
     const PreparedWsprTransmission &plan = current_transmission_request.payload;
     snapshot.plan_type = plan.plan_type;
-    snapshot.frame_count =
-        plan.total_frame_count != 0U ? plan.total_frame_count : plan.frameCount();
-    snapshot.current_frame = plan.current_frame;
     snapshot.callsign_raw = plan.callsign_raw;
     snapshot.callsign_normalized =
         !plan.callsign_normalized.empty() ? plan.callsign_normalized : plan.callsign;
     snapshot.locator_raw = plan.locator_raw;
     snapshot.locator_normalized =
         !plan.locator_normalized.empty() ? plan.locator_normalized : plan.locator;
+
+    if (active_wspr_plan_in_progress && !active_wspr_plan.empty())
+    {
+        const PreparedWsprTransmission &active_plan = active_wspr_plan;
+        snapshot.frame_count =
+            active_plan.total_frame_count != 0U
+                ? active_plan.total_frame_count
+                : active_plan.frameCount();
+        snapshot.current_frame = active_wspr_frame_index + 1U;
+        if (active_wspr_frame_index < active_plan.frame_callsigns.size())
+        {
+            snapshot.frame_callsign =
+                active_plan.frame_callsigns.at(active_wspr_frame_index);
+        }
+        else
+        {
+            snapshot.frame_callsign = snapshot.callsign_normalized;
+        }
+        if (active_wspr_frame_index < active_plan.frame_locators.size())
+        {
+            snapshot.frame_locator =
+                active_plan.frame_locators.at(active_wspr_frame_index);
+        }
+        else
+        {
+            snapshot.frame_locator = snapshot.locator_normalized;
+        }
+        return snapshot;
+    }
+
+    snapshot.frame_count =
+        plan.total_frame_count != 0U ? plan.total_frame_count : plan.frameCount();
+    snapshot.current_frame = plan.current_frame;
     snapshot.frame_callsign =
         !plan.frame_callsign.empty() ? plan.frame_callsign : snapshot.callsign_normalized;
     snapshot.frame_locator =

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -2298,11 +2298,33 @@ int main()
         {
             const WsprRuntimeStatusSnapshot snapshot =
                 current_tx_runtime_status_snapshot();
+            const TransmissionRequest request =
+                current_transmission_request_for_test();
             require(
                 snapshot.plan_type == "Type2Type3Paired" &&
                     snapshot.frame_count == 2U &&
                     snapshot.current_frame == 1U,
                 "paired runtime snapshot must expose first-frame progress");
+            require(
+                request.payload.frames.size() == 1U &&
+                    request.payload.current_frame == 1U &&
+                    request.payload.total_frame_count == 1U,
+                "paired first-slot request must carry a self-consistent slot-scoped payload");
+            wsprrypi::TransmissionRequest controller_request;
+            controller_request.mode = wsprrypi::TransmissionMode::WSPR;
+            controller_request.output.backend = wsprrypi::BackendKind::SI5351;
+            controller_request.output.output = wsprrypi::ClockSource::SI5351_CLK0;
+            controller_request.output.gpio = request.tx_gpio;
+            controller_request.calibration.ppm = request.ppm;
+            wsprrypi::WsprPayload first_payload;
+            first_payload.prepared = request.payload;
+            first_payload.base_frequency_hz = request.actual_rf_frequency_hz;
+            controller_request.payload = first_payload;
+            const wsprrypi::ExecutionPlan first_frame_plan =
+                wsprrypi::ExecutionPlanCompiler{}.compile(controller_request);
+            require(
+                first_frame_plan.events.size() == WSPR_SYMBOL_COUNT,
+                "paired first-slot request must compile into one WSPR frame");
             require(
                 snapshot.callsign_normalized == "AA0NT/12" &&
                     snapshot.locator_normalized == "EM18IG" &&
@@ -2320,11 +2342,33 @@ int main()
         {
             const WsprRuntimeStatusSnapshot snapshot =
                 current_tx_runtime_status_snapshot();
+            const TransmissionRequest request =
+                current_transmission_request_for_test();
             require(
                 snapshot.plan_type == "Type2Type3Paired" &&
                     snapshot.frame_count == 2U &&
                     snapshot.current_frame == 2U,
                 "paired runtime snapshot must advance to the second frame after completion");
+            require(
+                request.payload.frames.size() == 1U &&
+                    request.payload.current_frame == 1U &&
+                    request.payload.total_frame_count == 1U,
+                "paired second-slot request must remain slot-local while scheduler runtime status tracks overall paired progress");
+            wsprrypi::TransmissionRequest controller_request;
+            controller_request.mode = wsprrypi::TransmissionMode::WSPR;
+            controller_request.output.backend = wsprrypi::BackendKind::SI5351;
+            controller_request.output.output = wsprrypi::ClockSource::SI5351_CLK0;
+            controller_request.output.gpio = request.tx_gpio;
+            controller_request.calibration.ppm = request.ppm;
+            wsprrypi::WsprPayload second_payload;
+            second_payload.prepared = request.payload;
+            second_payload.base_frequency_hz = request.actual_rf_frequency_hz;
+            controller_request.payload = second_payload;
+            const wsprrypi::ExecutionPlan second_frame_plan =
+                wsprrypi::ExecutionPlanCompiler{}.compile(controller_request);
+            require(
+                second_frame_plan.events.size() == WSPR_SYMBOL_COUNT,
+                "paired second-slot request must compile into one WSPR frame without crashing");
             require(
                 snapshot.callsign_normalized == "AA0NT/12" &&
                     snapshot.locator_normalized == "EM18IG" &&


### PR DESCRIPTION
Resolve a crash when executing frame 2 of Type2Type3 paired WSPR transmissions caused by an inconsistent committed request.

Previously, the scheduler constructed a slot-scoped payload containing a single frame while preserving current_frame as a 1-based index into the original multi-frame plan. Execution interpreted this as an index into the payload frames vector, resulting in an out-of-range access when frames.size() was 1 and current_frame was 2.

This change restores a clear contract:

- Committed WSPR payloads are strictly slot-local
- frames.size() represents only the frame(s) for this execution slot
- current_frame is 1-based within the committed payload
- total_frame_count reflects the payload scope, not full plan progress

Paired transmission progress is now tracked exclusively in scheduler state using active_wspr_plan and active_wspr_frame_index and exposed via runtime status snapshots.

Key changes:

- Make slot_plan_for_frame construct self-consistent single-frame payloads
- Remove dual-index design and active_frame_index field
- Restore execution to use current_frame as payload-local selector
- Move paired progress reporting to scheduler runtime status path
- Update semantics tests to validate slot-local payload invariants

This preserves all core invariants:

- Single commit boundary via commit_execution_request
- Immutable execution snapshot
- Scheduler owns policy, backend executes only
- No hidden state coupling between layers

Result:

- Paired Type2Type3 transmissions execute both frames without crash
- Runtime status correctly reports frame 1 of 2 then frame 2 of 2
- Backend receives consistent, unambiguous execution requests