### PR TITLE
Add and harden UI update checker with backend version metadata

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -98,7 +98,8 @@ SUBMODULE_SRCDIRS += $(wildcard ./WSPR-Transmitter/src)
 
 PRJ := $(strip $(shell 	url="$$(git remote get-url origin 2>/dev/null)"; 	if [ -n "$$url" ]; then 		echo "$$url" 		| sed -E 's#.*/##; s#\.git$$##'; 	else 		echo unknown; 	fi ))
 EXE_NAME := $(shell echo $(PRJ) | tr '[:upper:]' '[:lower:]')
-BRH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | awk '{ gsub(/[^[:alnum:]]+/, "-"); sub(/-$$/, ""); print }' || echo unknown)
+RAW_BRH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+BRH := $(shell printf '%s\n' "$(RAW_BRH)" | awk '{ gsub(/[^[:alnum:]]+/, "-"); sub(/-$$/, ""); print }' || echo unknown)
 RAW_TAG := $(strip $(shell git describe --tags --match "v[0-9]*" --match "[0-9]*" --abbrev=0 2>/dev/null))
 BASE_VER := $(if $(RAW_TAG),$(patsubst v%,%,$(RAW_TAG)),0.0.0)
 
@@ -106,6 +107,7 @@ PRE := $(shell if [ "$(BRH)" != "main" ] && [ "$(BRH)" != "master" ]; then echo 
 VER := $(BASE_VER)$(PRE)
 
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+FULL_COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 VER := $(shell if ! git describe --tags --exact-match >/dev/null 2>&1; then echo "$(VER)+$(COMMIT)"; else echo "$(VER)"; fi)
 
 OUT := $(strip $(EXE_NAME))
@@ -320,6 +322,8 @@ CXXFLAGS += -I$(abspath ./WSPR-Reference/src/wspr)
 # Build metadata defines
 CXXFLAGS += -DMAKE_TAG=\"$(VER)\" \
             -DMAKE_BRH=\"$(BRH)\" \
+            -DMAKE_RAW_BRH=\"$(RAW_BRH)\" \
+            -DMAKE_COMMIT=\"$(FULL_COMMIT)\" \
             -DMAKE_EXE=\"$(OUT)\" \
             -DMAKE_PRJ=\"$(PRJ)\"
 

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -71,6 +71,8 @@ int main()
         read_text_file("/home/pi/WsprryPi/src/web_socket.cpp");
     const std::string web_server_source =
         read_text_file("/home/pi/WsprryPi/src/web_server.cpp");
+    const std::string makefile_source =
+        read_text_file("/home/pi/WsprryPi/src/Makefile");
     require(
         websocket_source.find("else if (cmd == \"stop\")") != std::string::npos &&
             websocket_source.find("stop_transmission_by_user_request(persist_transmit);") !=
@@ -405,8 +407,12 @@ int main()
             site_source.find("function maybePromptForUiRefresh(serverVersion)") != std::string::npos &&
             site_source.find("maybePromptForUiRefresh(response.ui_version);") != std::string::npos &&
             site_source.find("normalizedServerVersion === dismissedUiRefreshVersion") != std::string::npos &&
-            web_server_source.find("j[\"ui_version\"] = get_raw_version_string();") != std::string::npos,
-        "site.js must detect backend UI version changes using the existing /version response without repeatedly prompting for a dismissed version");
+            web_server_source.find("j[\"ui_version\"] = get_raw_version_string();") != std::string::npos &&
+            web_server_source.find("j[\"wspr_branch\"] = get_exe_raw_branch();") != std::string::npos &&
+            web_server_source.find("j[\"wspr_display_branch\"] = get_exe_branch();") != std::string::npos &&
+            web_server_source.find("j[\"wspr_exe_version\"] = get_exe_version();") != std::string::npos &&
+            web_server_source.find("j[\"wspr_commit\"] = get_exe_commit();") != std::string::npos,
+        "site.js must detect backend UI version changes using the existing /version response, and backend /version must expose raw branch, executable version, and commit metadata");
     require(
         site_source.find("title: \"UI refresh required\"") != std::string::npos &&
             site_source.find("The WsprryPi web interface has been updated. Refresh this page to load the new web pages, CSS, and JavaScript.") != std::string::npos &&
@@ -431,6 +437,87 @@ int main()
             site_source.find("event.key !== \"Escape\"") != std::string::npos &&
             site_source.find("closeFooterMetaPanel();") != std::string::npos,
         "site.js must close the footer About panel on outside click and Escape while keeping click-based toggling");
