### PR TITLE
PR: Fix Calibration Controls Behavior for WSPR and CW Modes

### DIFF
--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -307,6 +307,14 @@ int main()
         site_source.find("confirm-modal-body--preformatted") != std::string::npos &&
             site_source.find("preserveLineBreaks = options.preserveLineBreaks === true") != std::string::npos,
         "shared confirm modal must support preserving diagnostic line breaks for detail dialogs");
+    require(
+        ui_source.find("function isWsprConfigMode()") != std::string::npos &&
+            ui_source.find("const useNtp = isWsprMode && backend === \"gpio\" && $(\"#use_ntp\").is(\":checked\");") != std::string::npos &&
+            ui_source.find("$(\"#ntp_calibration_control\")") != std::string::npos &&
+            ui_source.find("$ppm.prop(\"disabled\", !isWsprMode || useNtp);") != std::string::npos &&
+            ui_source.find("$ppmCw.prop(\"disabled\", isWsprMode);") != std::string::npos &&
+            ui_source.find("syncCalibrationControls();") != std::string::npos,
+        "config UI must make calibration controls mode-aware so WSPR follows NTP while CW keeps PPM editable");
 
     const std::string config_view_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/views/config.php");
@@ -357,6 +365,10 @@ int main()
     require(
         config_view_source.find("config-runtime-item config-runtime-item--action") == std::string::npos,
         "Runtime state grid must no longer dedicate a large action tile to Stop transmission");
+    require(
+        config_view_source.find("id=\"ntp_calibration_control\"") != std::string::npos &&
+            config_view_source.find("id=\"use_ntp\"") != std::string::npos,
+        "Configuration view must expose the dedicated NTP calibration control wrapper without changing the existing field binding");
     require(
         config_view_source.find("config-runtime-item config-runtime-item--switch") == std::string::npos,
         "Runtime state body must no longer dedicate a body tile to the Transmit enabled control");

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -309,7 +309,8 @@ int main()
         "shared confirm modal must support preserving diagnostic line breaks for detail dialogs");
     require(
         ui_source.find("function isWsprConfigMode()") != std::string::npos &&
-            ui_source.find("const useNtp = isWsprMode && backend === \"gpio\" && $(\"#use_ntp\").is(\":checked\");") != std::string::npos &&
+            ui_source.find("const useNtp = isWsprMode && $(\"#use_ntp\").is(\":checked\");") != std::string::npos &&
+            ui_source.find("backend === \"gpio\" && $(\"#use_ntp\").is(\":checked\");") == std::string::npos &&
             ui_source.find("$(\"#ntp_calibration_control\")") != std::string::npos &&
             ui_source.find("$ppm.prop(\"disabled\", !isWsprMode || useNtp);") != std::string::npos &&
             ui_source.find("$ppmCw.prop(\"disabled\", isWsprMode);") != std::string::npos &&


### PR DESCRIPTION
## Summary

This PR corrects the behavior of calibration controls in the Configuration UI.

Specifically:
- In **WSPR mode**, enabling NTP now properly disables manual PPM input.
- In **CW modes (QRSS, FSKCW, DFCW)**:
  - NTP control is hidden
  - Manual PPM remains fully editable

This aligns the UI with intended behavior and removes incorrect backend-dependent logic.

---

## Problem

Previously:
- PPM input was only disabled when:
  - WSPR mode AND
  - backend === "gpio" AND
  - NTP enabled

This caused incorrect behavior:
- On Si5351 backend, PPM remained editable even when NTP was enabled
- UI logic incorrectly tied calibration behavior to backend instead of mode

---

## Solution

### 1. UI Logic Fix

Updated:
- `WsprryPi-UI/data/index.js`

Change:
```javascript
const useNtp = isWsprMode && $("#use_ntp").is(":checked");
```

Removed:
```javascript
backend === "gpio"
```

### New Behavior

#### WSPR mode:
- NTP ON → PPM disabled
- NTP OFF → PPM enabled

#### CW modes:
- NTP control hidden
- CW PPM (`#ppm_cw`) always enabled

---

## 2. Test Updates

Updated:
- `src/tests/ui_source_regression_test.cpp`

Changes:
- Ensure backend-dependent logic is not present
- Enforce mode-based calibration behavior
- Confirm presence of correct UI bindings

---

## Files Changed

### UI Submodule (`WsprryPi-UI`)
- `data/index.js`

### Parent Repo
- `src/tests/ui_source_regression_test.cpp`

---

## Testing

```
cd src
make -j$(nproc)
make semantics-test
```

### Results

- `dial_frequency_semantics_test` — PASSED
- `ui_source_regression_test` — PASSED

---

## Manual Verification

In browser console:

```javascript
document.getElementById("use_ntp").checked
document.getElementById("ppm").disabled
```

### Expected:

| Mode | NTP | PPM |
|-----|-----|-----|
| WSPR | ON | disabled |
| WSPR | OFF | enabled |
| QRSS/FSKCW/DFCW | any | enabled |
| CW modes | any | NTP hidden |

---

## Why This Matters

- Removes incorrect coupling between backend and calibration UI
- Ensures consistent behavior across all backends
- Matches operator expectations
- Prevents accidental misconfiguration

---

## Risk

Low:
- UI-only change
- No backend impact
- Fully covered by regression tests

---

## Conclusion

This PR ensures calibration controls behave correctly and consistently based on
mode, not backend, restoring expected user experience and correctness.
