### PR TITLE
Fix guarded mode switching and disabled-mode config handling

### DIFF
--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1547,7 +1547,9 @@ bool validate_config_candidate(
     }
 
     const bool frequencies_ok = set_frequencies(candidate);
-    if (!frequencies_ok && !trim_copy_string(candidate.frequencies).empty())
+    if (candidate.transmit &&
+        !frequencies_ok &&
+        !trim_copy_string(candidate.frequencies).empty())
     {
         if (error_message != nullptr && error_message->empty())
         {
@@ -1668,7 +1670,10 @@ bool validate_config_candidate(
 
     if (candidate.mode == ModeType::QRSS)
     {
-        if (!has_qrss_startup_request() &&
+        const bool transmit_validation_required =
+            candidate.transmit || has_qrss_startup_request();
+        if (transmit_validation_required &&
+            !has_qrss_startup_request() &&
             !persisted_qrss_config_available(candidate))
         {
             if (error_message != nullptr)
@@ -1678,12 +1683,17 @@ bool validate_config_candidate(
             return false;
         }
 
-        return validate_non_wspr_repeat_interval_policy(candidate, error_message);
+        return transmit_validation_required
+                   ? validate_non_wspr_repeat_interval_policy(candidate, error_message)
+                   : true;
     }
 
     if (candidate.mode == ModeType::FSKCW)
     {
-        if (!has_fskcw_startup_request() &&
+        const bool transmit_validation_required =
+            candidate.transmit || has_fskcw_startup_request();
+        if (transmit_validation_required &&
+            !has_fskcw_startup_request() &&
             !persisted_fskcw_config_available(candidate))
         {
             if (error_message != nullptr)
@@ -1693,12 +1703,17 @@ bool validate_config_candidate(
             return false;
         }
 
-        return validate_non_wspr_repeat_interval_policy(candidate, error_message);
+        return transmit_validation_required
+                   ? validate_non_wspr_repeat_interval_policy(candidate, error_message)
+                   : true;
     }
 
     if (candidate.mode == ModeType::DFCW)
     {
-        if (!has_dfcw_startup_request() &&
+        const bool transmit_validation_required =
+            candidate.transmit || has_dfcw_startup_request();
+        if (transmit_validation_required &&
+            !has_dfcw_startup_request() &&
             !persisted_dfcw_config_available(candidate))
         {
             if (error_message != nullptr)
@@ -1708,7 +1723,9 @@ bool validate_config_candidate(
             return false;
         }
 
-        return validate_non_wspr_repeat_interval_policy(candidate, error_message);
+        return transmit_validation_required
+                   ? validate_non_wspr_repeat_interval_policy(candidate, error_message)
+                   : true;
     }
 
     if (candidate.mode != ModeType::WSPR)

--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -1828,7 +1828,8 @@ namespace
             }
 
             nlohmann::json semantic_error_details;
-            if (!validate_wspr_semantics(
+            if (candidate_config.transmit &&
+                !validate_wspr_semantics(
                     candidate_config,
                     &validation_error,
                     &semantic_error_details))
@@ -2131,7 +2132,8 @@ void patch_all_from_web(const nlohmann::json &j)
             throw std::runtime_error(error_message);
         }
 
-        if (!validate_wspr_semantics(
+        if (candidate_config.transmit &&
+            !validate_wspr_semantics(
                 candidate_config,
                 &error_message,
                 &error_details))

--- a/src/tests/guarded_mode_change_persistence_test.cpp
+++ b/src/tests/guarded_mode_change_persistence_test.cpp
@@ -3,6 +3,7 @@
 #include "scheduling.hpp"
 
 #include <cstdlib>
+#include <exception>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -44,6 +45,7 @@ int main()
     exiting_wspr.store(false, std::memory_order_relaxed);
     reset_current_transmission_request_for_test();
     set_scheduler_execution_suppressed_for_test(true);
+    set_si5351_detection_override_for_test(true);
 
     config.use_ini = true;
     config.ini_filename = "/tmp/guarded_mode_change_single_persist.ini";
@@ -53,7 +55,7 @@ int main()
     config.grid_square = "EM18";
     config.power_dbm = 20;
     config.frequencies = "20m";
-    config.gpio_tx_pin = 4;
+    config.transmit_backend = TransmitBackendKind::SI5351;
     resolve_backend_specific_config(config);
     config_to_json();
     write_text_file(config.ini_filename, "");
@@ -78,17 +80,7 @@ int main()
         "guarded mode-change stop must not publish an extra persistence generation");
 
     patch_all_from_web({
-        {"Operation", {{"Mode", "QRSS"}, {"Transmit", false}}},
-        {"CW",
-         {{"Message", "CQ"},
-          {"Base Frequency", 14096900.0},
-          {"Shift Hz", 5.0},
-          {"Dot Seconds", 3.0},
-          {"Intra Element Gap", 1.0},
-          {"Inter Character Gap", 3.0},
-          {"Inter Word Gap", 7.0},
-          {"Start Minute", 0},
-          {"Repeat Minutes", 10}}}
+        {"Operation", {{"Mode", "QRSS"}, {"Transmit", false}}}
     });
 
     const std::string ini_after_guard = read_text_file(config.ini_filename);
@@ -104,7 +96,25 @@ int main()
             iniFile.getData().at("Operation").at("Transmit") == "false",
         "guarded mode-change final save must persist the final mode and disabled transmit state");
 
+    bool transmit_enable_rejected = false;
+    try
+    {
+        patch_all_from_web({
+            {"Operation", {{"Transmit", true}}}
+        });
+    }
+    catch (const std::exception &e)
+    {
+        transmit_enable_rejected =
+            std::string(e.what()).find("Missing QRSS configuration") !=
+            std::string::npos;
+    }
+    require(
+        transmit_enable_rejected,
+        "missing QRSS configuration must still prevent enabling transmit");
+
     set_scheduler_execution_suppressed_for_test(false);
+    clear_si5351_detection_override_for_test();
     std::cout << "guarded_mode_change_persistence_test passed" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -125,12 +125,18 @@ int main()
             ui_source.find("function persistDisabledModeChange(targetMode, previousMode = currentConfigModeSelection)") != std::string::npos &&
             ui_source.find("\"Mode\": normalizedTargetMode,") != std::string::npos &&
             ui_source.find("\"Transmit\": false,") != std::string::npos &&
-            ui_source.find("applyCommittedConfigMode(normalizedTargetMode, { skipAutosave: true });") != std::string::npos &&
+            ui_source.find("applyCommittedConfigMode(normalizedTargetMode, {\n                skipAutosave: true,\n                keepAutosaveSuspended: true,\n            });") != std::string::npos &&
+            ui_source.find("options.keepAutosaveSuspended !== true") != std::string::npos &&
+            ui_source.find("function suppressNextPersistedConfigDraftRestore()") != std::string::npos &&
+            ui_source.find("populateConfig();") != std::string::npos &&
+            ui_source.find("shouldSuppressDisabledModeSwitchReloadFailure(message)") != std::string::npos &&
             ui_source.find("clearPendingModeChange();") != std::string::npos &&
             ui_source.find("pendingModeChange.awaitingRuntimeIdle === false") != std::string::npos &&
             ui_source.find("requestTransmitEnabledChange(false, true") == std::string::npos &&
             ui_source.find("setTransmitFromBackend(false);") != std::string::npos &&
-            ui_source.find("if (!stopTransmission({ persistTransmit: false })) {") != std::string::npos &&
+            ui_source.find("function startGuardedActiveModeChange()") != std::string::npos &&
+            ui_source.find("completeGuardedActiveModeChange();") != std::string::npos &&
+            ui_source.find("guardedActiveModeChange: true,") != std::string::npos &&
             ui_source.find("suspendConfigAutosave(true);") != std::string::npos &&
             ui_source.find("input:not(#transmit, [name=\"mode_toggle\"], [name=\"qrss_type\"])") != std::string::npos &&
             ui_source.find("configAutosaveNeedsRuntimeRefresh = true;") != std::string::npos &&


### PR DESCRIPTION
- Replace fire-and-forget guarded mode switch flow with explicit stop-ack-driven sequencing
- Keep mode-switch modal open until stop + mode PATCH complete
- Add guarded active mode-change workflow helpers and timeout handling
- Route stop acknowledgements case-insensitively and accept stable status=ok stop responses
- Prevent stale runtime idle events from completing guarded mode changes
- Allow Operation.Mode changes while Operation.Transmit=false even when mode-specific transmit config is incomplete
- Keep QRSS/FSKCW/DFCW/WSPR transmit validation enforced when enabling transmit
- Gate WSPR semantic validation on transmit-enabled state
- Preserve scheduler commit_execution_request() boundaries
- Prevent autosave/draft restore from overwriting backend-refreshed mode data after guarded mode switches
- Suppress transient disabled-mode reload validation popups during accepted non-transmitting mode switches
- Refresh backend config after guarded mode PATCH success
- Add/update guarded mode-switch and UI regression coverage