### PR TITLE
PR: Display Configured WSPR TX Power in Operations "Current WSPR Plan"

### DIFF
--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -3416,6 +3416,7 @@ void send_ws_message(
         j["offset_hz"] = snapshot.offset_hz;
         j["frequency_is_skip"] = snapshot.frequency_is_skip;
         j["plan_type"] = snapshot.plan_type;
+        j["power_dbm"] = snapshot.power_dbm;
         j["frame_count"] = snapshot.frame_count;
         j["current_frame"] = snapshot.current_frame;
         j["callsign_raw"] = snapshot.callsign_raw;
@@ -3561,6 +3562,7 @@ WsprRuntimeStatusSnapshot current_tx_runtime_status_snapshot()
 
     if (config.mode == ModeType::WSPR)
     {
+        snapshot.power_dbm = config.wspr.power_dbm;
         snapshot.frequency_is_skip =
             current_transmission_request.isSkipWindow() ||
             (current_dial_frequency == 0.0 &&
@@ -3618,6 +3620,7 @@ WsprRuntimeStatusSnapshot current_tx_runtime_status_snapshot()
 
     const PreparedWsprTransmission &plan = current_transmission_request.payload;
     snapshot.plan_type = plan.plan_type;
+    snapshot.power_dbm = plan.power_dbm;
     snapshot.callsign_raw = plan.callsign_raw;
     snapshot.callsign_normalized =
         !plan.callsign_normalized.empty() ? plan.callsign_normalized : plan.callsign;

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -283,6 +283,7 @@ struct WsprRuntimeStatusSnapshot
     double offset_hz = 0.0;
     bool frequency_is_skip = false;
     std::string plan_type;
+    int power_dbm = 0;
     std::size_t frame_count = 0;
     std::size_t current_frame = 0; // 1-based, 0 when unavailable
     std::string callsign_raw;

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -2929,6 +2929,9 @@ int main(int argc, char *argv[])
         require(
             snapshot.frequency_hz > 0.0,
             "runtime snapshots must expose the active WSPR dial frequency");
+        require(
+            snapshot.power_dbm == 20,
+            "runtime snapshots must expose the committed WSPR transmit power in dBm");
         config.transmit = false;
         clear_current_wspr_runtime_state_for_test();
         const WsprRuntimeStatusSnapshot disabled_snapshot =
@@ -2936,6 +2939,9 @@ int main(int argc, char *argv[])
         require(
             disabled_snapshot.frequency_hz > 0.0,
             "idle disabled WSPR runtime snapshots must still expose the next configured dial frequency");
+        require(
+            disabled_snapshot.power_dbm == 20,
+            "idle WSPR runtime snapshots must retain the configured WSPR transmit power in dBm");
         finish_runtime_planning_state_for_identity_test();
     }
 

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -242,6 +242,7 @@ int main()
             site_source.find("frequencyHz") != std::string::npos &&
             site_source.find("offsetHz") != std::string::npos &&
             site_source.find("frequencyIsSkip") != std::string::npos &&
+            site_source.find("powerDbm") != std::string::npos &&
             site_source.find("cw_message") != std::string::npos &&
             site_source.find("cw_active_char_index") != std::string::npos &&
             site_source.find("if (typeof handleRuntimeStatusUpdate === \"function\") {") != std::string::npos &&
@@ -261,6 +262,7 @@ int main()
             site_source.find("planLabelNode.textContent = \"Next message at:\";") != std::string::npos &&
             site_source.find("const idleValue = transmitEnabled") != std::string::npos &&
             site_source.find(": \"Disabled\";") != std::string::npos &&
+            site_source.find("summary += ` ${currentRuntimeStatus.powerDbm}dBm`;") != std::string::npos &&
             site_source.find("charNode.textContent = character;") != std::string::npos &&
             site_source.find("renderCwRuntimeMessage(planNode, message, activeCharIndex);") != std::string::npos &&
             site_source.find("charNode.textContent = isActive && character === \" \" ? \"_\" : character;") == std::string::npos,
@@ -277,9 +279,12 @@ int main()
             websocket_source.find("reply[\"frequency_hz\"] = snapshot.frequency_hz;") != std::string::npos &&
             websocket_source.find("reply[\"offset_hz\"] = snapshot.offset_hz;") != std::string::npos &&
             websocket_source.find("reply[\"frequency_is_skip\"] = snapshot.frequency_is_skip;") != std::string::npos &&
+            websocket_source.find("reply[\"power_dbm\"] = snapshot.power_dbm;") != std::string::npos &&
             scheduling_source.find("j[\"frequency_hz\"] = snapshot.frequency_hz;") != std::string::npos &&
             scheduling_source.find("j[\"offset_hz\"] = snapshot.offset_hz;") != std::string::npos &&
             scheduling_source.find("j[\"frequency_is_skip\"] = snapshot.frequency_is_skip;") != std::string::npos &&
+            scheduling_source.find("j[\"power_dbm\"] = snapshot.power_dbm;") != std::string::npos &&
+            scheduling_source.find("snapshot.power_dbm = plan.power_dbm;") != std::string::npos &&
             scheduling_source.find("if (snapshot.tx_state == \"transmitting\")") != std::string::npos &&
             scheduling_source.find("snapshot.runtime_mode = mode_type_name(config.mode);") != std::string::npos &&
             scheduling_source.find("runtime_transmit_enabled(config)") != std::string::npos &&

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -371,6 +371,7 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
             reply["offset_hz"] = snapshot.offset_hz;
             reply["frequency_is_skip"] = snapshot.frequency_is_skip;
             reply["plan_type"] = snapshot.plan_type;
+            reply["power_dbm"] = snapshot.power_dbm;
             reply["frame_count"] = snapshot.frame_count;
             reply["current_frame"] = snapshot.current_frame;
             reply["callsign_raw"] = snapshot.callsign_raw;


### PR DESCRIPTION
## Summary

This PR updates the Operations tab to include the configured WSPR transmit power
(dBm) in the "Current WSPR Plan" display, and ensures the backend exposes this
value consistently in runtime snapshots.

**Before:**
Type1Single AA0NT EM18

**After:**
Type1Single AA0NT EM18 20dBm

---

## Problem

- The Operations panel did not display WSPR TX power.
- UI only showed callsign and locator.
- Power information existed in configuration but was not surfaced in runtime state.
- This created ambiguity between:
  - WSPR TX Power (dBm)
  - Backend drive power (GPIO / Si5351)

---

## Solution

### 1. Backend: Add `power_dbm` to Runtime Snapshot

Extended:
- `WsprRuntimeStatusSnapshot`

Added:
- `power_dbm` (int)

Behavior:
- When a WSPR plan is active:
  - `power_dbm = plan.power_dbm`
- When idle (no committed plan):
  - `power_dbm = config.wspr.power_dbm`

This ensures:
- Active and waiting UI both reflect configured TX power
- No dependency on backend-specific power levels

---

### 2. WebSocket: Expose Power in Runtime State

Added to:
- Transmit event payloads
- `get_tx_state` response

Field:
- `power_dbm`

---

### 3. UI: Display Power in Plan Summary

Updated:
- `WsprryPi-UI/data/site.js`

Behavior:
- Appends `" <power>dBm"` to plan summary
- Uses runtime state (`powerDbm`)
- Only shown when valid (> 0)

Example:
```
Type1Single AA0NT EM18 20dBm
```

---

### 4. Tests

#### Updated:
- `dial_frequency_semantics_test.cpp`
  - Verifies:
    - Active WSPR snapshot includes correct `power_dbm`
    - Idle snapshot retains configured TX power

- `ui_source_regression_test.cpp`
  - Verifies:
    - UI consumes `powerDbm`
    - Summary string includes `"dBm"`

---

## Files Changed

### Parent Repo
- `src/scheduling.hpp`
- `src/scheduling.cpp`
- `src/web_socket.cpp`
- `src/tests/dial_frequency_semantics_test.cpp`
- `src/tests/ui_source_regression_test.cpp`

### Submodule (`WsprryPi-UI`)
- `data/site.js`

---

## Submodule Notes

- UI changes committed in submodule
- Parent repo updated to new submodule pointer

---

## Testing

```
cd src
make -j$(nproc)
make semantics-test
```

### Results

- `dial_frequency_semantics_test` — PASSED
- `ui_source_regression_test` — PASSED

---

## Runtime Verification

- Operations panel now shows:
  - Correct plan type
  - Callsign
  - Locator
  - Configured TX power (dBm)

- Works for:
  - Active transmission
  - Waiting state
  - Skip windows (no power shown if not applicable)

---

## Why This Matters

- Aligns UI with WSPR protocol semantics
- Removes ambiguity between TX power and hardware drive levels
- Improves operator visibility and confidence
- Keeps UI driven by scheduler/runtime state

---

## Risk

Low:
- Read-only exposure of existing configuration value
- Fully covered by tests
- No changes to transmission behavior

---

## Conclusion

This PR ensures the Operations UI correctly reflects WSPR transmission power,
bringing the display in line with actual transmitted parameters.
