### PR TITLE
PR: Fix Operations Frequency Panel to Reflect Runtime Scheduler State

### DIFF
--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -3412,6 +3412,9 @@ void send_ws_message(
         j["tx_state"] = tx_state;
         j["runtime_mode"] = snapshot.runtime_mode;
         j["next_transmission_at"] = snapshot.next_transmission_at;
+        j["frequency_hz"] = snapshot.frequency_hz;
+        j["offset_hz"] = snapshot.offset_hz;
+        j["frequency_is_skip"] = snapshot.frequency_is_skip;
         j["plan_type"] = snapshot.plan_type;
         j["frame_count"] = snapshot.frame_count;
         j["current_frame"] = snapshot.current_frame;
@@ -3558,16 +3561,28 @@ WsprRuntimeStatusSnapshot current_tx_runtime_status_snapshot()
 
     if (config.mode == ModeType::WSPR)
     {
-        snapshot.frequency_hz = current_transmission_request.dial_frequency_hz;
-        if (snapshot.frequency_hz <= 0.0)
+        snapshot.frequency_is_skip =
+            current_transmission_request.isSkipWindow() ||
+            (current_dial_frequency == 0.0 &&
+             !current_frequency_entry.token.empty());
+        if (snapshot.frequency_is_skip)
         {
-            snapshot.frequency_hz = current_dial_frequency;
+            snapshot.frequency_hz = 0.0;
+            snapshot.offset_hz = 0.0;
         }
-        if (snapshot.frequency_hz <= 0.0)
+        else
         {
-            snapshot.frequency_hz = first_configured_wspr_dial_frequency_hz();
+            snapshot.frequency_hz = current_transmission_request.dial_frequency_hz;
+            if (snapshot.frequency_hz <= 0.0)
+            {
+                snapshot.frequency_hz = current_dial_frequency;
+            }
+            if (snapshot.frequency_hz <= 0.0)
+            {
+                snapshot.frequency_hz = first_configured_wspr_dial_frequency_hz();
+            }
+            snapshot.offset_hz = current_transmission_request.applied_offset_hz;
         }
-        snapshot.offset_hz = current_transmission_request.applied_offset_hz;
     }
     else if (config.mode == ModeType::QRSS)
     {

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -281,6 +281,7 @@ struct WsprRuntimeStatusSnapshot
     std::string next_transmission_at;
     double frequency_hz = 0.0;
     double offset_hz = 0.0;
+    bool frequency_is_skip = false;
     std::string plan_type;
     std::size_t frame_count = 0;
     std::size_t current_frame = 0; // 1-based, 0 when unavailable

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1808,6 +1808,12 @@ int main(int argc, char *argv[])
         require(
             !skip_request.hasSelectorGPIO(),
             "runtime multi-slot skip regression must not prepare selector GPIO for the trailing skip window");
+        const WsprRuntimeStatusSnapshot skip_snapshot =
+            current_tx_runtime_status_snapshot();
+        require(
+            skip_snapshot.frequency_is_skip &&
+                nearly_equal(skip_snapshot.frequency_hz, 0.0),
+            "runtime snapshots must expose a committed 0 Hz WSPR slot as an explicit skip window");
 
         transmitter_cb(
             WsprTransmissionCallbackEvent::SKIPPED,
@@ -1822,6 +1828,12 @@ int main(int argc, char *argv[])
                 nearly_equal(wrapped_request.dial_frequency_hz, 14095600.0) &&
                 nearly_equal(wrapped_request.actual_rf_frequency_hz, 14097100.0),
             "runtime multi-slot skip regression must wrap cleanly to the next valid transmission after SKIPPED");
+        const WsprRuntimeStatusSnapshot wrapped_snapshot =
+            current_tx_runtime_status_snapshot();
+        require(
+            !wrapped_snapshot.frequency_is_skip &&
+                nearly_equal(wrapped_snapshot.frequency_hz, 14095600.0),
+            "runtime snapshots must return to the next committed WSPR dial frequency after a skip completes");
 
         cleanup_scheduler_regression_test_state();
     }

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -241,12 +241,17 @@ int main()
             site_source.find("nextTransmissionAt") != std::string::npos &&
             site_source.find("frequencyHz") != std::string::npos &&
             site_source.find("offsetHz") != std::string::npos &&
+            site_source.find("frequencyIsSkip") != std::string::npos &&
             site_source.find("cw_message") != std::string::npos &&
             site_source.find("cw_active_char_index") != std::string::npos &&
             site_source.find("if (typeof handleRuntimeStatusUpdate === \"function\") {") != std::string::npos &&
             site_source.find("const selectedMode =\n        typeof selectedConfigMode === \"function\" ? selectedConfigMode() : \"\";") != std::string::npos &&
             site_source.find("renderRuntimeFrequencyPane(frequencyNode, currentMode, currentRuntimeStatus);") != std::string::npos &&
             site_source.find("function buildRuntimeFrequencyItems(currentMode, status)") != std::string::npos &&
+            site_source.find("function runtimeFrequencyPrimaryLabel(currentMode, status)") != std::string::npos &&
+            site_source.find("return \"Next Frequency\";") != std::string::npos &&
+            site_source.find("return \"(Skip)\";") != std::string::npos &&
+            site_source.find("queueRuntimeStatusRefresh();") != std::string::npos &&
             site_source.find("function formatDisplayFrequency(valueHz, options = {})") != std::string::npos &&
             site_source.find("forceUnit: \"Hz\"") != std::string::npos &&
             site_source.find("function renderCwRuntimeMessage(node, message, activeCharIndex)") != std::string::npos &&
@@ -264,12 +269,17 @@ int main()
         scheduling_source.find("snapshot.next_transmission_at") != std::string::npos &&
             scheduling_source.find("snapshot.frequency_hz = current_transmission_request.dial_frequency_hz;") != std::string::npos &&
             scheduling_source.find("snapshot.offset_hz = current_transmission_request.applied_offset_hz;") != std::string::npos &&
+            scheduling_source.find("snapshot.frequency_is_skip =") != std::string::npos &&
             scheduling_source.find("snapshot.frequency_hz = config.qrss.frequency_hz;") != std::string::npos &&
             scheduling_source.find("snapshot.frequency_hz = config.fskcw.space_frequency_hz;") != std::string::npos &&
             scheduling_source.find("snapshot.frequency_hz = config.dfcw.dot_frequency_hz;") != std::string::npos &&
             websocket_source.find("reply[\"next_transmission_at\"] = snapshot.next_transmission_at;") != std::string::npos &&
             websocket_source.find("reply[\"frequency_hz\"] = snapshot.frequency_hz;") != std::string::npos &&
             websocket_source.find("reply[\"offset_hz\"] = snapshot.offset_hz;") != std::string::npos &&
+            websocket_source.find("reply[\"frequency_is_skip\"] = snapshot.frequency_is_skip;") != std::string::npos &&
+            scheduling_source.find("j[\"frequency_hz\"] = snapshot.frequency_hz;") != std::string::npos &&
+            scheduling_source.find("j[\"offset_hz\"] = snapshot.offset_hz;") != std::string::npos &&
+            scheduling_source.find("j[\"frequency_is_skip\"] = snapshot.frequency_is_skip;") != std::string::npos &&
             scheduling_source.find("if (snapshot.tx_state == \"transmitting\")") != std::string::npos &&
             scheduling_source.find("snapshot.runtime_mode = mode_type_name(config.mode);") != std::string::npos &&
             scheduling_source.find("runtime_transmit_enabled(config)") != std::string::npos &&
@@ -320,11 +330,12 @@ int main()
     const std::size_t runtime_plan_position =
         operation_view_source.find("id=\"runtime_plan_label\"");
     require(
-        runtime_mode_position != std::string::npos &&
+            runtime_mode_position != std::string::npos &&
             runtime_frequency_position != std::string::npos &&
             runtime_plan_position != std::string::npos &&
             operation_view_source.find("operation-panel__label operation-panel__label--split") != std::string::npos &&
-            operation_view_source.find("<span>Frequency</span>") != std::string::npos &&
+            operation_view_source.find("id=\"runtime_frequency_primary_label\"") != std::string::npos &&
+            operation_view_source.find(">Frequency</span>") != std::string::npos &&
             runtime_mode_position < runtime_frequency_position &&
             runtime_frequency_position < runtime_plan_position,
         "Operation view must place the Frequency pane between the Current mode and mode-specific runtime panes");

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -369,6 +369,7 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
             reply["next_transmission_at"] = snapshot.next_transmission_at;
             reply["frequency_hz"] = snapshot.frequency_hz;
             reply["offset_hz"] = snapshot.offset_hz;
+            reply["frequency_is_skip"] = snapshot.frequency_is_skip;
             reply["plan_type"] = snapshot.plan_type;
             reply["frame_count"] = snapshot.frame_count;
             reply["current_frame"] = snapshot.current_frame;


### PR DESCRIPTION
## Summary

This PR fixes a live UI/runtime bug (#298) in the Operations tab where the **Frequency panel
always displayed the first configured frequency**, instead of reflecting the actual
scheduler state.

The fix ensures the UI is driven by the **committed runtime scheduler state**, including
proper handling of skip windows (`0`), and updates immediately across transmit lifecycle
events.

---

## Problem

- Operations panel always showed the **first configured frequency**
- Did not update when:
  - advancing through frequency list
  - entering skip windows (`0`)
  - transitioning between transmit / waiting states
- UI relied on **static config fallback**, not runtime state

---

## Solution Overview

### 1. Backend: Expose Explicit Runtime Frequency State

Extended runtime snapshot:

- `frequency_hz`
- `offset_hz`
- `frequency_is_skip` (new)

Key behavior:
- Skip windows (`0`) are explicitly represented instead of falling back
- Snapshot reflects **committed scheduler request**, not configuration

Updated:
- `src/scheduling.hpp`
- `src/scheduling.cpp`
- `src/web_socket.cpp`

---

### 2. WebSocket: Push Complete Runtime State

Transmit events now include:
- `frequency_hz`
- `offset_hz`
- `frequency_is_skip`

Also included in `get_tx_state` response.

---

### 3. UI: Make Frequency Panel State-Driven

Updated Operations UI:

#### Display Rules

| State | Label | Value |
|------|------|------|
| Waiting | Next Frequency | next scheduled frequency |
| Transmitting | Frequency | current frequency |
| Skip window | Frequency / Next Frequency | (Skip) |

#### Behavior

- Panel updates immediately:
  - after transmit completes
  - after skip window
  - after cancel/stop
- Uses runtime state instead of config fallback

#### Skip Handling

- `0` → displayed as `(Skip)`
- No more `0.000000 MHz` or incorrect band fallback

Updated:
- `WsprryPi-UI/data/site.js`
- `WsprryPi-UI/data/views/operation.php`

---

### 4. UI Refresh After Events

Added:
- `queueRuntimeStatusRefresh()`

Triggers fresh state fetch after:
- COMPLETE
- SKIPPED
- STOPPED
- CANCELED

---

### 5. Tests

#### Added / Updated

- Runtime scheduler regression:
  - `20m,30m,0`
  - verifies correct progression and skip handling

- Snapshot validation:
  - ensures skip state is preserved

- UI regression:
  - verifies:
    - dynamic label switching
    - `(Skip)` rendering
    - new JS hooks

Updated:
- `src/tests/dial_frequency_semantics_test.cpp`
- `src/tests/ui_source_regression_test.cpp`

---

## Files Changed

### Parent Repository

- `src/scheduling.hpp`
- `src/scheduling.cpp`
- `src/web_socket.cpp`
- `src/tests/dial_frequency_semantics_test.cpp`
- `src/tests/ui_source_regression_test.cpp`

### UI Submodule (`WsprryPi-UI`)

- `data/site.js`
- `data/views/operation.php`

---

## Submodule Notes

- UI changes are committed in the `WsprryPi-UI` submodule
- Parent repo updates submodule pointer accordingly

---

## Testing

```
cd src
make -j$(nproc)
make semantics-test
```

### Results

- `dial_frequency_semantics_test` — PASSED
- `ui_source_regression_test` — PASSED

---

## Runtime Verification

Tested with:

```
20m 30m 0
```

Observed behavior:

- Waiting → Next Frequency updates correctly
- Transmitting → Frequency updates correctly
- Skip → displays `(Skip)`
- Scheduler advances correctly through all states

---

## Why This Matters

- UI now reflects **actual scheduler behavior**
- Eliminates confusing stale frequency display
- Properly supports skip windows
- Keeps UI aligned with committed execution model

---

## Risk

Low:
- Changes are localized
- Fully covered by tests
- No change to scheduling logic itself

---

## Conclusion

This PR ensures the Operations Frequency panel is accurate, real-time, and
fully aligned with scheduler execution, including proper handling of skip windows.