+    const std::string version_check_display_branch = "version-check";
+    const std::string version_check_raw_branch = "version_check";
+    const std::string version_check_short_sha = "7b05546";
+    const std::string version_check_head_sha =
+        "7b05546abcdef0123456789abcdef0123456789";
+    require(
+        version_check_head_sha.rfind(version_check_short_sha, 0) == 0 &&
+            version_check_display_branch == "version-check" &&
+            version_check_raw_branch == "version_check",
+        "test fixture must model a displayed version-check branch, raw version_check branch, and matching GitHub HEAD short SHA");
+    require(
+        makefile_source.find("RAW_BRH :=") != std::string::npos &&
+            makefile_source.find("BRH := $(shell printf '%s\\n' \"$(RAW_BRH)\"") != std::string::npos &&
+            makefile_source.find("-DMAKE_BRH=\\\"$(BRH)\\\"") != std::string::npos &&
+            makefile_source.find("-DMAKE_RAW_BRH=\\\"$(RAW_BRH)\\\"") != std::string::npos &&
+            makefile_source.find("-DMAKE_COMMIT=\\\"$(FULL_COMMIT)\\\"") != std::string::npos,
+        "build metadata must pass sanitized MAKE_BRH for display, raw MAKE_RAW_BRH for update lookup, and full commit to version.cpp");
+    require(
+        site_source.find("const UPDATE_CHECK_CACHE_SCHEMA_VERSION = 5;") != std::string::npos &&
+            site_source.find("function updateCheckShaMatches(currentSha, targetHeadSha)") != std::string::npos &&
+            site_source.find("return normalizedHead.startsWith(normalizedCurrent);") != std::string::npos &&
+            site_source.find("function updateCheckNoUpdateComparison()") != std::string::npos &&
+            site_source.find("updateCheckShaMatches(versionInfo.currentSha, selectedBranch.headSha)") != std::string::npos &&
+            site_source.find("? updateCheckNoUpdateComparison()") != std::string::npos &&
+            site_source.find(": await compareGithubCommits(versionInfo.currentSha, selectedBranch.headSha)") != std::string::npos &&
+            site_source.find("if (error.status === 404)") != std::string::npos &&
+            site_source.find("updateAvailable: !updateCheckShaMatches(currentSha, headSha)") != std::string::npos &&
+            site_source.find("throw error;") != std::string::npos,
+        "update checker must invalidate stale fallback cache entries and short-circuit matching full or short SHAs before GitHub compare");
+    require(
+        site_source.find("async function isCurrentShaInBranch(currentSha, branchInfo)") != std::string::npos &&
+            site_source.find("return status === \"identical\" || status === \"behind\";") != std::string::npos &&
+            site_source.find("async function selectGithubUpdateBranch(versionInfo)") != std::string::npos &&
+            site_source.find("const currentBranch = versionInfo.currentBranch;") != std::string::npos &&
+            site_source.find("const mainBranch = await lookupGithubBranch(\"main\");") != std::string::npos &&
+            site_source.find("await isCurrentShaInBranch(versionInfo.currentSha, mainBranch)") != std::string::npos &&
+            site_source.find("main membership probe failed") != std::string::npos &&
+            site_source.find("return Object.assign(mainBranch, { fallbackUsed: false });") != std::string::npos &&
+            site_source.find("return Object.assign(develBranch, { fallbackUsed: false });") != std::string::npos &&
+            site_source.find("return Object.assign(await lookupGithubBranch(\"main\"), { fallbackUsed: true });") != std::string::npos &&
+            site_source.find("return Object.assign(await lookupGithubBranch(\"main\"), { fallbackUsed: false });") != std::string::npos &&
+            site_source.find("return Object.assign(await lookupGithubBranch(currentBranch), { fallbackUsed: false });") != std::string::npos &&
+            site_source.find("const selectedBranch = await selectGithubUpdateBranch(versionInfo);") != std::string::npos,
+        "update checker must select upstream main for local devel only when current SHA is part of main, fall back to main when upstream devel is missing, and keep main/feature branch behavior unchanged");
+    require(
+        site_source.find("local devel falling back to upstream main because upstream devel returned HTTP 404") != std::string::npos &&
+            site_source.find("local devel resolved to upstream main because the current SHA is part of main") != std::string::npos &&
+            site_source.find("local devel staying on upstream devel because the current SHA is not part of main") != std::string::npos,
+        "update checker must log devel fallback, devel-to-main resolution, and devel-stays-devel decisions");
+    require(
+        site_source.find("async function resolveReleaseTargetSha(targetCommitish, memo = null)") != std::string::npos &&
+            site_source.find("if (memo instanceof Map && memo.has(target))") != std::string::npos &&
+            site_source.find("return memo.get(target);") != std::string::npos &&
+            site_source.find("return rememberResolvedTarget((await lookupGithubBranch(target)).headSha);") != std::string::npos &&
+            site_source.find("`${UPDATE_CHECK_API_BASE}/git/ref/tags/${encodeURIComponent(target)}`") != std::string::npos &&
+            site_source.find("const resolvedTargets = new Map();") != std::string::npos &&
+            site_source.find("resolvedSha = await resolveReleaseTargetSha(target, resolvedTargets);") != std::string::npos,
+        "release matching must resolve each target_commitish once per scan, try branch lookup before tag lookup, and preserve tag dereferencing");
+    require(
+        site_source.find("const rawBackendBranch = typeof response?.wspr_branch === \"string\"") != std::string::npos &&
+            site_source.find("const rawBackendCommit = typeof response?.wspr_commit === \"string\"") != std::string::npos &&
+            site_source.find("const currentDisplayVersion = rawDisplayVersion || rawUiVersion;") != std::string::npos &&
+            site_source.find("const displayBranch = branchMatch ? branchMatch[1].trim() : \"\";") != std::string::npos &&
+            site_source.find("const currentBranch = rawBackendBranch || displayBranch;") != std::string::npos &&
+            site_source.find("displayBranch,") != std::string::npos &&
+            site_source.find("rawBranch=${versionInfo.currentBranch}") != std::string::npos &&
+            site_source.find("version-check") == std::string::npos &&
+            site_source.find("version_check") == std::string::npos,
+        "update checker must prefer backend wspr_branch/wspr_commit, keep display text independent, and avoid hard-coded branch normalization or branch-name guessing");
+    require(
+        site_source.find("return Object.assign(await lookupGithubBranch(currentBranch), { fallbackUsed: false });") != std::string::npos &&
+            site_source.find("if (error.status !== 404)") != std::string::npos &&
+            site_source.find("return Object.assign(await lookupGithubBranch(\"devel\"), { fallbackUsed: true });") != std::string::npos,
+        "update checker must compare existing non-main/non-devel branches against that branch and fall back to devel only on a true 404");
+    require(
+        site_source.find("Update check parsed displayBranch=") != std::string::npos &&
+            site_source.find("Update check branch lookup:") != std::string::npos &&
+            site_source.find("Update check branch lookup failed for") != std::string::npos &&
+            site_source.find("Update check branch lookup result for") != std::string::npos &&
+            site_source.find("Update check selected targetBranch=") != std::string::npos,
+        "update checker must log parsed display branch, raw branch/SHA, branch lookup URL/status/result, selected target branch, fallback state, and target HEAD for debugging");
     require(
         ui_source.find("function isWsprConfigMode()") != std::string::npos &&
             ui_source.find("const useNtp = isWsprMode && $(\"#use_ntp\").is(\":checked\");") != std::string::npos &&

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -142,6 +142,14 @@ constexpr std::string_view to_string_view(T value) noexcept
 #define MAKE_BRH "unknown" ///< Fallback for the branch name.
 #endif
 
+#ifndef MAKE_RAW_BRH
+#define MAKE_RAW_BRH "unknown" ///< Fallback for the raw branch name.
+#endif
+
+#ifndef MAKE_COMMIT
+#define MAKE_COMMIT "unknown" ///< Fallback for the commit SHA.
+#endif
+
 #ifndef MAKE_EXE
 #define MAKE_EXE "unknown" ///< Fallback for the executable name.
 #endif
@@ -153,6 +161,8 @@ constexpr std::string_view to_string_view(T value) noexcept
 // Compile-time string views for sanitized values
 constexpr std::string_view SANITIZED_TAG = to_string_view(MAKE_TAG); ///< Sanitized build tag.
 constexpr std::string_view SANITIZED_BRH = to_string_view(MAKE_BRH); ///< Sanitized branch name.
+constexpr std::string_view RAW_BRH = to_string_view(MAKE_RAW_BRH); ///< Raw branch name.
+constexpr std::string_view SANITIZED_COMMIT = to_string_view(MAKE_COMMIT); ///< Sanitized commit SHA.
 constexpr std::string_view SANITIZED_EXE = to_string_view(MAKE_EXE); ///< Sanitized executable name.
 constexpr std::string_view SANITIZED_PRJ = to_string_view(MAKE_PRJ); ///< Sanitized project name.
 
@@ -180,6 +190,32 @@ std::string get_exe_version()
 std::string get_exe_branch()
 {
     return std::string(SANITIZED_BRH);
+}
+
+/**
+ * @brief Retrieves the raw branch name.
+ *
+ * This function returns the Git branch name associated with the build.
+ * If the `MAKE_RAW_BRH` macro is not defined, it returns "unknown".
+ *
+ * @return A `std::string` representing the raw build branch name.
+ */
+std::string get_exe_raw_branch()
+{
+    return std::string(RAW_BRH);
+}
+
+/**
+ * @brief Retrieves the current commit SHA.
+ *
+ * This function returns the Git commit SHA associated with the build.
+ * If the `MAKE_COMMIT` macro is not defined, it returns "unknown".
+ *
+ * @return A `std::string` representing the build commit SHA.
+ */
+std::string get_exe_commit()
+{
+    return std::string(SANITIZED_COMMIT);
 }
 
 /**

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -52,6 +52,34 @@ extern std::string get_project_name();
 extern std::string get_exe_name();
 
 /**
+ * @brief Retrieves the executable semantic version.
+ *
+ * @return A `std::string` representing the executable version.
+ */
+extern std::string get_exe_version();
+
+/**
+ * @brief Retrieves the build branch name.
+ *
+ * @return A `std::string` representing the build branch name.
+ */
+extern std::string get_exe_branch();
+
+/**
+ * @brief Retrieves the raw build branch name.
+ *
+ * @return A `std::string` representing the raw build branch name.
+ */
+extern std::string get_exe_raw_branch();
+
+/**
+ * @brief Retrieves the build commit SHA.
+ *
+ * @return A `std::string` representing the build commit SHA.
+ */
+extern std::string get_exe_commit();
+
+/**
  * @brief Retrieves the current debug state based on the build configuration.
  *
  * This function determines whether the current build is a debug or release

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -214,6 +214,10 @@ void WebServer::start(int port)
               nlohmann::json j;
               j["wspr_version"] = version;
               j["ui_version"] = get_raw_version_string();
+              j["wspr_branch"] = get_exe_raw_branch();
+              j["wspr_display_branch"] = get_exe_branch();
+              j["wspr_exe_version"] = get_exe_version();
+              j["wspr_commit"] = get_exe_commit();
               res.set_content(j.dump(4), "application/json");
             });
 


### PR DESCRIPTION
## Overview

Introduce a UI-side update checker backed by GitHub and progressively harden it to be:

- Branch-accurate
- SHA-accurate
- Robust against API edge cases
- Independent of display string parsing

This PR includes both the initial implementation and subsequent hardening.

---

## Initial implementation

- Add UI update checker using GitHub API
- Fetch branch HEAD via:
  - `/repos/WsprryPi/WsprryPi/branches/{branch}`
- Compare current commit vs upstream HEAD
- Show modal when update is available
- Add footer indicator with warning styling
- Cache results for one hour
- Suppress repeated modal prompts per update target

---

## Backend version metadata

- Add structured fields to `/version`:
  - `wspr_branch` (raw Git branch)
  - `wspr_display_branch` (sanitized for UI)
  - `wspr_commit` (full 40-character SHA)
  - `wspr_exe_version`
- Preserve existing display strings

### Build metadata split

- `MAKE_BRH` → sanitized display branch
- `MAKE_RAW_BRH` → actual Git branch
- `MAKE_COMMIT` → full commit SHA

### New backend functions

- `get_exe_raw_branch()`
- `get_exe_commit()`

---

## UI parsing changes

- Use `wspr_branch` as the source of truth for GitHub lookup
- Use `wspr_commit` for SHA comparison
- Keep display version unchanged
- Retain display parsing only as a fallback for older backends
- Remove all branch-name normalization and guessing

---

## Devel branch hardening

When the local branch is `devel`:

- Try upstream `devel`
- If upstream `devel` returns 404 → fall back to `main`
- If upstream `devel` exists:
  - Probe whether current SHA is part of `main`
  - If yes → use `main`
  - Otherwise → stay on `devel`

### Membership detection

- Use GitHub compare API
- Treat `identical` and `behind` as “part of main”

### Resilience

- Main membership probe is best-effort
- Failures do not break update detection
- Fallback continues with upstream `devel`

---

## Compare API hardening

- Handle HTTP 404 from compare:
  - If SHA matches → no update
  - If SHA differs → update available
- Prevent false negatives when comparing non-reachable commits
- Support both short and full SHA comparisons

---

## Release resolution improvements

- Resolve branch before tag
- Avoid unnecessary `/git/ref/tags/*` calls
- Add per-scan memoization for `target_commitish`
- Preserve annotated tag dereferencing

---

## UI behavior

- Modal shown once per update target
- Footer warning persists after dismiss
- Tooltip: “An update is available”
- Link points to release if available, otherwise releases page
- Modal state isolated from other confirm flows

---

## Caching

- Add schema versioning
- Increment to `UPDATE_CHECK_CACHE_SCHEMA_VERSION = 5`
- Invalidate stale or incorrect cached results

---

## Testing

- Extend `ui_source_regression_test.cpp` to cover:
  - Raw vs display branch separation
  - Devel → main resolution
  - Compare 404 fallback behavior
  - Release resolution memoization
  - Cache schema invalidation

### Manual testing

- Mock GitHub responses via fetch override
- Validate all branch selection paths:
  - main
  - devel
  - feature branches
  - missing branches
- Verify modal suppression and footer behavior
- Confirm no repeated tag lookup noise

---

## Verification

- `node --check WsprryPi-UI/data/site.js`
- `make -j$(nproc) build/bin/ui_source_regression_test`
- `./build/bin/ui_source_regression_test`

---

## Result

- Accurate branch selection using real Git metadata
- No dependence on display string parsing
- Robust handling of GitHub API edge cases
- Clean API usage with reduced noise
- Correct behavior across main, devel, and feature branches
