### PR TITLE
Merge QRSS Timing to Devel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,322 @@
+# WsprryPi Repository Instructions
+
+These instructions apply to the entire WsprryPi repository unless a more specific nested `AGENTS.md` overrides them.
+
+## Working Principles
+
+- Inspect the current repository, branch, working-tree status, submodule status, and relevant implementation contracts before acting.
+- Keep work tightly within the user-approved scope.
+- Preserve all existing changes. A dirty working tree belongs to the user unless explicitly stated otherwise.
+- Do not discard, overwrite, reset, stage, commit, amend, rebase, push, or create a pull request unless the user explicitly requests that action.
+- Do not broaden a focused feature, fix, documentation task, or investigation into adjacent cleanup or refactoring.
+- Prefer the smallest maintainable change that satisfies the requested behavior.
+- Distinguish clearly among:
+  - implemented behavior
+  - planned or proposed behavior
+  - explicit non-goals
+  - unresolved decisions
+  - validation still required
+- Never describe work as complete unless the required implementation, tests, documentation review, and applicable runtime validation have actually been completed.
+
+## Request Boundaries
+
+- For research, review, diagnosis, planning, or report-only requests:
+  - Inspect relevant files and evidence.
+  - Report findings and recommendations.
+  - Do not modify files or operational state.
+- For implementation requests:
+  - Make only the approved changes.
+  - Add or update appropriate tests.
+  - Review documentation impact.
+  - Run safe, relevant validation.
+- If a task is divided into approved slices, implement only the current slice. Do not silently begin later slices.
+- If an ambiguity would materially change behavior, compatibility, persistence, hardware operation, or user workflow, stop and ask for direction.
+
+## Raspberry Pi and Hardware Safety
+
+WsprryPi controls radio-transmission and Raspberry Pi hardware.
+
+Unless the user explicitly authorizes live hardware operation, do not:
+
+- start a transmission
+- generate a test tone
+- key transmitter GPIO
+- change GPIO state
+- exercise attached transmitter hardware
+- install or replace the running binary
+- stop, start, enable, disable, or restart system services
+- change system configuration
+- reboot or shut down the Raspberry Pi
+- run installation or removal targets
+- use `sudo` for a mutating action
+
+Treat compilation, non-hardware unit tests, source inspection, and configuration validation as distinct from live-device qualification.
+
+Never claim that hardware, RF output, GPIO timing, service lifecycle, or installation behavior has been validated solely because source-level tests passed.
+
+Before any authorized live transmission, confirm the exact frequency, mode, duration, output path, attached hardware, and stopping procedure.
+
+## User Interface Work: Impeccable Is Required
+
+Any task affecting a user interface must use the Impeccable skill.
+
+UI work includes, but is not limited to:
+
+- HTML, PHP templates, CSS, or JavaScript presentation
+- forms, settings, controls, navigation, dialogs, and status feedback
+- responsive or mobile behavior
+- accessibility
+- wording, labels, hints, validation messages, and operator workflow
+- screenshots or documentation depicting the UI
+
+For every UI task:
+
+1. Read and follow the Impeccable skill before making UI changes.
+2. Inspect the existing design language and interaction patterns.
+3. Preserve established visual and behavioral consistency unless a redesign is explicitly requested.
+4. Use Impeccable during design or implementation, not merely as a final mention.
+5. Render and inspect the resulting interface at applicable desktop and mobile sizes.
+6. Address relevant Impeccable findings or explain why a finding is not applicable.
+7. Report the UI workflow exercised and the visual evidence reviewed.
+
+If the Impeccable skill is missing, unavailable, or cannot be used, stop before making UI changes and tell the user what is unavailable. Do not silently substitute another visual-review workflow.
+
+Do not commit local skill/runtime artifacts such as `.agents/`, `.impeccable/`, `.claude/`, or `.codex/` unless the user explicitly requests them and they are intended repository content.
+
+## Submodule Policy
+
+WsprryPi uses Git submodules in two distinct roles:
+
+- `WsprryPi-UI` at the repository root contains the first-party application web interface.
+- Submodules under `src/` provide libraries and supporting components used by the C++ application.
+
+Treat every submodule as a separate Git repository with its own branch, working tree, history, tests, and commit boundary.
+
+### Initial Inspection
+
+Before building, testing, or modifying code, inspect the parent repository and all submodules:
+
+```sh
+git status --short --branch
+git submodule status --recursive
+git submodule foreach --recursive 'git status --short --branch'
+```
+
+Interpret submodule status carefully:
+
+- A leading `-` means the submodule is not initialized.
+- A leading `+` means it is checked out at a commit different from the parent repository’s recorded commit.
+- A dirty submodule contains local changes that must be preserved.
+- A detached `HEAD` is common for a checked-out submodule and must not be mistaken for an error or permission to discard work.
+
+Report unexpected, dirty, uninitialized, or mismatched submodule state before making changes that could affect it.
+
+### Initialization
+
+When required for inspection, building, or testing, initialize submodules at the commits recorded by the parent repository:
+
+```sh
+git submodule update --init --recursive
+```
+
+Do not use any of the following unless the user explicitly requests a dependency update:
+
+```sh
+git submodule update --remote
+git submodule foreach git pull
+git submodule foreach git reset --hard
+```
+
+Do not automatically move a submodule to its latest upstream branch. The parent repository’s recorded commit is the authoritative dependency version.
+
+Do not change submodule URLs, branches, or `.gitmodules` configuration unless that is explicitly in scope.
+
+### Root UI Submodule
+
+`WsprryPi-UI` is the editable first-party web UI.
+
+For UI work:
+
+- Follow the mandatory Impeccable workflow.
+- Verify that `WsprryPi-UI` is initialized at the commit recorded by the parent repository.
+- Inspect the UI submodule’s branch and working-tree status separately.
+- Make UI source changes inside `WsprryPi-UI`.
+- Do not replace missing UI sources with copies from an installed web root, generated output, or another checkout.
+- Coordinate UI behavior with the parent repository’s configuration, validation, persistence, websocket, scheduling, and runtime contracts.
+- Run UI-specific tests in the UI repository and applicable integration or source-regression tests in the parent repository.
+- Treat the UI commit and the parent repository’s updated submodule pointer as separate reviewable changes.
+
+Do not update the parent repository’s `WsprryPi-UI` pointer until the intended UI commit exists and has been reviewed.
+
+### `src/` Dependency Submodules
+
+Submodules under `src/` are dependencies and must be treated as read-only by default.
+
+- Do not modify a `src/` submodule merely to work around a parent-repository problem.
+- Do not update a dependency revision as incidental cleanup.
+- Do not apply formatting, refactoring, warning cleanup, or modernization inside dependency submodules unless explicitly requested.
+- If a required fix appears to belong in a dependency, report:
+  - the affected submodule
+  - its current recorded commit
+  - the suspected defect
+  - why a parent-level fix would be inappropriate
+  - the proposed dependency change and validation
+- Obtain approval before editing the dependency submodule.
+- Keep dependency changes independently buildable and testable where its repository supports that.
+- Update the parent repository’s submodule pointer only after the dependency change has been reviewed and committed in the dependency repository.
+
+Never conceal a dependency modification inside an otherwise parent-only change.
+
+### Dirty Submodules
+
+Existing submodule changes belong to the user.
+
+- Do not reset, clean, switch, checkout, stash, rebase, or overwrite a dirty submodule.
+- Do not run recursive commands that could mutate every submodule.
+- Work around unrelated dirty submodules when safe.
+- If the requested work overlaps a dirty submodule, inspect the existing changes and continue from them only when the task clearly authorizes that scope.
+- Otherwise stop and ask for direction.
+
+### Commit and Push Ordering
+
+Do not commit or push unless explicitly requested.
+
+When an authorized change includes a submodule:
+
+1. Review the submodule diff.
+2. Run the submodule’s relevant tests.
+3. Commit the submodule change in that submodule repository.
+4. Ensure the submodule commit is available on its intended remote before publishing a parent commit that references it.
+5. Review the parent repository diff, including the exact old and new submodule commit IDs.
+6. Commit the parent repository’s pointer update separately or as an explicitly reviewed part of the parent change.
+7. Push only the repositories the user authorized.
+
+Never push a parent commit whose submodule pointer refers only to an unpushed local commit. That would leave other checkouts unable to initialize the recorded revision.
+
+### Validation and Reporting
+
+Build and test against the exact submodule commits recorded by the parent repository unless the approved task intentionally changes them.
+
+In the completion report, state:
+
+- parent repository branch and working-tree state
+- initialized and uninitialized submodules
+- dirty or mismatched submodules
+- every submodule modified
+- old and new submodule commit IDs, if pointers changed
+- tests run inside each affected submodule
+- integration tests run in the parent repository
+- whether submodule commits and parent-pointer commits were created or pushed
+
+Do not describe the parent repository as clean when one of its submodules is dirty or checked out at an unexpected commit.
+
+## Configuration and Compatibility
+
+- Inspect the full configuration lifecycle before changing settings:
+  - defaults
+  - file or JSON parsing
+  - validation
+  - internal configuration structures
+  - web form population
+  - autosave or persistence
+  - serialization
+  - scheduling and runtime consumption
+  - tests and documentation
+- Preserve compatibility with existing valid configurations unless a migration is explicitly approved.
+- Do not silently replace or normalize a user’s custom value merely because the UI introduces a preset.
+- Keep displayed units and persisted semantics accurate. Distinguish seconds, hertz, PPM, minutes, and dot-length multipliers.
+- Keep QRSS, FSKCW, and DFCW shared timing behavior synchronized where the existing configuration contract requires it.
+- Ensure disabled or derived controls still produce an intentional and valid persisted configuration.
+- Treat previews and transient UI selections separately from persisted settings unless the user explicitly approves immediate persistence.
+
+## Operator Workflow
+
+- Evaluate changes from the operator’s point of view, not only from the underlying data model.
+- Put action feedback near the control that triggered it.
+- Make disabled, derived, pending, invalid, and saved states visually and semantically clear.
+- Do not let a preview or exploratory action silently persist settings.
+- Preserve user-entered drafts when validation fails unless the approved behavior says otherwise.
+- Make defaults discoverable without obscuring advanced control.
+- Avoid exposing internal implementation terminology when a clear operator-facing term exists.
+
+## Build and Test Discipline
+
+Use the repository’s existing Makefile targets and test infrastructure.
+
+Run tests from `src` unless the project’s current instructions say otherwise.
+
+A typical non-hardware regression command is:
+
+```sh
+cd src
+make semantics-test
+```
+
+Use focused targets when they cover the changed behavior, including as applicable:
+
+```sh
+make guarded-mode-change-persistence-test
+make band-gpio-default-convergence-test
+make band-gpio-rotation-test
+make selector-shutdown-cleanup-test
+make monitor-file-regression-test
+make gpio-line-resolver-test
+make non-wspr-repeat-policy-test
+```
+
+For UI changes, include the existing UI/source regression coverage and perform the Impeccable visual workflow.
+
+Do not run hardware-dependent, installation, service-management, or transmission targets without explicit authorization.
+
+Do not assume a test command is safe merely because its target name contains `test`; inspect what the target executes first.
+
+When reporting validation:
+
+- State exactly which commands ran.
+- State whether each command passed, failed, or was skipped.
+- Separate automated tests from visual review and real-hardware qualification.
+- Do not conceal warnings, intentional skips, environment limitations, or untested behavior.
+- Run a whitespace/error check on the final diff when appropriate.
+
+## Documentation Requirements
+
+Review documentation impact for every user-visible or operator-facing change.
+
+Changes involving configuration, modes, timing, frequencies, scheduling, GPIO, transmitter backends, installation, services, logging, maintenance, or UI workflow should be presumed to require documentation review.
+
+Before declaring work complete:
+
+1. Identify the affected operator behavior.
+2. Locate the corresponding documentation in the Wsprry Pi documentation repository when available.
+3. Update documentation in the appropriate repository when that work is in scope.
+4. Keep current behavior, future plans, and known limitations clearly separated.
+5. Do not include internal bug-fix narration or regression-test details in user documentation unless they materially help the operator.
+
+If documentation changes are outside the approved scope, report the exact documentation follow-up rather than silently omitting it.
+
+Every implementation summary must include a `Documentation Impact` section that lists:
+
+- documentation updated
+- documentation considered but unchanged
+- documentation still required
+- why no documentation change was necessary, if applicable
+
+## Completion Report
+
+Lead with the outcome and provide evidence.
+
+For implementation work, report:
+
+- behavior implemented
+- important files changed
+- tests and checks run
+- UI and Impeccable review performed, when applicable
+- hardware or runtime qualification performed
+- validation that remains outstanding
+- documentation impact
+- working-tree status
+- whether anything was committed or pushed
+
+If work remains incomplete, state the exact next unfinished step.
+
+Never claim release readiness, installation success, service correctness, hardware correctness, or transmission correctness without the corresponding evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,18 @@ If the Impeccable skill is missing, unavailable, or cannot be used, stop before 
 
 Do not commit local skill/runtime artifacts such as `.agents/`, `.impeccable/`, `.claude/`, or `.codex/` unless the user explicitly requests them and they are intended repository content.
 
+## Operator Documentation Repository
+
+Operator documentation lives in the separate sibling Git repository `../Wsprry_Pi_Docs`; it is not a submodule of `WsprryPi`.
+
+- Inspect and follow `Wsprry_Pi_Docs/AGENTS.md` before working there.
+- Do not write to that repository without explicit cross-repository authorization.
+- Preserve its current branch and working tree, including all existing user changes.
+- Build, render, and verify documentation using that repository's documented workflow.
+- Use Impeccable to review affected rendered UI documentation. Replace screenshots only when they are materially inaccurate.
+- Keep application, `WsprryPi-UI` submodule, and `Wsprry_Pi_Docs` changes as separate review, commit, and push boundaries.
+- If cross-repository documentation changes are not authorized, review and report the required operator-documentation follow-up without modifying that repository.
+
 ## Submodule Policy
 
 WsprryPi uses Git submodules in two distinct roles:

--- a/config/wsprrypi.ini
+++ b/config/wsprrypi.ini
@@ -233,6 +233,10 @@ Fade Slice Ms = 2
 ; Valid range: 0 to 59.
 Start Minute = 0
 
+; Start Second:
+; Seconds after the configured start minute for each scheduled CW launch.
+Start Second = 5
+
 ; Repeat Minutes:
 ; Repeat interval in minutes for scheduled QRSS/FSKCW/DFCW launches.
 ; Must be greater than 0.

--- a/docs/plans/cw-timing-presets.md
+++ b/docs/plans/cw-timing-presets.md
@@ -2,7 +2,7 @@
 
 Status: Proposed  
 Implementation state: Not implemented  
-Repositories affected: `WsprryPi` and `WsprryPi-UI`
+Repositories affected: `WsprryPi`, `WsprryPi-UI`, and `Wsprry_Pi_Docs` (the separate sibling operator-documentation repository)
 
 ## Purpose
 
@@ -778,6 +778,24 @@ The backend configuration schema should not require modification for the initial
 
 Existing backend source may require no functional change if the UI can preserve its current seven-value timing contract. Do not modify backend code merely to make the change appear symmetrical.
 
+The engineering implementation contract remains at `WsprryPi/docs/plans/cw-timing-presets.md`. Operator-facing documentation does not belong in this repository; it belongs in the separate sibling `Wsprry_Pi_Docs` repository.
+
+### `Wsprry_Pi_Docs`
+
+Operator documentation lives in the separate sibling Git repository `../Wsprry_Pi_Docs`. It is not a `WsprryPi` submodule and must be treated as an independent repository boundary.
+
+Before working there:
+
+- inspect and follow that repository's own `AGENTS.md`;
+- inspect and preserve its current branch and working tree, including all existing user changes;
+- obtain explicit authorization for cross-repository writes;
+- build and render the documentation using that repository's documented workflow;
+- use Impeccable to review affected rendered HTML;
+- replace screenshots only when the implemented interface makes an existing image materially inaccurate; and
+- keep its diff, review, commit, and push boundary separate from `WsprryPi` and `WsprryPi-UI`.
+
+If cross-repository documentation changes are not authorized, inspect documentation impact and provide a follow-up report without modifying `Wsprry_Pi_Docs`.
+
 ### `src/` Dependency Submodules
 
 No changes to dependency submodules under `src/` are expected.
@@ -1065,8 +1083,10 @@ The feature is acceptable when:
 - Backend regression and repeat-policy tests pass.
 - Impeccable review and rendered-page inspection are complete.
 - Documentation impact has been reviewed.
+- When cross-repository documentation changes are authorized, required operator documentation in `Wsprry_Pi_Docs` is updated, rendered using that repository's workflow, and reviewed with Impeccable.
+- When cross-repository documentation changes are not authorized, the required `Wsprry_Pi_Docs` follow-up is reported without implying that a documentation write was required or completed.
 - No `src/` dependency submodule changes are required.
-- UI and parent-repository changes remain separately reviewable.
+- UI, parent-repository, and operator-documentation changes remain separately reviewable.
 - Hardware or live-transmission validation is not claimed unless separately authorized and performed.
 
 ## Non-Goals
@@ -1091,11 +1111,21 @@ This initial feature does not:
 - modify transmitter hardware behavior;
 - modify dependency submodules under `src/`;
 - authorize live RF, GPIO, service, installation, or hardware testing;
-- commit or push either repository.
+- commit or push any repository.
 
 ## Documentation Impact
 
-Implementation must review operator documentation covering:
+Operator documentation lives in the separate sibling `Wsprry_Pi_Docs` repository, not in `WsprryPi`. Before editing, verify the current documentation structure and content rather than assuming prior inspection remains current.
+
+Known affected areas from prior inspection are:
+
+- `docs/User_Interface/Setup/Signal_Setup/index.md`;
+- `docs/Advanced_Operations/index.md`; and
+- `docs/Command_Line_Operations/index.md`.
+
+Current verification must determine which of these files, and whether any additional files, actually require changes for the implemented behavior.
+
+Documentation impact review must cover:
 
 - CW modulation selection;
 - shared QRSS1, QRSS3, and QRSS6 Speed presets;
@@ -1135,18 +1165,23 @@ Do not include internal test or refactoring details in operator documentation un
 
 ## Submodule and Commit Boundaries
 
-The implementation is expected to involve the `WsprryPi-UI` submodule and parent `WsprryPi` repository.
+The implementation may involve three independent Git repository boundaries:
+
+1. the `WsprryPi-UI` submodule for UI implementation;
+2. the parent `WsprryPi` repository for tests, the reviewed UI pointer, and this engineering plan; and
+3. the separate sibling `Wsprry_Pi_Docs` repository for operator documentation when cross-repository writes are explicitly authorized.
 
 If commits are later authorized:
 
 1. Review the complete UI submodule diff.
 2. Run UI behavioral and Impeccable validation.
 3. Commit the UI change inside `WsprryPi-UI`.
-4. Ensure the UI commit is available on its intended remote before publishing a parent pointer to it.
-5. Review parent integration tests and documentation changes.
-6. Review the exact old and new UI submodule commit IDs.
-7. Commit the parent submodule-pointer update and parent changes separately or as an explicitly reviewed parent change.
-8. Push only when explicitly authorized.
+4. Ensure the UI commit is pushed to its intended remote before publishing a parent commit that points to it.
+5. Review parent integration tests, the exact old and new UI submodule commit IDs, the pointer update, and the engineering-plan change.
+6. Commit the parent submodule-pointer update, tests, and plan separately or as an explicitly reviewed parent change.
+7. In `Wsprry_Pi_Docs`, independently review the authorized operator-documentation diff, render the documentation using that repository's workflow, and complete Impeccable review of affected rendered HTML.
+8. Commit documentation changes independently in `Wsprry_Pi_Docs`.
+9. Push only the repositories explicitly authorized, preserving the three separate publication boundaries.
 
 Do not modify or advance unrelated `src/` submodules.
 
@@ -1165,10 +1200,13 @@ Do not modify or advance unrelated `src/` submodules.
 11. Extend parent source-contract and backend regression coverage.
 12. Run safe automated tests.
 13. Render and inspect all required UI states with Impeccable.
-14. Update operator documentation.
-15. Review complete parent and submodule diffs.
-16. Report remaining hardware or runtime qualification separately.
-17. Commit or push only if explicitly requested.
+14. Review operator-documentation impact in the separate sibling `Wsprry_Pi_Docs` repository.
+15. Only with explicit cross-repository authorization, update the required operator documentation in `Wsprry_Pi_Docs`.
+16. Render the authorized documentation changes using that repository's workflow and review affected rendered HTML with Impeccable; replace screenshots only if materially inaccurate.
+17. If documentation writes are not authorized, report the required `Wsprry_Pi_Docs` follow-up instead.
+18. Review complete UI submodule, parent, and authorized documentation diffs separately.
+19. Report remaining hardware or runtime qualification separately.
+20. Commit or push only if explicitly requested for each repository boundary.
 
 ## Implementation Gate
 
@@ -1183,4 +1221,5 @@ Before implementation:
 5. Confirm that Impeccable is available.
 6. Compare current behavior with this document.
 7. Report any remaining material drift or ambiguity.
-8. Obtain explicit approval to implement.
+8. Obtain explicit approval to implement application and UI changes.
+9. Obtain explicit cross-repository authorization to modify `Wsprry_Pi_Docs`, or define the documentation deliverable as a follow-up report only.

--- a/docs/plans/cw-timing-presets.md
+++ b/docs/plans/cw-timing-presets.md
@@ -571,6 +571,22 @@ During configuration population:
 
 Configuration loading must not overwrite custom timing merely because preset controls now exist.
 
+### Repairing an Invalid Inactive Spacing Triplet
+
+All seven timing values must be valid before autosave. If the inactive spacing triplet is invalid:
+
+1. Block autosave without normalizing the invalid values or changing modulation.
+2. Identify the invalid inactive group in the save-status feedback.
+3. Provide a `Review QRSS/FSKCW spacing` action when the conventional triplet is invalid, or a `Review DFCW spacing` action when the DFCW triplet is invalid.
+4. When invoked, reveal a temporary inactive-triplet repair section without changing `Operation.Mode`.
+5. Focus the first invalid field in the revealed group.
+6. Keep the unresolved invalid group revealed while saving remains blocked; do not hide it automatically or allow a close action to hide it.
+7. Revealing the repair section must not mutate timing values or trigger autosave.
+8. If the operator closes the repair section after its fields are valid, closing it must not mutate values, change `Operation.Mode`, or trigger autosave.
+9. After all seven timing values become valid, validate once and schedule one coherent autosave.
+
+Do not automatically switch modulation to expose an invalid inactive triplet. The repair section is a temporary editing surface for preserved inactive values, not a modulation change or a second persisted spacing mode.
+
 ### Disabled Fields and Serialization
 
 Disabled timing fields still represent active configuration values.
@@ -616,6 +632,19 @@ Each intentional selector transition should follow one coherent path:
 
 Configuration population must use a non-saving synchronization path.
 
+### Autosave Feedback for Inactive Timing Errors
+
+When autosave is blocked by an invalid inactive triplet, save-status feedback must:
+
+- state that settings were not saved;
+- name either QRSS/FSKCW spacing or DFCW spacing as the group requiring correction;
+- expose the applicable review action;
+- keep the action available until the group is valid;
+- avoid implying that the active modulation or its active spacing is invalid when it is not; and
+- transition through one validation and one coherent autosave after all seven timing values become valid.
+
+Opening or closing the repair section is navigation and disclosure only. Neither action may mark the configuration dirty, issue a PATCH, schedule autosave, change `Operation.Mode`, or alter the autosave baseline.
+
 ## Validation
 
 ### Shared Dot Duration
@@ -630,6 +659,8 @@ When a preset is selected, validate the canonical preset value even if the visib
 
 Do not rely solely on existing validation behavior that treats a disabled input as valid.
 
+Finite-number validation must be enforced symmetrically for Dot Seconds and all six gap values across every supported input path. A small parent-backend change is permitted when needed to make candidate validation, configuration parsing, command-line parsing, and web PATCH validation enforce the same finite-and-positive contract. This does not authorize a schema change or alteration of valid timing semantics.
+
 ### Gap Multipliers
 
 All six persisted gap multipliers must be:
@@ -638,7 +669,7 @@ All six persisted gap multipliers must be:
 - finite;
 - greater than zero.
 
-The visible validation state should emphasize the active triplet, but serialization must never replace an invalid inactive value silently.
+The visible validation state should emphasize the active triplet, but serialization must never replace an invalid inactive value silently. An invalid inactive triplet blocks autosave and uses the temporary repair workflow defined above.
 
 When Standard is selected:
 
@@ -683,6 +714,11 @@ The UI estimate and backend repeat-policy calculation must agree for equivalent 
 - Announce meaningful calculated-duration changes without excessive screen-reader chatter.
 - Use operator-facing terminology rather than internal variable or JSON names.
 - Preserve visible validation feedback for advanced editable fields.
+- Identify an invalid inactive spacing group in save-status feedback using its operator-facing name.
+- Make each inactive-group review action keyboard operable and expose a clear accessible name.
+- When a review action reveals the repair section, move focus to the first invalid field and announce the newly available editing context without excessive chatter.
+- Keep an unresolved invalid repair section exposed while autosave remains blocked.
+- Return focus predictably when a valid repair section is closed, without changing modulation or timing values.
 - Explain how to enable editing when a field is disabled.
 - Explain that QRSS speed names select a shared base duration without implying identical modulation construction.
 
@@ -979,7 +1015,18 @@ Verify:
 - disabled preset controls serialize canonical valid values;
 - invalid custom values are not silently relabeled as presets;
 - validation identifies the applicable active controls;
-- inactive values are not silently discarded.
+- inactive values are not silently discarded;
+- all seven timing values must be valid before autosave;
+- an invalid inactive triplet blocks autosave without normalization or a modulation change;
+- save-status feedback identifies the invalid inactive group;
+- an invalid conventional triplet provides `Review QRSS/FSKCW spacing`;
+- an invalid DFCW triplet provides `Review DFCW spacing`;
+- the review action reveals the applicable temporary repair section and focuses its first invalid field;
+- revealing the repair section does not change `Operation.Mode`, mutate values, mark the configuration dirty, or trigger autosave;
+- an unresolved invalid repair section cannot be hidden while autosave remains blocked;
+- closing a valid repair section does not change `Operation.Mode`, mutate values, or trigger autosave;
+- correcting the last invalid timing value validates once and schedules one coherent autosave; and
+- the repair workflow never automatically switches modulation.
 
 ### Backend Regression Tests
 
@@ -989,6 +1036,7 @@ Verify:
 - QRSS and FSKCW continue sharing conventional gap values;
 - DFCW continues using separate gap values;
 - all seven timing values load, validate, serialize, and round-trip;
+- Dot Seconds and all six gap values receive symmetrical finite-and-positive validation across supported input paths;
 - conventional timing produces expected runtime durations;
 - DFCW timing produces expected runtime durations;
 - message-duration calculations include mode-appropriate spacing;
@@ -1014,6 +1062,12 @@ Using Impeccable and the rendered application, verify:
 - calculated-duration updates;
 - message-duration and repeat validation;
 - autosave feedback;
+- blocked autosave with an invalid inactive QRSS/FSKCW triplet and its review action;
+- blocked autosave with an invalid inactive DFCW triplet and its review action;
+- temporary inactive-triplet repair disclosure, first-invalid-field focus, and predictable close focus;
+- unresolved invalid repair content remaining visible while saving is blocked;
+- repair disclosure opening and closing without modulation, value, dirty-state, or autosave side effects;
+- one coherent autosave after the final invalid timing value becomes valid;
 - reload restoration;
 - keyboard order and radio-group behavior;
 - focus behavior when entering Advanced;
@@ -1078,6 +1132,13 @@ The feature is acceptable when:
 - Timing controls are grouped coherently.
 - Existing custom configurations round-trip without loss.
 - All seven existing timing values remain preserved.
+- All seven timing values must be finite and positive before autosave.
+- An invalid inactive triplet blocks autosave without normalization or automatic modulation changes.
+- Save-status feedback names the invalid inactive spacing group and provides the applicable review action.
+- The review action reveals a temporary repair section and focuses the first invalid field without mutating configuration state or triggering autosave.
+- An unresolved invalid repair section remains visible while saving is blocked.
+- Correcting the final invalid timing value validates once and schedules one coherent autosave.
+- Dot Seconds and all six gap values receive symmetrical finite-number validation across supported input paths, with a small parent-backend consistency change allowed if required.
 - No backend configuration migration is required.
 - UI behavioral tests cover transitions, persistence, validation, and autosave.
 - Backend regression and repeat-policy tests pass.
@@ -1103,6 +1164,9 @@ This initial feature does not:
 - introduce persisted preset names;
 - introduce persisted Spacing-mode names;
 - restore hidden previous advanced drafts;
+- automatically switch modulation to repair an invalid inactive spacing triplet;
+- normalize, discard, or conceal an invalid inactive triplet;
+- treat opening or closing the temporary inactive-triplet repair section as a configuration change;
 - change the backend configuration schema;
 - alter RF frequency behavior;
 - alter Frequency Offset semantics;

--- a/docs/plans/cw-timing-presets.md
+++ b/docs/plans/cw-timing-presets.md
@@ -1,0 +1,668 @@
+# CW Timing Presets
+
+Status: Proposed  
+Implementation state: Not implemented  
+Repositories affected: `WsprryPi` and `WsprryPi-UI`
+
+## Purpose
+
+Add clear QRSS1, QRSS3, and QRSS6 timing presets to the WsprryPi web interface while preserving support for custom CW timing.
+
+The design must:
+
+- Default new CW configurations to QRSS3.
+- Make standard timing easy to select and understand.
+- Preserve existing custom timing configurations.
+- Keep advanced controls available without presenting every operator with editable low-level timing fields.
+- Preserve the existing backend configuration format.
+- Apply consistently to QRSS, FSKCW, and DFCW where they share CW timing.
+- Group related timing controls together in the UI.
+
+## Current Behavior
+
+The CW Control panel currently presents these settings as independent editable fields:
+
+- CW modulation mode:
+  - QRSS
+  - FSKCW
+  - DFCW
+- Dot Seconds
+- Frequency Offset
+- Base Frequency
+- Frequency calibration
+- Start minute
+- Repeat interval
+- Intra-Element Gap
+- Inter-Character Gap
+- Inter-Word Gap
+
+The backend already uses:
+
+- `CW.Dot Seconds` as the shared dot duration for QRSS, FSKCW, and DFCW.
+- `CW.Intra Element Gap` as a dot-length multiplier.
+- `CW.Inter Character Gap` as a dot-length multiplier.
+- `CW.Inter Word Gap` as a dot-length multiplier.
+
+Actual gap durations are calculated from:
+
+```text
+gap duration = dot duration × gap multiplier
+```
+
+The current default timing is:
+
+```text
+Dot Seconds:          3
+Intra Element Gap:    1
+Inter Character Gap:  3
+Inter Word Gap:       7
+```
+
+This corresponds to QRSS3 with standard Morse spacing.
+
+## Proposed Operator Model
+
+### Modulation Mode
+
+Continue to provide the existing modulation choices:
+
+- QRSS
+- FSKCW
+- DFCW
+
+These choices control how the signal is generated. They are separate from the speed preset.
+
+### Speed Preset
+
+Add a Speed control with four choices:
+
+- QRSS1
+- QRSS3
+- QRSS6
+- Advanced
+
+The choices map to dot duration as follows:
+
+| Speed | Dot duration |
+|---|---:|
+| QRSS1 | 1 second |
+| QRSS3 | 3 seconds |
+| QRSS6 | 6 seconds |
+| Advanced | Operator-defined positive duration |
+
+QRSS3 is the default when a new or incomplete CW configuration requires a default.
+
+### Dot Duration
+
+Keep the Dot Duration field visible for all speed selections.
+
+For QRSS1, QRSS3, and QRSS6:
+
+- Populate the corresponding duration.
+- Disable manual editing.
+- Display the selected value clearly.
+- Explain that the duration comes from the selected speed preset.
+
+For Advanced:
+
+- Enable manual editing.
+- Preserve the current valid duration when switching into Advanced.
+- Require a finite value greater than zero.
+- Continue using the backend’s existing validation limits and semantics.
+
+Selecting Advanced must not blank or arbitrarily reset the current duration.
+
+### Spacing Mode
+
+Add a separate Spacing control with two choices:
+
+- Standard
+- Advanced
+
+This control is independent of the Speed preset. An operator may therefore use:
+
+- QRSS1 with standard spacing
+- QRSS3 with advanced spacing
+- QRSS6 with standard spacing
+- An advanced dot duration with either standard or advanced spacing
+
+### Standard Spacing
+
+Standard spacing uses these multipliers:
+
+| Gap | Multiplier |
+|---|---:|
+| Intra-element | 1× dot |
+| Inter-character | 3× dot |
+| Inter-word | 7× dot |
+
+When Standard spacing is selected:
+
+- Populate the gap fields with `1`, `3`, and `7`.
+- Disable manual editing of the three multiplier fields.
+- Continue displaying the fields so the operator can see the effective rules.
+- Display the calculated duration for each gap.
+
+Examples:
+
+| Speed | Intra-element | Inter-character | Inter-word |
+|---|---:|---:|---:|
+| QRSS1 | 1 second | 3 seconds | 7 seconds |
+| QRSS3 | 3 seconds | 9 seconds | 21 seconds |
+| QRSS6 | 6 seconds | 18 seconds | 42 seconds |
+
+### Advanced Spacing
+
+When Advanced spacing is selected:
+
+- Enable the three existing gap multiplier fields.
+- Preserve their current valid values.
+- Require every multiplier to be finite and greater than zero.
+- Display the calculated duration beside or beneath each field.
+- Recalculate the displayed duration whenever the dot duration or a multiplier changes.
+
+The persisted values remain multipliers, not seconds.
+
+## Proposed UI Organization
+
+Place all related timing controls together near the top of the CW Control panel.
+
+Recommended organization:
+
+```text
+CW Control
+
+  Modulation
+  Mode: [ QRSS ] [ FSKCW ] [ DFCW ]
+
+  CW Timing
+  Speed: [ QRSS1 ] [ QRSS3 ] [ QRSS6 ] [ Advanced ]
+
+  Dot duration:
+  [ 3 seconds — disabled ]
+  Determined by the QRSS3 preset.
+
+  Spacing:
+  [ Standard ] [ Advanced ]
+
+  Intra-element:
+  [ 1 — disabled ] × dot = 3 seconds
+
+  Inter-character:
+  [ 3 — disabled ] × dot = 9 seconds
+
+  Inter-word:
+  [ 7 — disabled ] × dot = 21 seconds
+
+  Frequency and Schedule
+  Base frequency | Frequency offset
+  Frequency calibration
+  Start minute | Repeat interval
+```
+
+The exact responsive arrangement may vary, but the semantic grouping must remain clear.
+
+On narrow screens, controls should stack in this order:
+
+1. Modulation mode
+2. Speed preset
+3. Dot duration
+4. Spacing mode
+5. Gap controls
+6. Frequency controls
+7. Scheduling controls
+
+## Configuration Compatibility
+
+### Existing Keys
+
+Continue using the existing configuration keys:
+
+```json
+{
+  "CW": {
+    "Dot Seconds": 3.0,
+    "Intra Element Gap": 1.0,
+    "Inter Character Gap": 3.0,
+    "Inter Word Gap": 7.0
+  }
+}
+```
+
+Do not require new backend configuration keys for the initial implementation.
+
+In particular, do not initially persist:
+
+- `Speed Preset`
+- `QRSS Mode`
+- `Advanced Dot Timing`
+- `Spacing Mode`
+- `Advanced Spacing`
+
+These are UI interpretations of the effective timing values.
+
+### Inferring the Speed Selection
+
+When loading configuration:
+
+| Persisted Dot Seconds | Selected speed |
+|---:|---|
+| Exactly `1` | QRSS1 |
+| Exactly `3` | QRSS3 |
+| Exactly `6` | QRSS6 |
+| Any other valid positive value | Advanced |
+
+Use numeric comparison appropriate for parsed configuration values. Do not use formatted display strings to infer the selection.
+
+### Inferring the Spacing Selection
+
+When loading configuration:
+
+| Persisted multipliers | Selected spacing |
+|---|---|
+| Exactly `1`, `3`, and `7` | Standard |
+| Any other valid positive combination | Advanced |
+
+A custom configuration must remain custom after loading and saving.
+
+### Defaults
+
+When no valid CW timing is available, use:
+
+```text
+Speed:               QRSS3
+Dot Seconds:         3
+Spacing:             Standard
+Intra Element Gap:   1
+Inter Character Gap: 3
+Inter Word Gap:      7
+```
+
+An existing valid configuration always takes precedence over these defaults.
+
+## State-Transition Rules
+
+### Selecting QRSS1, QRSS3, or QRSS6
+
+When an operator selects a preset:
+
+1. Set Dot Seconds to the preset value.
+2. Disable manual editing of Dot Duration.
+3. Recalculate all displayed gap durations.
+4. Validate the effective configuration.
+5. Use the existing autosave workflow.
+
+### Selecting Advanced Speed
+
+When an operator selects Advanced:
+
+1. Retain the current valid Dot Seconds value.
+2. Enable the Dot Duration field.
+3. Focus behavior should not unexpectedly select, erase, or replace the value.
+4. Revalidate changes through the existing live-validation workflow.
+
+### Selecting Standard Spacing
+
+When an operator selects Standard:
+
+1. Set the multipliers to `1`, `3`, and `7`.
+2. Disable manual editing of the multiplier fields.
+3. Recalculate displayed gap durations.
+4. Validate the effective configuration.
+5. Use the existing autosave workflow.
+
+Switching from Advanced spacing to Standard is an intentional configuration change. It replaces custom multipliers with `1`, `3`, and `7`.
+
+### Selecting Advanced Spacing
+
+When an operator selects Advanced spacing:
+
+1. Retain the current valid multipliers.
+2. Enable the three multiplier fields.
+3. Continue showing calculated durations.
+4. Revalidate changes through the existing live-validation workflow.
+
+### Loading Existing Configuration
+
+During configuration population:
+
+1. Load the four persisted timing values.
+2. Infer Speed from Dot Seconds.
+3. Infer Spacing from the three multipliers.
+4. Set enabled and disabled states without causing an unintended autosave.
+5. Calculate the displayed effective durations.
+6. Synchronize the autosave baseline only after population is complete.
+
+Configuration loading must not overwrite custom timing merely because a preset selector now exists.
+
+### Disabled Fields and Serialization
+
+Disabled timing fields still represent active configuration values.
+
+Before collecting the configuration payload:
+
+- Read the effective timing state rather than relying on browser form submission semantics.
+- Ensure Dot Seconds and all three gap multipliers remain present.
+- Serialize the same four existing `CW` keys.
+- Never treat a disabled control as an absent or optional setting.
+
+## Validation
+
+### Dot Duration
+
+Dot Duration must be:
+
+- numeric
+- finite
+- greater than zero
+
+When a preset is selected, validation applies to the effective preset value even though the field is disabled.
+
+### Gap Multipliers
+
+Every multiplier must be:
+
+- numeric
+- finite
+- greater than zero
+
+When Standard spacing is selected, validation applies to the effective `1`, `3`, and `7` values.
+
+### Repeat Interval
+
+Existing message-duration and repeat-interval validation remains applicable.
+
+The implementation must continue detecting configurations in which the calculated CW message duration exceeds the configured repeat interval.
+
+This is especially important for:
+
+- QRSS6
+- long messages
+- large advanced gap multipliers
+- custom dot durations
+
+## Accessibility and Interaction Requirements
+
+- Use a fieldset and legend or an equivalent accessible grouping for Speed.
+- Use a separate accessible group for Spacing.
+- Do not communicate disabled or advanced state through color alone.
+- Associate all explanatory text and calculated-duration output with the applicable control.
+- Keep keyboard operation complete and predictable.
+- Ensure disabled values remain readable in both light and dark themes.
+- Announce calculated-duration changes appropriately without creating excessive screen-reader chatter.
+- Use operator-facing names and avoid exposing internal variable or JSON key names as primary labels.
+- Preserve visible validation feedback for advanced editable fields.
+- Explain how to enable editing when a field is disabled.
+
+Suggested operator-facing labels:
+
+```text
+Speed
+Dot duration
+Spacing
+Intra-element gap
+Inter-character gap
+Inter-word gap
+```
+
+Suggested supporting text:
+
+```text
+QRSS3 uses a three-second dot duration.
+
+Standard spacing uses 1×, 3×, and 7× the selected dot duration.
+
+Select Advanced to enter a custom dot duration.
+
+Select Advanced spacing to edit the gap multipliers.
+```
+
+## Impeccable Requirement
+
+This is UI work and must use the Impeccable skill as required by the repository’s `AGENTS.md`.
+
+Before implementation:
+
+1. Confirm that the Impeccable skill is installed and available.
+2. Read and follow its instructions.
+3. Inspect the existing WsprryPi design language and responsive behavior.
+
+During and after implementation:
+
+1. Use Impeccable to review the proposed grouping and hierarchy.
+2. Render the actual Setup page.
+3. Exercise QRSS1, QRSS3, QRSS6, Advanced speed, Standard spacing, and Advanced spacing.
+4. Inspect desktop and mobile layouts.
+5. Inspect both supported themes.
+6. Review disabled, enabled, invalid, saving, and saved states.
+7. Address applicable findings.
+8. Report any finding intentionally not adopted and why.
+
+If Impeccable is unavailable, stop before changing UI files.
+
+Do not commit `.agents/`, `.impeccable/`, or other local skill/runtime state unless explicitly requested.
+
+## Repository Boundaries
+
+### `WsprryPi-UI`
+
+Expected UI work belongs in the root `WsprryPi-UI` submodule, including:
+
+- timing control markup
+- labels and help text
+- responsive layout
+- selection and enablement logic
+- calculated-duration presentation
+- form population
+- autosave interaction
+- UI validation
+- UI-specific tests
+
+Inspect the submodule at the exact commit recorded by the parent repository before making changes.
+
+### `WsprryPi`
+
+Expected parent-repository work may include:
+
+- UI/source regression tests
+- integration-contract tests
+- configuration compatibility tests
+- message-duration and repeat-policy regression coverage
+- documentation or planning references
+- a reviewed update to the `WsprryPi-UI` submodule pointer
+
+The backend configuration schema should not require modification for the initial implementation.
+
+### `src/` Submodules
+
+No changes to dependency submodules under `src/` are expected.
+
+If implementation appears to require such a change, stop and report why before modifying a dependency.
+
+## Expected Implementation Seams
+
+Confirm current paths before implementation.
+
+Likely UI seams:
+
+```text
+WsprryPi-UI/data/views/config.php
+WsprryPi-UI/data/index.js
+WsprryPi-UI/data/site.js
+WsprryPi-UI/data/index.css
+WsprryPi-UI/data/site.css
+```
+
+Likely parent-repository seams:
+
+```text
+src/config_handler.hpp
+src/config_handler.cpp
+src/arg_parser.cpp
+src/scheduling.cpp
+src/tests/ui_source_regression_test.cpp
+src/tests/dial_frequency_semantics_test.cpp
+src/tests/non_wspr_repeat_policy_test.cpp
+```
+
+Do not modify every listed file automatically. Inspect the current contracts and change only what the approved implementation requires.
+
+## Required Test Coverage
+
+### UI State Tests
+
+Verify:
+
+- Missing timing defaults to QRSS3.
+- QRSS1 sets Dot Seconds to `1`.
+- QRSS3 sets Dot Seconds to `3`.
+- QRSS6 sets Dot Seconds to `6`.
+- Preset dot fields are disabled.
+- Advanced enables Dot Duration.
+- Entering Advanced preserves the current valid value.
+- A custom dot duration loads as Advanced.
+- Standard spacing sets `1`, `3`, and `7`.
+- Standard spacing disables the multiplier fields.
+- Advanced spacing enables the multiplier fields.
+- Custom multipliers load as Advanced spacing.
+- Switching from Advanced spacing to Standard intentionally restores `1`, `3`, and `7`.
+- Switching into Advanced spacing retains the current values.
+
+### Calculated-Duration Tests
+
+Verify:
+
+| Dot duration | Multipliers | Expected durations |
+|---:|---|---|
+| 1 | `1/3/7` | `1/3/7` seconds |
+| 3 | `1/3/7` | `3/9/21` seconds |
+| 6 | `1/3/7` | `6/18/42` seconds |
+| 2.5 | `1/3/7` | `2.5/7.5/17.5` seconds |
+| 3 | `1.5/4/8` | `4.5/12/24` seconds |
+
+Presentation formatting must not change the persisted numeric values.
+
+### Persistence Tests
+
+Verify that configuration collection continues emitting:
+
+```text
+CW.Dot Seconds
+CW.Intra Element Gap
+CW.Inter Character Gap
+CW.Inter Word Gap
+```
+
+Verify:
+
+- Preset values save correctly.
+- Disabled fields are still serialized.
+- Advanced values survive save and reload.
+- Existing custom configurations round-trip without loss.
+- Loading configuration does not trigger an unintended normalization autosave.
+- No new backend keys are required.
+
+### Backend Regression Tests
+
+Verify:
+
+- Dot duration remains shared across QRSS, FSKCW, and DFCW.
+- Standard and advanced multipliers produce the expected runtime durations.
+- All four values remain subject to backend validation.
+- Message-duration calculations continue including inter-element, inter-character, and inter-word spacing.
+- Repeat-policy rejection still works for messages longer than the repeat interval.
+- Existing configurations without UI metadata remain valid.
+
+### Visual and Workflow Tests
+
+Using Impeccable and the rendered application, verify:
+
+- desktop layout
+- mobile layout
+- light theme
+- dark theme
+- QRSS1, QRSS3, and QRSS6 selections
+- Advanced dot editing
+- Standard and Advanced spacing
+- disabled-field legibility
+- validation errors
+- calculated-duration updates
+- autosave feedback
+- reload and restoration of custom values
+
+Automated tests do not replace this workflow exercise.
+
+## Acceptance Criteria
+
+The feature is acceptable when:
+
+- CW Modes defaults to QRSS3 when no valid existing timing is available.
+- Operators can select QRSS1, QRSS3, or QRSS6 directly.
+- Presets reliably produce one-, three-, or six-second dots.
+- Dot Duration is editable only in Advanced speed.
+- Standard spacing reliably produces `1/3/7` multipliers.
+- Gap multipliers are editable only in Advanced spacing.
+- The UI displays calculated gap durations.
+- Timing controls are grouped coherently.
+- Existing custom configurations remain custom and round-trip without loss.
+- No backend configuration migration is required.
+- QRSS, FSKCW, and DFCW continue sharing the established timing contract.
+- Relevant UI, persistence, backend, and repeat-policy tests pass.
+- Impeccable review and real rendered-page inspection are complete.
+- Documentation impact has been reviewed.
+- No `src/` dependency submodule changes are required.
+- Parent and UI submodule changes remain separately reviewable.
+- Hardware or live-transmission validation is not claimed unless separately performed and authorized.
+
+## Non-Goals
+
+This initial feature does not:
+
+- change Morse dash duration from three dots
+- introduce independently persisted preset names
+- change the backend configuration schema
+- create different dot durations for QRSS, FSKCW, and DFCW
+- alter RF frequency behavior
+- alter frequency offset semantics
+- alter scheduling semantics
+- redesign the entire Setup page
+- modify transmitter hardware behavior
+- modify dependency submodules under `src/`
+- authorize live RF, GPIO, service, installation, or hardware testing
+- commit or push either repository
+
+## Documentation Impact
+
+Implementation should review the operator documentation covering:
+
+- CW mode selection
+- QRSS timing
+- FSKCW and DFCW timing
+- CW gap multipliers
+- repeat intervals
+- the Signal Setup web interface
+- screenshots depicting the CW Control panel
+
+Documentation must distinguish:
+
+- speed presets
+- custom dot duration
+- standard spacing
+- advanced spacing
+- multiplier values
+- calculated durations in seconds
+
+Screenshots should be replaced only when the changed UI makes the existing image materially inaccurate. Age alone is not a reason to replace a contextually correct screenshot.
+
+## Implementation Gate
+
+This document is a proposed implementation contract, not authorization to modify code.
+
+Before implementation:
+
+1. Inspect the current parent repository and recursive submodule state.
+2. Confirm the exact `WsprryPi-UI` revision.
+3. Confirm that Impeccable is available.
+4. Compare current implementation behavior with this document.
+5. Report any material drift or ambiguity.
+6. Obtain explicit approval to implement.

--- a/docs/plans/cw-timing-presets.md
+++ b/docs/plans/cw-timing-presets.md
@@ -6,21 +6,66 @@ Repositories affected: `WsprryPi` and `WsprryPi-UI`
 
 ## Purpose
 
-Add clear QRSS1, QRSS3, and QRSS6 timing presets to the WsprryPi web interface while preserving support for custom CW timing.
+Add QRSS1, QRSS3, and QRSS6 speed presets to the WsprryPi web interface while preserving custom CW timing and the existing mode-specific behavior of QRSS, FSKCW, and DFCW.
+
+The speed presets define a shared base timing unit, \(T\):
+
+| Speed preset | Base timing unit |
+|---|---:|
+| QRSS1 | \(T = 1\) second |
+| QRSS3 | \(T = 3\) seconds |
+| QRSS6 | \(T = 6\) seconds |
+| Advanced | Operator-defined positive \(T\) |
+
+The presets apply to QRSS, FSKCW, and DFCW. They do not make those modes instantiate dots, dashes, tones, or gaps identically.
 
 The design must:
 
-- Default new CW configurations to QRSS3.
+- Default new or incomplete CW timing to QRSS3.
+- Apply the selected base timing unit consistently across QRSS, FSKCW, and DFCW.
+- Preserve each modulation’s existing element-construction rules.
+- Preserve the existing QRSS/FSKCW and DFCW spacing contracts.
 - Make standard timing easy to select and understand.
 - Preserve existing custom timing configurations.
 - Keep advanced controls available without presenting every operator with editable low-level timing fields.
 - Preserve the existing backend configuration format.
-- Apply consistently to QRSS, FSKCW, and DFCW where they share CW timing.
+- Preserve all existing timing keys, including inactive mode-specific values.
 - Group related timing controls together in the UI.
+- Avoid changing RF, scheduling, or transmitter behavior outside the approved timing-preset presentation.
+
+## Governing Timing Model
+
+The implementation must keep two concepts distinct:
+
+1. **Shared speed contract**
+   - QRSS1, QRSS3, QRSS6, and Advanced select the shared base duration \(T\).
+   - The existing `CW.Dot Seconds` value stores \(T\).
+   - QRSS, FSKCW, and DFCW all consume this shared value.
+
+2. **Mode-specific signal construction**
+   - Each modulation constructs its transmitted elements according to its existing runtime behavior.
+   - Selecting a speed preset must not replace those mode-specific rules with one universal Morse timing model.
+
+### Mode-Specific Construction
+
+| Modulation | Dot construction | Dash construction | Standard spacing |
+|---|---|---|---|
+| QRSS | Keyed element lasting \(T\) | Keyed element lasting \(3T\) | Conventional `1/3/7` multipliers |
+| FSKCW | Mode-specific tone element lasting \(T\) | Mode-specific tone element lasting \(3T\) | Conventional `1/3/7` multipliers |
+| DFCW | Tone-distinguished element lasting \(T\) | Different-tone element also lasting \(T\) | DFCW-specific `0.333333/1/3` multipliers |
+
+The table describes the timing contract that the preset UI must preserve. The existing scheduler and modulation implementations remain authoritative for the exact construction and placement of transmitted elements.
+
+The preset feature must not:
+
+- make a DFCW dash last \(3T\);
+- apply conventional `1/3/7` spacing to DFCW;
+- replace DFCW’s frequency-distinguished elements with ordinary keyed Morse elements;
+- create separate dot-duration values for the three modulation modes.
 
 ## Current Behavior
 
-The CW Control panel currently presents these settings as independent editable fields:
+The CW Control panel currently presents settings including:
 
 - CW modulation mode:
   - QRSS
@@ -32,45 +77,70 @@ The CW Control panel currently presents these settings as independent editable f
 - Frequency calibration
 - Start minute
 - Repeat interval
-- Intra-Element Gap
-- Inter-Character Gap
-- Inter-Word Gap
+- QRSS/FSKCW gap multipliers
+- DFCW-specific gap multipliers
 
 The backend already uses:
 
-- `CW.Dot Seconds` as the shared dot duration for QRSS, FSKCW, and DFCW.
-- `CW.Intra Element Gap` as a dot-length multiplier.
-- `CW.Inter Character Gap` as a dot-length multiplier.
-- `CW.Inter Word Gap` as a dot-length multiplier.
+- one shared Dot Seconds value for QRSS, FSKCW, and DFCW;
+- one spacing triplet shared by QRSS and FSKCW;
+- a separate spacing triplet for DFCW;
+- separate runtime construction paths for conventional CW timing and DFCW timing.
 
 Actual gap durations are calculated from:
 
 ```text
-gap duration = dot duration × gap multiplier
+gap duration = shared base duration T × active gap multiplier
 ```
 
-The current default timing is:
+### Current Shared Default
 
 ```text
-Dot Seconds:          3
+Dot Seconds: 3
+```
+
+This corresponds to QRSS3.
+
+### Current QRSS/FSKCW Standard Spacing
+
+```text
 Intra Element Gap:    1
 Inter Character Gap:  3
 Inter Word Gap:       7
 ```
 
-This corresponds to QRSS3 with standard Morse spacing.
+### Current DFCW Standard Spacing
+
+```text
+DFCW Intra Element Gap:    0.333333
+DFCW Inter Character Gap:  1
+DFCW Inter Word Gap:       3
+```
+
+These triplets are intentionally different and must remain separately persisted.
 
 ## Proposed Operator Model
 
 ### Modulation Mode
 
-Continue to provide the existing modulation choices:
+Continue providing the existing modulation choices:
 
 - QRSS
 - FSKCW
 - DFCW
 
-These choices control how the signal is generated. They are separate from the speed preset.
+The modulation selection controls how the signal is generated. It is separate from the Speed preset.
+
+Changing modulation must:
+
+- preserve the shared Dot Seconds value;
+- preserve both stored spacing triplets;
+- display the spacing triplet applicable to the selected modulation;
+- infer Standard or Advanced spacing from the active triplet;
+- recalculate the active mode’s displayed durations;
+- not normalize or overwrite either triplet merely because modulation changed.
+
+QRSS and FSKCW use the same conventional spacing triplet. DFCW uses its separate DFCW spacing triplet.
 
 ### Speed Preset
 
@@ -81,69 +151,104 @@ Add a Speed control with four choices:
 - QRSS6
 - Advanced
 
-The choices map to dot duration as follows:
+The preset names use established QRSS speed nomenclature, but the selected base duration applies to QRSS, FSKCW, and DFCW.
 
-| Speed | Dot duration |
-|---|---:|
-| QRSS1 | 1 second |
-| QRSS3 | 3 seconds |
-| QRSS6 | 6 seconds |
-| Advanced | Operator-defined positive duration |
+Recommended supporting text:
 
-QRSS3 is the default when a new or incomplete CW configuration requires a default.
+```text
+Select the shared base duration used by QRSS, FSKCW, and DFCW.
+Each modulation retains its own dot, dash, tone, and spacing behavior.
+```
+
+QRSS3 is the default when no valid existing shared dot duration is available.
 
 ### Dot Duration
 
-Keep the Dot Duration field visible for all speed selections.
+Keep Dot Duration visible for every Speed selection.
 
 For QRSS1, QRSS3, and QRSS6:
 
-- Populate the corresponding duration.
+- Populate Dot Duration with `1`, `3`, or `6`.
 - Disable manual editing.
-- Display the selected value clearly.
-- Explain that the duration comes from the selected speed preset.
+- Display the effective value clearly.
+- Explain that the selected Speed preset determines the value.
 
 For Advanced:
 
 - Enable manual editing.
-- Preserve the current valid duration when switching into Advanced.
+- Preserve the currently effective valid Dot Duration when entering Advanced.
 - Require a finite value greater than zero.
-- Continue using the backend’s existing validation limits and semantics.
+- Continue using existing backend validation limits and semantics.
 
-Selecting Advanced must not blank or arbitrarily reset the current duration.
+Selecting Advanced must not blank or arbitrarily replace the current duration.
+
+The initial implementation does not retain hidden previous advanced drafts. For example:
+
+```text
+Advanced 2.5 → QRSS3 → Advanced
+```
+
+results in an editable value of `3`, not restoration of `2.5`.
+
+This is intentional. Hidden draft restoration is outside the initial scope.
 
 ### Spacing Mode
 
-Add a separate Spacing control with two choices:
+Add one visible Spacing control with two choices:
 
 - Standard
 - Advanced
 
-This control is independent of the Speed preset. An operator may therefore use:
+The visible control operates on the spacing triplet applicable to the selected modulation.
 
-- QRSS1 with standard spacing
-- QRSS3 with advanced spacing
-- QRSS6 with standard spacing
-- An advanced dot duration with either standard or advanced spacing
+| Selected modulation | Active spacing triplet |
+|---|---|
+| QRSS | Shared QRSS/FSKCW triplet |
+| FSKCW | Shared QRSS/FSKCW triplet |
+| DFCW | DFCW-specific triplet |
+
+Spacing is independent of Speed. Examples include:
+
+- QRSS1 with Standard QRSS spacing
+- FSKCW3 with Advanced conventional spacing
+- DFCW6 with Standard DFCW spacing
+- an Advanced base duration with either Standard or Advanced mode-specific spacing
 
 ### Standard Spacing
 
-Standard spacing uses these multipliers:
+Standard spacing is mode-aware.
+
+#### QRSS and FSKCW
 
 | Gap | Multiplier |
 |---|---:|
-| Intra-element | 1× dot |
-| Inter-character | 3× dot |
-| Inter-word | 7× dot |
+| Intra-element | `1` |
+| Inter-character | `3` |
+| Inter-word | `7` |
 
-When Standard spacing is selected:
+#### DFCW
 
-- Populate the gap fields with `1`, `3`, and `7`.
-- Disable manual editing of the three multiplier fields.
+| Gap | Multiplier |
+|---|---:|
+| Intra-element | `0.333333` |
+| Inter-character | `1` |
+| Inter-word | `3` |
+
+When Standard is selected:
+
+- Populate only the active triplet with its canonical standard values.
+- Disable manual editing of the visible active triplet.
 - Continue displaying the fields so the operator can see the effective rules.
-- Display the calculated duration for each gap.
+- Display the calculated duration for each visible gap.
+- Preserve the inactive triplet unchanged.
+- Validate the resulting active values.
+- Schedule one coherent autosave after state is complete.
+
+Selecting Standard is an intentional configuration change. It replaces custom values only in the active triplet.
 
 Examples:
+
+#### QRSS/FSKCW Standard Spacing
 
 | Speed | Intra-element | Inter-character | Inter-word |
 |---|---:|---:|---:|
@@ -151,21 +256,44 @@ Examples:
 | QRSS3 | 3 seconds | 9 seconds | 21 seconds |
 | QRSS6 | 6 seconds | 18 seconds | 42 seconds |
 
+#### DFCW Standard Spacing
+
+The persisted DFCW intra-element multiplier is the canonical decimal `0.333333`, not an exact mathematical one-third.
+
+| Speed | Intra-element | Inter-character | Inter-word |
+|---|---:|---:|---:|
+| QRSS1 | 0.333333 second | 1 second | 3 seconds |
+| QRSS3 | 0.999999 second | 3 seconds | 9 seconds |
+| QRSS6 | 1.999998 seconds | 6 seconds | 18 seconds |
+
+The UI may format calculated durations for readability, but presentation rounding must not change persisted values or preset inference.
+
+If rounded values are shown, supporting text or accessible detail must avoid implying that the canonical persisted multiplier has changed.
+
 ### Advanced Spacing
 
 When Advanced spacing is selected:
 
-- Enable the three existing gap multiplier fields.
+- Enable the three fields in the active triplet.
 - Preserve their current valid values.
 - Require every multiplier to be finite and greater than zero.
-- Display the calculated duration beside or beneath each field.
-- Recalculate the displayed duration whenever the dot duration or a multiplier changes.
+- Display calculated durations beside or beneath the active fields.
+- Recalculate displayed durations whenever Dot Duration or an active multiplier changes.
+- Preserve the inactive triplet unchanged.
 
 The persisted values remain multipliers, not seconds.
 
+The initial implementation does not restore hidden previous advanced spacing drafts. For example:
+
+```text
+Advanced spacing → Standard → Advanced spacing
+```
+
+retains the newly applied standard values and makes them editable. It does not restore the earlier custom triplet.
+
 ## Proposed UI Organization
 
-Place all related timing controls together near the top of the CW Control panel.
+Place the related timing controls together near the top of CW Control.
 
 Recommended organization:
 
@@ -180,19 +308,24 @@ CW Control
 
   Dot duration:
   [ 3 seconds — disabled ]
-  Determined by the QRSS3 preset.
+  QRSS3 provides a shared base duration of three seconds.
 
   Spacing:
   [ Standard ] [ Advanced ]
 
   Intra-element:
-  [ 1 — disabled ] × dot = 3 seconds
+  [ active multiplier — disabled ] × base duration = calculated duration
 
   Inter-character:
-  [ 3 — disabled ] × dot = 9 seconds
+  [ active multiplier — disabled ] × base duration = calculated duration
 
   Inter-word:
-  [ 7 — disabled ] × dot = 21 seconds
+  [ active multiplier — disabled ] × base duration = calculated duration
+
+  Mode-specific explanation:
+  QRSS and FSKCW use conventional 1×/3×/7× spacing.
+  DFCW uses its existing 0.333333×/1×/3× spacing and
+  frequency-distinguished equal-duration elements.
 
   Frequency and Schedule
   Base frequency | Frequency offset
@@ -200,23 +333,34 @@ CW Control
   Start minute | Repeat interval
 ```
 
-The exact responsive arrangement may vary, but the semantic grouping must remain clear.
+Only the spacing triplet applicable to the selected modulation should be presented as active.
+
+The UI may:
+
+- reuse the existing separate QRSS/FSKCW and DFCW controls;
+- show and hide the applicable triplet;
+- or bind one visible presentation to separate underlying values.
+
+Regardless of implementation, both persisted triplets must survive loading, editing, modulation changes, and saving.
+
+### Narrow-Screen Order
 
 On narrow screens, controls should stack in this order:
 
 1. Modulation mode
 2. Speed preset
-3. Dot duration
+3. Dot Duration
 4. Spacing mode
-5. Gap controls
-6. Frequency controls
-7. Scheduling controls
+5. Active gap controls
+6. Mode-specific timing explanation
+7. Frequency controls
+8. Scheduling controls
 
 ## Configuration Compatibility
 
-### Existing Keys
+### Existing Timing Keys
 
-Continue using the existing configuration keys:
+Continue preserving all existing timing values:
 
 ```json
 {
@@ -224,10 +368,21 @@ Continue using the existing configuration keys:
     "Dot Seconds": 3.0,
     "Intra Element Gap": 1.0,
     "Inter Character Gap": 3.0,
-    "Inter Word Gap": 7.0
+    "Inter Word Gap": 7.0,
+    "DFCW Intra Element Gap": 0.333333,
+    "DFCW Inter Character Gap": 1.0,
+    "DFCW Inter Word Gap": 3.0
   }
 }
 ```
+
+Confirm the exact spelling and capitalization against the current configuration contract before implementation.
+
+The timing inventory consists of:
+
+- one shared Dot Seconds value;
+- three QRSS/FSKCW spacing values;
+- three DFCW spacing values.
 
 Do not require new backend configuration keys for the initial implementation.
 
@@ -239,46 +394,95 @@ In particular, do not initially persist:
 - `Spacing Mode`
 - `Advanced Spacing`
 
-These are UI interpretations of the effective timing values.
+These are UI interpretations of effective persisted values.
 
-### Inferring the Speed Selection
+### Speed Inference
 
 When loading configuration:
 
-| Persisted Dot Seconds | Selected speed |
+| Persisted Dot Seconds | Selected Speed |
 |---:|---|
 | Exactly `1` | QRSS1 |
 | Exactly `3` | QRSS3 |
 | Exactly `6` | QRSS6 |
 | Any other valid positive value | Advanced |
 
-Use numeric comparison appropriate for parsed configuration values. Do not use formatted display strings to infer the selection.
+Use strict numeric equality after finite-number parsing.
 
-### Inferring the Spacing Selection
+Preset values are exactly representable and are written directly by the UI. Do not use fuzzy comparison that would classify a deliberate custom value such as `3.0000001` as QRSS3.
 
-When loading configuration:
+### Mode-Aware Spacing Inference
 
-| Persisted multipliers | Selected spacing |
+Infer Spacing independently from the active triplet.
+
+#### QRSS or FSKCW Selected
+
+| Active persisted multipliers | Selected Spacing |
 |---|---|
 | Exactly `1`, `3`, and `7` | Standard |
 | Any other valid positive combination | Advanced |
 
-A custom configuration must remain custom after loading and saving.
+#### DFCW Selected
+
+| Active persisted multipliers | Selected Spacing |
+|---|---|
+| Exactly `0.333333`, `1`, and `3` | Standard |
+| Any other valid positive combination | Advanced |
+
+Use the exact canonical persisted DFCW constant `0.333333`. Do not infer Standard by comparing against an independently calculated one-third value.
+
+The inactive triplet does not determine the visible Spacing selection.
+
+Examples:
+
+- QRSS selected, conventional triplet standard, DFCW triplet custom:
+  - visible Spacing is Standard;
+  - DFCW custom values remain untouched.
+- DFCW selected, DFCW triplet custom, conventional triplet standard:
+  - visible Spacing is Advanced;
+  - conventional standard values remain untouched.
+- Switching between those modes changes the visible inference without modifying either triplet.
 
 ### Defaults
 
-When no valid CW timing is available, use:
+When timing keys are absent, use:
 
 ```text
-Speed:               QRSS3
-Dot Seconds:         3
-Spacing:             Standard
-Intra Element Gap:   1
-Inter Character Gap: 3
-Inter Word Gap:      7
+Speed:                         QRSS3
+Dot Seconds:                   3
+
+QRSS/FSKCW spacing:
+  Intra Element Gap:           1
+  Inter Character Gap:         3
+  Inter Word Gap:              7
+
+DFCW spacing:
+  DFCW Intra Element Gap:      0.333333
+  DFCW Inter Character Gap:    1
+  DFCW Inter Word Gap:         3
 ```
 
-An existing valid configuration always takes precedence over these defaults.
+An existing valid configuration takes precedence over these defaults.
+
+### Missing, Invalid, and Malformed Values
+
+Treat these cases separately:
+
+1. **Absent key**
+   - Apply the established default for that key.
+   - Do not disturb other present valid values.
+
+2. **Present numeric but non-finite or non-positive value**
+   - Preserve visible evidence of invalid input when the current data path can represent it.
+   - Select Advanced for the affected active timing group.
+   - Present validation requiring correction.
+   - Do not silently normalize corruption into a valid preset unless existing backend behavior prevents the value from reaching the UI.
+
+3. **Wrong JSON type or structurally malformed configuration**
+   - Preserve the backend’s configuration parsing error behavior.
+   - Do not conceal a parsing failure by treating it as an absent value.
+
+Implementation must inspect the existing loader and backend parser before finalizing invalid-value behavior. It must not weaken existing configuration validation.
 
 ## State-Transition Rules
 
@@ -286,54 +490,86 @@ An existing valid configuration always takes precedence over these defaults.
 
 When an operator selects a preset:
 
-1. Set Dot Seconds to the preset value.
+1. Set shared Dot Seconds to `1`, `3`, or `6`.
 2. Disable manual editing of Dot Duration.
-3. Recalculate all displayed gap durations.
-4. Validate the effective configuration.
-5. Use the existing autosave workflow.
+3. Preserve both spacing triplets.
+4. Recalculate displayed durations for the active modulation.
+5. Revalidate the effective active timing and message duration.
+6. Schedule one autosave after state is coherent.
+
+The selected Speed persists across modulation changes because Dot Seconds is shared.
 
 ### Selecting Advanced Speed
 
 When an operator selects Advanced:
 
-1. Retain the current valid Dot Seconds value.
-2. Enable the Dot Duration field.
-3. Focus behavior should not unexpectedly select, erase, or replace the value.
-4. Revalidate changes through the existing live-validation workflow.
+1. Retain the currently effective valid Dot Seconds.
+2. Enable Dot Duration.
+3. Do not erase, replace, or unexpectedly select the value.
+4. Preserve both spacing triplets.
+5. Revalidate through the existing live-validation workflow.
+6. Schedule autosave only when the effective value actually changes.
 
 ### Selecting Standard Spacing
 
 When an operator selects Standard:
 
-1. Set the multipliers to `1`, `3`, and `7`.
-2. Disable manual editing of the multiplier fields.
-3. Recalculate displayed gap durations.
-4. Validate the effective configuration.
-5. Use the existing autosave workflow.
-
-Switching from Advanced spacing to Standard is an intentional configuration change. It replaces custom multipliers with `1`, `3`, and `7`.
+1. Determine the active triplet from the selected modulation.
+2. For QRSS or FSKCW, set only the shared conventional triplet to `1/3/7`.
+3. For DFCW, set only the DFCW triplet to `0.333333/1/3`.
+4. Preserve the inactive triplet unchanged.
+5. Disable manual editing of the active fields.
+6. Recalculate displayed active gap durations.
+7. Revalidate the effective active timing and message duration.
+8. Schedule one autosave after state is coherent.
 
 ### Selecting Advanced Spacing
 
 When an operator selects Advanced spacing:
 
-1. Retain the current valid multipliers.
-2. Enable the three multiplier fields.
-3. Continue showing calculated durations.
-4. Revalidate changes through the existing live-validation workflow.
+1. Determine the active triplet from the selected modulation.
+2. Retain the active triplet’s current values.
+3. Enable the active fields.
+4. Preserve the inactive triplet unchanged.
+5. Continue showing calculated active durations.
+6. Revalidate through the existing live-validation workflow.
+7. Do not autosave merely because controls became editable if values did not change.
+
+### Changing Modulation
+
+When changing between QRSS, FSKCW, and DFCW:
+
+1. Preserve shared Dot Seconds.
+2. Preserve the QRSS/FSKCW spacing triplet.
+3. Preserve the DFCW spacing triplet.
+4. Select the newly active triplet.
+5. Infer Standard or Advanced from that triplet.
+6. Update field visibility and enablement.
+7. Update mode-specific explanatory text.
+8. Recalculate active durations and message duration.
+9. Do not normalize the newly active triplet.
+10. Do not overwrite the newly inactive triplet.
+11. Follow the existing guarded mode-change and autosave policy.
+
+A modulation change must not be treated as a request to apply Standard spacing.
 
 ### Loading Existing Configuration
 
 During configuration population:
 
-1. Load the four persisted timing values.
-2. Infer Speed from Dot Seconds.
-3. Infer Spacing from the three multipliers.
-4. Set enabled and disabled states without causing an unintended autosave.
-5. Calculate the displayed effective durations.
-6. Synchronize the autosave baseline only after population is complete.
+1. Load shared Dot Seconds.
+2. Load the complete QRSS/FSKCW spacing triplet.
+3. Load the complete DFCW spacing triplet.
+4. Infer Speed from Dot Seconds.
+5. Determine the active triplet from the selected modulation.
+6. Infer visible Spacing from the active triplet.
+7. Set visible values, help text, and enabled states.
+8. Calculate active gap durations and message duration.
+9. Preserve inactive values in UI state.
+10. Avoid triggering autosave or normalization.
+11. Synchronize the autosave baseline only after population is complete.
 
-Configuration loading must not overwrite custom timing merely because a preset selector now exists.
+Configuration loading must not overwrite custom timing merely because preset controls now exist.
 
 ### Disabled Fields and Serialization
 
@@ -341,62 +577,119 @@ Disabled timing fields still represent active configuration values.
 
 Before collecting the configuration payload:
 
-- Read the effective timing state rather than relying on browser form submission semantics.
-- Ensure Dot Seconds and all three gap multipliers remain present.
-- Serialize the same four existing `CW` keys.
-- Never treat a disabled control as an absent or optional setting.
+- Read canonical effective timing state rather than relying on native browser form-submission semantics.
+- Include shared Dot Seconds.
+- Include all three QRSS/FSKCW gap multipliers.
+- Include all three DFCW gap multipliers.
+- Preserve inactive custom values.
+- Never treat a disabled or hidden timing control as absent.
+- Never derive the inactive triplet from the active triplet.
+- Serialize all existing timing keys with their existing numeric semantics.
+
+## Central Timing-State Requirement
+
+Do not scatter preset, enablement, validation, calculation, and autosave behavior among unrelated event handlers.
+
+Implement testable timing-state functions that can:
+
+- parse Dot Seconds;
+- infer Speed;
+- identify the active spacing triplet;
+- infer mode-aware Spacing;
+- apply a Speed transition;
+- apply a Standard or Advanced spacing transition;
+- preserve the inactive triplet;
+- compute calculated gap durations;
+- expose canonical effective values for serialization;
+- synchronize controls without autosaving during population.
+
+Keep pure timing decisions independent of DOM mutation and autosave where practical.
+
+Each intentional selector transition should follow one coherent path:
+
+1. update canonical values;
+2. update visible controls;
+3. update enabled states and help text;
+4. recalculate durations;
+5. validate once;
+6. schedule no more than one autosave.
+
+Configuration population must use a non-saving synchronization path.
 
 ## Validation
 
-### Dot Duration
+### Shared Dot Duration
 
 Dot Duration must be:
 
-- numeric
-- finite
-- greater than zero
+- numeric;
+- finite;
+- greater than zero.
 
-When a preset is selected, validation applies to the effective preset value even though the field is disabled.
+When a preset is selected, validate the canonical preset value even if the visible input is disabled.
+
+Do not rely solely on existing validation behavior that treats a disabled input as valid.
 
 ### Gap Multipliers
 
-Every multiplier must be:
+All six persisted gap multipliers must be:
 
-- numeric
-- finite
-- greater than zero
+- numeric;
+- finite;
+- greater than zero.
 
-When Standard spacing is selected, validation applies to the effective `1`, `3`, and `7` values.
+The visible validation state should emphasize the active triplet, but serialization must never replace an invalid inactive value silently.
 
-### Repeat Interval
+When Standard is selected:
 
-Existing message-duration and repeat-interval validation remains applicable.
+- QRSS/FSKCW canonical values are `1/3/7`;
+- DFCW canonical values are `0.333333/1/3`.
 
-The implementation must continue detecting configurations in which the calculated CW message duration exceeds the configured repeat interval.
+### Message Duration and Repeat Interval
+
+Existing mode-specific message-duration and repeat-interval validation remains applicable.
+
+The implementation must continue detecting configurations in which the calculated message duration exceeds the configured repeat interval.
+
+Duration calculation must use:
+
+- shared Dot Seconds;
+- the selected modulation’s element-construction rules;
+- the selected modulation’s active spacing triplet;
+- the actual message.
 
 This is especially important for:
 
-- QRSS6
-- long messages
-- large advanced gap multipliers
-- custom dot durations
+- QRSS6;
+- FSKCW6;
+- DFCW6;
+- long messages;
+- large advanced gap multipliers;
+- custom Dot Duration;
+- modulation changes that activate a different spacing triplet.
+
+The UI estimate and backend repeat-policy calculation must agree for equivalent inputs.
 
 ## Accessibility and Interaction Requirements
 
-- Use a fieldset and legend or an equivalent accessible grouping for Speed.
+- Use a fieldset and legend or equivalent accessible grouping for Speed.
 - Use a separate accessible group for Spacing.
-- Do not communicate disabled or advanced state through color alone.
-- Associate all explanatory text and calculated-duration output with the applicable control.
+- Associate Spacing with the selected modulation’s timing context.
+- Do not communicate disabled, active, standard, or advanced state through color alone.
+- Associate help and calculated-duration output with applicable controls.
 - Keep keyboard operation complete and predictable.
-- Ensure disabled values remain readable in both light and dark themes.
-- Announce calculated-duration changes appropriately without creating excessive screen-reader chatter.
-- Use operator-facing names and avoid exposing internal variable or JSON key names as primary labels.
+- Preserve visible focus indicators.
+- Ensure disabled values remain legible in light and dark themes.
+- Announce meaningful calculated-duration changes without excessive screen-reader chatter.
+- Use operator-facing terminology rather than internal variable or JSON names.
 - Preserve visible validation feedback for advanced editable fields.
 - Explain how to enable editing when a field is disabled.
+- Explain that QRSS speed names select a shared base duration without implying identical modulation construction.
 
-Suggested operator-facing labels:
+Suggested labels:
 
 ```text
+Modulation
 Speed
 Dot duration
 Spacing
@@ -408,80 +701,99 @@ Inter-word gap
 Suggested supporting text:
 
 ```text
-QRSS3 uses a three-second dot duration.
+QRSS3 selects a shared base duration of three seconds.
 
-Standard spacing uses 1×, 3×, and 7× the selected dot duration.
+QRSS and FSKCW use conventional dot, dash, and spacing timing.
 
-Select Advanced to enter a custom dot duration.
+DFCW uses equal-duration, frequency-distinguished elements and
+DFCW-specific spacing.
 
-Select Advanced spacing to edit the gap multipliers.
+Select Advanced to enter a custom base duration.
+
+Select Advanced spacing to edit the active mode’s gap multipliers.
 ```
 
 ## Impeccable Requirement
 
-This is UI work and must use the Impeccable skill as required by the repository’s `AGENTS.md`.
+This is UI work and must use the Impeccable skill as required by `AGENTS.md`.
 
 Before implementation:
 
-1. Confirm that the Impeccable skill is installed and available.
-2. Read and follow its instructions.
-3. Inspect the existing WsprryPi design language and responsive behavior.
+1. Confirm that Impeccable is installed and usable.
+2. Read its instructions completely.
+3. Load the required `WsprryPi-UI` product and design context.
+4. Use the product register appropriate to the technical appliance interface.
+5. Inspect existing desktop, mobile, light-theme, and dark-theme behavior.
 
 During and after implementation:
 
-1. Use Impeccable to review the proposed grouping and hierarchy.
-2. Render the actual Setup page.
-3. Exercise QRSS1, QRSS3, QRSS6, Advanced speed, Standard spacing, and Advanced spacing.
-4. Inspect desktop and mobile layouts.
-5. Inspect both supported themes.
-6. Review disabled, enabled, invalid, saving, and saved states.
-7. Address applicable findings.
-8. Report any finding intentionally not adopted and why.
+1. Use Impeccable to review hierarchy and progressive disclosure.
+2. Preserve the restrained bench-instrument design language.
+3. Render the actual Setup page.
+4. Exercise every modulation and timing combination.
+5. Inspect desktop and mobile layouts.
+6. Inspect both supported themes.
+7. Review disabled, enabled, invalid, saving, saved, and failed-save states.
+8. Address applicable findings.
+9. Report findings intentionally not adopted and why.
+10. Finish with an Impeccable polish pass.
 
 If Impeccable is unavailable, stop before changing UI files.
 
-Do not commit `.agents/`, `.impeccable/`, or other local skill/runtime state unless explicitly requested.
+Do not commit `.agents/`, `.impeccable/`, `.codex/`, or other local runtime state unless explicitly requested.
 
 ## Repository Boundaries
 
 ### `WsprryPi-UI`
 
-Expected UI work belongs in the root `WsprryPi-UI` submodule, including:
+UI work belongs in the root `WsprryPi-UI` submodule, including:
 
-- timing control markup
-- labels and help text
-- responsive layout
-- selection and enablement logic
-- calculated-duration presentation
-- form population
-- autosave interaction
-- UI validation
-- UI-specific tests
+- timing-control markup;
+- labels and help text;
+- responsive layout;
+- Speed and Spacing selection;
+- mode-aware enablement;
+- calculated-duration presentation;
+- configuration population;
+- canonical timing-state logic;
+- autosave interaction;
+- UI validation;
+- behavioral UI tests.
 
 Inspect the submodule at the exact commit recorded by the parent repository before making changes.
 
 ### `WsprryPi`
 
-Expected parent-repository work may include:
+Parent-repository work may include:
 
-- UI/source regression tests
-- integration-contract tests
-- configuration compatibility tests
-- message-duration and repeat-policy regression coverage
-- documentation or planning references
-- a reviewed update to the `WsprryPi-UI` submodule pointer
+- UI/source regression tests;
+- integration-contract tests;
+- configuration compatibility tests;
+- mode-specific message-duration coverage;
+- repeat-policy regression coverage;
+- documentation or planning references;
+- a reviewed `WsprryPi-UI` submodule-pointer update.
 
 The backend configuration schema should not require modification for the initial implementation.
 
-### `src/` Submodules
+Existing backend source may require no functional change if the UI can preserve its current seven-value timing contract. Do not modify backend code merely to make the change appear symmetrical.
+
+### `src/` Dependency Submodules
 
 No changes to dependency submodules under `src/` are expected.
 
-If implementation appears to require such a change, stop and report why before modifying a dependency.
+If implementation appears to require such a change, stop and report:
+
+- the affected submodule;
+- why parent or UI changes are insufficient;
+- the proposed dependency modification;
+- required validation.
+
+Do not modify a dependency without explicit approval.
 
 ## Expected Implementation Seams
 
-Confirm current paths before implementation.
+Confirm current paths and contracts before implementation.
 
 Likely UI seams:
 
@@ -503,36 +815,70 @@ src/scheduling.cpp
 src/tests/ui_source_regression_test.cpp
 src/tests/dial_frequency_semantics_test.cpp
 src/tests/non_wspr_repeat_policy_test.cpp
+src/tests/qrss_execution_regression_test.cpp
 ```
 
-Do not modify every listed file automatically. Inspect the current contracts and change only what the approved implementation requires.
+Do not modify every listed file automatically. Inspect current contracts and change only what the approved implementation requires.
+
+## UI Behavioral Test Requirement
+
+The current source-fragment regression test is insufficient to prove state transitions, serialization, accessibility state, or autosave behavior.
+
+Add a small behavioral test harness suitable for the current UI architecture.
+
+Prefer:
+
+- testable pure timing-state functions;
+- a lightweight DOM-capable JavaScript test layer where DOM behavior must be exercised;
+- deterministic tests that do not require live hardware;
+- no unnecessary production dependency expansion.
+
+The exact harness may be selected during implementation, but string-search assertions alone do not satisfy the behavioral acceptance criteria.
 
 ## Required Test Coverage
 
-### UI State Tests
+### Speed Tests
 
 Verify:
 
-- Missing timing defaults to QRSS3.
-- QRSS1 sets Dot Seconds to `1`.
-- QRSS3 sets Dot Seconds to `3`.
-- QRSS6 sets Dot Seconds to `6`.
-- Preset dot fields are disabled.
-- Advanced enables Dot Duration.
-- Entering Advanced preserves the current valid value.
-- A custom dot duration loads as Advanced.
-- Standard spacing sets `1`, `3`, and `7`.
-- Standard spacing disables the multiplier fields.
-- Advanced spacing enables the multiplier fields.
-- Custom multipliers load as Advanced spacing.
-- Switching from Advanced spacing to Standard intentionally restores `1`, `3`, and `7`.
-- Switching into Advanced spacing retains the current values.
+- absent Dot Seconds defaults to QRSS3;
+- QRSS1 sets Dot Seconds to `1`;
+- QRSS3 sets Dot Seconds to `3`;
+- QRSS6 sets Dot Seconds to `6`;
+- preset Dot Duration is disabled;
+- Advanced enables Dot Duration;
+- entering Advanced retains the current effective value;
+- custom positive Dot Duration loads as Advanced;
+- `3.0000001` loads as Advanced, not QRSS3;
+- speed selection persists across QRSS, FSKCW, and DFCW changes;
+- speed changes preserve both spacing triplets.
+
+### Mode-Aware Spacing Tests
+
+Verify:
+
+- QRSS with `1/3/7` infers Standard;
+- FSKCW with `1/3/7` infers Standard;
+- DFCW with `0.333333/1/3` infers Standard;
+- a noncanonical conventional triplet infers Advanced;
+- a noncanonical DFCW triplet infers Advanced;
+- mathematical one-third does not replace canonical `0.333333`;
+- Standard QRSS or FSKCW writes only `1/3/7`;
+- Standard DFCW writes only `0.333333/1/3`;
+- Standard disables the active fields;
+- Advanced enables the active fields;
+- selecting Standard preserves the inactive triplet;
+- selecting Advanced does not change either triplet;
+- switching modulation changes visible inference without normalization;
+- QRSS and FSKCW expose the same shared triplet;
+- DFCW exposes its separate triplet;
+- custom inactive values survive modulation changes and saving.
 
 ### Calculated-Duration Tests
 
-Verify:
+#### QRSS/FSKCW Cases
 
-| Dot duration | Multipliers | Expected durations |
+| Dot Duration | Multipliers | Expected gap durations |
 |---:|---|---|
 | 1 | `1/3/7` | `1/3/7` seconds |
 | 3 | `1/3/7` | `3/9/21` seconds |
@@ -540,129 +886,301 @@ Verify:
 | 2.5 | `1/3/7` | `2.5/7.5/17.5` seconds |
 | 3 | `1.5/4/8` | `4.5/12/24` seconds |
 
-Presentation formatting must not change the persisted numeric values.
+#### DFCW Cases
+
+| Dot Duration | Multipliers | Exact calculated gap durations |
+|---:|---|---|
+| 1 | `0.333333/1/3` | `0.333333/1/3` seconds |
+| 3 | `0.333333/1/3` | `0.999999/3/9` seconds |
+| 6 | `0.333333/1/3` | `1.999998/6/18` seconds |
+| 2.5 | `0.333333/1/3` | `0.8333325/2.5/7.5` seconds |
+| 3 | `0.5/2/4` | `1.5/6/12` seconds |
+
+Verify calculations before presentation formatting.
+
+Presentation rounding must not:
+
+- change persisted values;
+- affect Standard inference;
+- change message-duration calculations;
+- rewrite canonical `0.333333`.
+
+### Element-Construction Tests
+
+Verify that preset selection changes only shared \(T\), not mode construction:
+
+- QRSS dot remains \(T\);
+- QRSS dash remains \(3T\);
+- FSKCW dot remains \(T\);
+- FSKCW dash remains \(3T\);
+- DFCW dot remains a tone-distinguished element of \(T\);
+- DFCW dash remains a different-tone element of \(T\);
+- DFCW is not converted to a \(T/3T\) keyed-element model;
+- existing mode-specific message duration remains consistent with runtime scheduling.
 
 ### Persistence Tests
 
-Verify that configuration collection continues emitting:
+Verify that collection continues emitting all existing timing keys:
 
 ```text
 CW.Dot Seconds
 CW.Intra Element Gap
 CW.Inter Character Gap
 CW.Inter Word Gap
+CW.DFCW Intra Element Gap
+CW.DFCW Inter Character Gap
+CW.DFCW Inter Word Gap
 ```
+
+Confirm exact key names against current source.
 
 Verify:
 
-- Preset values save correctly.
-- Disabled fields are still serialized.
-- Advanced values survive save and reload.
-- Existing custom configurations round-trip without loss.
-- Loading configuration does not trigger an unintended normalization autosave.
-- No new backend keys are required.
+- preset values save correctly;
+- disabled fields remain serialized;
+- hidden inactive values remain serialized;
+- Advanced values survive save and reload;
+- both custom triplets survive round-trip;
+- saving QRSS or FSKCW does not reset DFCW spacing;
+- saving DFCW does not reset QRSS/FSKCW spacing;
+- loading configuration does not cause normalization autosave;
+- population causes no PATCH or autosave;
+- one selector action causes no more than one coherent autosave;
+- no new backend keys are required.
+
+### Invalid-Value Tests
+
+Verify:
+
+- absent values use documented defaults;
+- zero is rejected;
+- negative values are rejected;
+- blank advanced inputs are rejected;
+- non-finite-equivalent values are rejected;
+- wrong JSON types retain existing backend error behavior;
+- disabled preset controls serialize canonical valid values;
+- invalid custom values are not silently relabeled as presets;
+- validation identifies the applicable active controls;
+- inactive values are not silently discarded.
 
 ### Backend Regression Tests
 
 Verify:
 
-- Dot duration remains shared across QRSS, FSKCW, and DFCW.
-- Standard and advanced multipliers produce the expected runtime durations.
-- All four values remain subject to backend validation.
-- Message-duration calculations continue including inter-element, inter-character, and inter-word spacing.
-- Repeat-policy rejection still works for messages longer than the repeat interval.
-- Existing configurations without UI metadata remain valid.
+- Dot Seconds remains shared across QRSS, FSKCW, and DFCW;
+- QRSS and FSKCW continue sharing conventional gap values;
+- DFCW continues using separate gap values;
+- all seven timing values load, validate, serialize, and round-trip;
+- conventional timing produces expected runtime durations;
+- DFCW timing produces expected runtime durations;
+- message-duration calculations include mode-appropriate spacing;
+- repeat-policy rejection works for messages longer than the interval;
+- existing configurations without UI metadata remain valid;
+- no backend migration is required.
 
 ### Visual and Workflow Tests
 
 Using Impeccable and the rendered application, verify:
 
-- desktop layout
-- mobile layout
-- light theme
-- dark theme
-- QRSS1, QRSS3, and QRSS6 selections
-- Advanced dot editing
-- Standard and Advanced spacing
-- disabled-field legibility
-- validation errors
-- calculated-duration updates
-- autosave feedback
-- reload and restoration of custom values
+- desktop layout at approximately `1440 × 900`;
+- narrow/mobile layout at approximately `390 × 844`;
+- light theme;
+- dark theme;
+- QRSS, FSKCW, and DFCW;
+- QRSS1, QRSS3, and QRSS6;
+- Advanced Dot Duration;
+- Standard and Advanced mode-aware spacing;
+- mode switching with one standard and one custom triplet;
+- mode switching with both triplets custom;
+- disabled-field legibility;
+- calculated-duration updates;
+- message-duration and repeat validation;
+- autosave feedback;
+- reload restoration;
+- keyboard order and radio-group behavior;
+- focus behavior when entering Advanced;
+- accessible group names and descriptions;
+- live-output announcements;
+- saving, saved, invalid, and failed-save states.
 
-Automated tests do not replace this workflow exercise.
+Automated tests do not replace rendered-page workflow inspection.
+
+## Automated Validation
+
+After implementation, inspect current Makefile targets before running them.
+
+Expected safe parent-repository validation from `src` includes:
+
+```sh
+make semantics-test
+make non-wspr-repeat-policy-test
+make qrss-execution-regression-test
+```
+
+Also run the new UI behavioral test target from the appropriate UI repository location.
+
+Do not run:
+
+```sh
+make test
+make test-tone
+make test-oneshot
+```
+
+unless separately authorized after inspecting their operational behavior. These may use elevated privileges or exercise transmitter paths.
+
+Final static checks must include:
+
+```sh
+git diff --check
+git status --short --branch
+git submodule status --recursive
+git submodule foreach --recursive 'git status --short --branch'
+```
+
+Report parent and submodule state separately.
 
 ## Acceptance Criteria
 
 The feature is acceptable when:
 
-- CW Modes defaults to QRSS3 when no valid existing timing is available.
+- CW Speed defaults to QRSS3 when no valid Dot Seconds value is available.
 - Operators can select QRSS1, QRSS3, or QRSS6 directly.
-- Presets reliably produce one-, three-, or six-second dots.
-- Dot Duration is editable only in Advanced speed.
-- Standard spacing reliably produces `1/3/7` multipliers.
-- Gap multipliers are editable only in Advanced spacing.
-- The UI displays calculated gap durations.
+- The presets select shared \(T\) values of one, three, or six seconds.
+- Dot Duration is editable only in Advanced Speed.
+- Speed selection applies to QRSS, FSKCW, and DFCW.
+- QRSS and FSKCW preserve their existing \(T/3T\) element timing.
+- DFCW preserves equal-duration, frequency-distinguished elements.
+- Standard QRSS/FSKCW spacing produces `1/3/7`.
+- Standard DFCW spacing produces `0.333333/1/3`.
+- Advanced spacing edits only the active triplet.
+- Changing modulation never normalizes or overwrites either triplet.
+- Both triplets survive loading, switching, saving, and reloading.
+- Calculated durations reflect the active modulation and spacing.
 - Timing controls are grouped coherently.
-- Existing custom configurations remain custom and round-trip without loss.
+- Existing custom configurations round-trip without loss.
+- All seven existing timing values remain preserved.
 - No backend configuration migration is required.
-- QRSS, FSKCW, and DFCW continue sharing the established timing contract.
-- Relevant UI, persistence, backend, and repeat-policy tests pass.
-- Impeccable review and real rendered-page inspection are complete.
+- UI behavioral tests cover transitions, persistence, validation, and autosave.
+- Backend regression and repeat-policy tests pass.
+- Impeccable review and rendered-page inspection are complete.
 - Documentation impact has been reviewed.
 - No `src/` dependency submodule changes are required.
-- Parent and UI submodule changes remain separately reviewable.
-- Hardware or live-transmission validation is not claimed unless separately performed and authorized.
+- UI and parent-repository changes remain separately reviewable.
+- Hardware or live-transmission validation is not claimed unless separately authorized and performed.
 
 ## Non-Goals
 
 This initial feature does not:
 
-- change Morse dash duration from three dots
-- introduce independently persisted preset names
-- change the backend configuration schema
-- create different dot durations for QRSS, FSKCW, and DFCW
-- alter RF frequency behavior
-- alter frequency offset semantics
-- alter scheduling semantics
-- redesign the entire Setup page
-- modify transmitter hardware behavior
-- modify dependency submodules under `src/`
-- authorize live RF, GPIO, service, installation, or hardware testing
-- commit or push either repository
+- make all modulation modes instantiate identical elements;
+- change QRSS or FSKCW dash duration from \(3T\);
+- change DFCW to a \(T/3T\) element model;
+- change DFCW’s frequency-distinguished dot/dash behavior;
+- replace DFCW Standard spacing with `1/3/7`;
+- combine the two persisted spacing triplets;
+- create different Dot Seconds values for each modulation;
+- introduce persisted preset names;
+- introduce persisted Spacing-mode names;
+- restore hidden previous advanced drafts;
+- change the backend configuration schema;
+- alter RF frequency behavior;
+- alter Frequency Offset semantics;
+- alter scheduling semantics outside recalculation from existing timing;
+- redesign the entire Setup page;
+- modify transmitter hardware behavior;
+- modify dependency submodules under `src/`;
+- authorize live RF, GPIO, service, installation, or hardware testing;
+- commit or push either repository.
 
 ## Documentation Impact
 
-Implementation should review the operator documentation covering:
+Implementation must review operator documentation covering:
 
-- CW mode selection
-- QRSS timing
-- FSKCW and DFCW timing
-- CW gap multipliers
-- repeat intervals
-- the Signal Setup web interface
-- screenshots depicting the CW Control panel
+- CW modulation selection;
+- shared QRSS1, QRSS3, and QRSS6 Speed presets;
+- custom Dot Duration;
+- QRSS element timing;
+- FSKCW element timing;
+- DFCW equal-duration, frequency-distinguished elements;
+- conventional QRSS/FSKCW spacing;
+- DFCW-specific spacing;
+- calculated durations;
+- repeat intervals;
+- Signal Setup;
+- screenshots depicting CW Control.
 
-Documentation must distinguish:
+Documentation must clearly distinguish:
 
-- speed presets
-- custom dot duration
-- standard spacing
-- advanced spacing
-- multiplier values
-- calculated durations in seconds
+- modulation from Speed;
+- shared \(T\) from mode-specific element construction;
+- QRSS/FSKCW spacing from DFCW spacing;
+- multiplier values from calculated seconds;
+- Standard from Advanced behavior;
+- active from preserved inactive values.
 
-Screenshots should be replaced only when the changed UI makes the existing image materially inaccurate. Age alone is not a reason to replace a contextually correct screenshot.
+Recommended documentation wording:
+
+```text
+QRSS1, QRSS3, and QRSS6 select the shared base duration used by
+QRSS, FSKCW, and DFCW. Each modulation retains its own signal
+construction. QRSS and FSKCW use conventional dot, dash, and
+spacing timing. DFCW uses equal-duration elements distinguished
+by frequency and retains its DFCW-specific spacing.
+```
+
+Replace screenshots only when the changed interface makes an existing image materially inaccurate. Age alone is not a reason to replace a contextually correct screenshot.
+
+Do not include internal test or refactoring details in operator documentation unless they materially help the operator.
+
+## Submodule and Commit Boundaries
+
+The implementation is expected to involve the `WsprryPi-UI` submodule and parent `WsprryPi` repository.
+
+If commits are later authorized:
+
+1. Review the complete UI submodule diff.
+2. Run UI behavioral and Impeccable validation.
+3. Commit the UI change inside `WsprryPi-UI`.
+4. Ensure the UI commit is available on its intended remote before publishing a parent pointer to it.
+5. Review parent integration tests and documentation changes.
+6. Review the exact old and new UI submodule commit IDs.
+7. Commit the parent submodule-pointer update and parent changes separately or as an explicitly reviewed parent change.
+8. Push only when explicitly authorized.
+
+Do not modify or advance unrelated `src/` submodules.
+
+## Implementation Sequence
+
+1. Reconfirm the current parent and recursive submodule state.
+2. Confirm the seven-key timing inventory and exact key spelling.
+3. Confirm the current QRSS, FSKCW, and DFCW runtime timing constructors.
+4. Confirm Impeccable availability and load the UI product/design context.
+5. Add testable mode-aware timing-state functions.
+6. Add behavioral tests for inference, transitions, preservation, calculations, serialization, validation, and autosave.
+7. Add accessible Speed and Spacing controls.
+8. Wire one coherent transition path per selector.
+9. Preserve non-saving configuration population.
+10. Reorganize the panel into timing, frequency, and scheduling groups.
+11. Extend parent source-contract and backend regression coverage.
+12. Run safe automated tests.
+13. Render and inspect all required UI states with Impeccable.
+14. Update operator documentation.
+15. Review complete parent and submodule diffs.
+16. Report remaining hardware or runtime qualification separately.
+17. Commit or push only if explicitly requested.
 
 ## Implementation Gate
 
-This document is a proposed implementation contract, not authorization to modify code.
+This document is an implementation contract, not authorization to modify code.
 
 Before implementation:
 
 1. Inspect the current parent repository and recursive submodule state.
 2. Confirm the exact `WsprryPi-UI` revision.
-3. Confirm that Impeccable is available.
-4. Compare current implementation behavior with this document.
-5. Report any material drift or ambiguity.
-6. Obtain explicit approval to implement.
+3. Confirm the exact timing-key inventory.
+4. Confirm current mode-specific runtime construction.
+5. Confirm that Impeccable is available.
+6. Compare current behavior with this document.
+7. Report any remaining material drift or ambiguity.
+8. Obtain explicit approval to implement.

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1285,6 +1285,7 @@ void print_usage(const std::string &message, int exit_code)
               << "  --cw-shift-hz <hz>                 FSKCW/DFCW frequency shift in Hz.\n"
               << "  --cw-dot-seconds <seconds>         Dot length in seconds.\n"
               << "  --cw-start-minute <0-59>           Scheduled non-WSPR start minute.\n"
+              << "  --cw-start-second <0-59>           Seconds after the scheduled CW start minute. Default: 5.\n"
               << "  --cw-repeat-minutes <minutes>      Scheduled non-WSPR repeat interval.\n"
               << "  --cw-intra-element-gap <multiple>  Gap between Morse elements.\n"
               << "  --cw-inter-character-gap <multiple>\n"
@@ -1454,6 +1455,17 @@ bool validate_config_candidate(
         if (error_message != nullptr)
         {
             *error_message = "Schedule start_minute must be between 0 and 59.";
+        }
+
+        return false;
+    }
+
+    if (candidate.schedule_start_second < 0 ||
+        candidate.schedule_start_second > 59)
+    {
+        if (error_message != nullptr)
+        {
+            *error_message = "Schedule start_second must be between 0 and 59.";
         }
 
         return false;
@@ -2652,6 +2664,18 @@ bool parse_command_line(int argc, char *argv[])
     clear_fskcw_startup_request();
     clear_dfcw_startup_request();
 
+    bool explicit_cw_start_second = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        const std::string arg = argv[i];
+        if (arg == "--cw-start-second" ||
+            arg.rfind("--cw-start-second=", 0) == 0)
+        {
+            explicit_cw_start_second = true;
+            break;
+        }
+    }
+
     // Check if any arguments (besides the program name) were provided.
     if (argc == 1) // No arguments or options provided.
     {
@@ -2790,6 +2814,7 @@ bool parse_command_line(int argc, char *argv[])
         {"cw-fade-slice-ms", required_argument, nullptr, 1034},
         {"cw-start-minute", required_argument, nullptr, 1035},
         {"cw-repeat-minutes", required_argument, nullptr, 1036},
+        {"cw-start-second", required_argument, nullptr, 1050},
         {"use-led", no_argument, nullptr, 1037},
         {"no-led", no_argument, nullptr, 1038},
         {"use-shutdown", no_argument, nullptr, 1039},
@@ -3156,6 +3181,30 @@ bool parse_command_line(int argc, char *argv[])
                 }
                 config.schedule_repeat_minutes =
                     parse_integer_option(optarg, "--cw-repeat-minutes");
+            }
+            catch (const std::exception &e)
+            {
+                print_usage(e.what(), EXIT_FAILURE);
+            }
+            break;
+        }
+        case 1050:
+        {
+            try
+            {
+                if (config.use_ini)
+                {
+                    print_usage("--cw-start-second is invalid when using INI file.", EXIT_FAILURE);
+                }
+                config.schedule_start_second =
+                    parse_integer_option(optarg, "--cw-start-second");
+                if (config.schedule_start_second < 0 ||
+                    config.schedule_start_second > 59)
+                {
+                    print_usage(
+                        "--cw-start-second must be between 0 and 59.",
+                        EXIT_FAILURE);
+                }
             }
             catch (const std::exception &e)
             {
@@ -3793,6 +3842,14 @@ bool parse_command_line(int argc, char *argv[])
         !dfcw_dot_frequency_arg.empty() ||
         !dfcw_dash_frequency_arg.empty() ||
         !dfcw_dot_seconds_arg.empty();
+
+    if (explicit_cw_start_second &&
+        (any_qrss_arg || any_fskcw_arg || any_dfcw_arg))
+    {
+        print_usage(
+            "--cw-start-second is a scheduled CW option and cannot be combined with transient QRSS, FSKCW, or DFCW startup options.",
+            EXIT_FAILURE);
+    }
     if (any_dfcw_arg)
     {
         if (config.use_ini)

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1424,11 +1424,12 @@ bool validate_config_candidate(
          !candidate.loop_tx) ||
         candidate.transmit;
 
-    if (candidate.modulation_dot_seconds <= 0.0)
+    if (!std::isfinite(candidate.modulation_dot_seconds) ||
+        candidate.modulation_dot_seconds <= 0.0)
     {
         if (error_message != nullptr)
         {
-            *error_message = "Modulation dot_seconds must be greater than 0.";
+            *error_message = "Modulation dot_seconds must be finite and greater than 0.";
         }
 
         return false;
@@ -1468,13 +1469,16 @@ bool validate_config_candidate(
         return false;
     }
 
-    if (candidate.cw_intra_element_gap <= 0.0 ||
+    if (!std::isfinite(candidate.cw_intra_element_gap) ||
+        !std::isfinite(candidate.cw_inter_character_gap) ||
+        !std::isfinite(candidate.cw_inter_word_gap) ||
+        candidate.cw_intra_element_gap <= 0.0 ||
         candidate.cw_inter_character_gap <= 0.0 ||
         candidate.cw_inter_word_gap <= 0.0)
     {
         if (error_message != nullptr)
         {
-            *error_message = "CW gap settings must be greater than 0.";
+            *error_message = "CW gap settings must be finite and greater than 0.";
         }
 
         return false;
@@ -1489,7 +1493,7 @@ bool validate_config_candidate(
     {
         if (error_message != nullptr)
         {
-            *error_message = "DFCW gap settings must be greater than 0.";
+            *error_message = "DFCW gap settings must be finite and greater than 0.";
         }
 
         return false;

--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -210,6 +210,17 @@ namespace
         throw std::runtime_error(context + " must be an integer.");
     }
 
+    int parse_strict_integer_config_value(
+        const nlohmann::json &source,
+        const std::string &context)
+    {
+        if (!source.is_number_integer() && !source.is_number_unsigned())
+        {
+            throw std::runtime_error(context + " must be an integer.");
+        }
+        return parse_integer_config_value(source, context);
+    }
+
     double parse_manual_ppm_value(
         const nlohmann::json &source,
         const std::string &context)
@@ -956,6 +967,7 @@ void init_default_config()
     config.cw_fade_out_ms = 0;
     config.cw_fade_slice_ms = 5;
     config.schedule_start_minute = 0;
+    config.schedule_start_second = 5;
     config.schedule_repeat_minutes = 10;
 
     // Runtime
@@ -1214,6 +1226,7 @@ namespace
                  key == "Fade Out Ms" ||
                  key == "Fade Slice Ms" ||
                  key == "Start Minute" ||
+                 key == "Start Second" ||
                  key == "Repeat Minutes"));
     }
 
@@ -1356,6 +1369,7 @@ namespace
             {"Fade Out Ms", 0},
             {"Fade Slice Ms", 5},
             {"Start Minute", 0},
+            {"Start Second", 5},
             {"Repeat Minutes", 10}};
         std::array<BandGPIOConfig, HAM_BAND_COUNT> default_band_gpio{};
         set_default_band_gpio_config(default_band_gpio);
@@ -1500,6 +1514,13 @@ namespace
                     source.at("CW").contains("Start Minute")
                 ? source.at("CW").at("Start Minute").get<int>()
                 : target.schedule_start_minute;
+        target.schedule_start_second =
+            source.contains("CW") &&
+                    source.at("CW").contains("Start Second")
+                ? parse_strict_integer_config_value(
+                      source.at("CW").at("Start Second"),
+                      "CW.Start Second")
+                : 5;
         target.schedule_repeat_minutes =
             source.contains("CW") &&
                     source.at("CW").contains("Repeat Minutes")
@@ -1695,6 +1716,7 @@ namespace
         target["CW"]["Fade Out Ms"] = source.cw_fade_out_ms;
         target["CW"]["Fade Slice Ms"] = source.cw_fade_slice_ms;
         target["CW"]["Start Minute"] = source.schedule_start_minute;
+        target["CW"]["Start Second"] = source.schedule_start_second;
         target["CW"]["Repeat Minutes"] = source.schedule_repeat_minutes;
 
         for (const auto &[band, band_name] : kHamBandJsonKeys)
@@ -1758,6 +1780,7 @@ namespace
         target.cw_fade_out_ms = source.cw_fade_out_ms;
         target.cw_fade_slice_ms = source.cw_fade_slice_ms;
         target.schedule_start_minute = source.schedule_start_minute;
+        target.schedule_start_second = source.schedule_start_second;
         target.schedule_repeat_minutes = source.schedule_repeat_minutes;
         target.mode = source.mode;
         target.wspr = source.wspr;
@@ -2090,6 +2113,7 @@ void json_to_ini()
                   key == "Fade Out Ms" ||
                   key == "Fade Slice Ms" ||
                   key == "Start Minute" ||
+                  key == "Start Second" ||
                   key == "Repeat Minutes"));
 
             if (!persist_key)

--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -38,6 +38,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
@@ -2255,6 +2256,47 @@ void patch_all_from_web(const nlohmann::json &j)
         if (!validate_config_candidate(candidate_config, &error_message))
         {
             throw std::runtime_error(error_message);
+        }
+
+        if (candidate_config.mode == ModeType::QRSS ||
+            candidate_config.mode == ModeType::FSKCW ||
+            candidate_config.mode == ModeType::DFCW)
+        {
+            std::chrono::nanoseconds message_duration{};
+            if (!compute_non_wspr_message_duration(
+                    candidate_config,
+                    message_duration,
+                    &error_message))
+            {
+                throw std::runtime_error(error_message);
+            }
+
+            const auto repeat_interval =
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::minutes(
+                        candidate_config.schedule_repeat_minutes));
+            if (message_duration > repeat_interval)
+            {
+                validate_non_wspr_repeat_interval_policy(
+                    candidate_config,
+                    &error_message);
+                throw ConfigValidationError(
+                    error_message,
+                    {
+                        {"policy", "cw_duration_repeat_interval"},
+                        {"field", "CW.Message"},
+                        {"mode",
+                         candidate_config.mode == ModeType::QRSS
+                             ? "QRSS"
+                             : (candidate_config.mode == ModeType::FSKCW
+                                    ? "FSKCW"
+                                    : "DFCW")},
+                        {"message_duration_seconds",
+                         std::chrono::duration<double>(message_duration).count()},
+                        {"repeat_interval_seconds",
+                         std::chrono::duration<double>(repeat_interval).count()},
+                    });
+            }
         }
 
         if (candidate_config.transmit &&

--- a/src/config_handler.hpp
+++ b/src/config_handler.hpp
@@ -306,6 +306,7 @@ struct ArgParserConfig
     int cw_fade_out_ms; ///< CW envelope fade-out duration in milliseconds.
     int cw_fade_slice_ms; ///< CW fade approximation slice duration in milliseconds.
     int schedule_start_minute;      ///< CW schedule minute offset within the hour.
+    int schedule_start_second;      ///< CW schedule second offset within the minute.
     int schedule_repeat_minutes;    ///< CW schedule repeat interval in minutes.
 
     // Runtime variables
@@ -376,6 +377,7 @@ struct ArgParserConfig
           cw_fade_out_ms(0),
           cw_fade_slice_ms(5),
           schedule_start_minute(0),
+          schedule_start_second(5),
           schedule_repeat_minutes(10),
           mode(ModeType::WSPR),
           wspr({}),
@@ -454,6 +456,7 @@ struct ArgParserConfig
         cw_fade_out_ms = other.cw_fade_out_ms;
         cw_fade_slice_ms = other.cw_fade_slice_ms;
         schedule_start_minute = other.schedule_start_minute;
+        schedule_start_second = other.schedule_start_second;
         schedule_repeat_minutes = other.schedule_repeat_minutes;
         mode = other.mode;
         wspr = other.wspr;
@@ -612,6 +615,7 @@ void ini_to_json(std::string filename);
  *       "Fade Out Ms": 0,
  *       "Fade Slice Ms": 5,
  *       "Start Minute": 0,
+ *       "Start Second": 5,
  *       "Repeat Minutes": 10
  *   }
  * }

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -282,6 +282,12 @@ std::atomic<bool> shutdown_after_wspr_plan{false};
 static bool managed_reload_tx_inhibited = false;
 static bool suppress_scheduler_execution_for_test = false;
 static std::atomic<std::uint64_t> non_wspr_schedule_generation{0};
+
+std::uint64_t non_wspr_schedule_generation_for_test() noexcept
+{
+    return non_wspr_schedule_generation.load(std::memory_order_acquire);
+}
+
 static std::atomic<BandGPIOPrepareStatus> active_band_gpio_prepare_status{
     BandGPIOPrepareStatus::Inactive};
 static std::atomic<bool> suppress_cancelled_ws_event_for_user_stop{false};
@@ -1285,15 +1291,15 @@ static void log_scheduler_path_selection(ModeType mode)
     llog.logS(INFO, "Scheduling path selected: ", mode_type_name(mode), ".");
 }
 
-static std::chrono::system_clock::time_point next_non_wspr_schedule_time(
-    const ArgParserConfig &cfg)
+std::chrono::system_clock::time_point next_non_wspr_schedule_time_for_test(
+    const ArgParserConfig &cfg,
+    const std::chrono::system_clock::time_point &now)
 {
-    const auto now = std::chrono::system_clock::now();
     std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
     std::tm local_tm{};
     localtime_r(&now_time_t, &local_tm);
     local_tm.tm_min = cfg.schedule_start_minute;
-    local_tm.tm_sec = 0;
+    local_tm.tm_sec = cfg.schedule_start_second;
     std::time_t candidate_time_t = std::mktime(&local_tm);
     auto candidate = std::chrono::system_clock::from_time_t(candidate_time_t);
     const auto repeat =
@@ -1305,6 +1311,14 @@ static std::chrono::system_clock::time_point next_non_wspr_schedule_time(
     }
 
     return candidate;
+}
+
+static std::chrono::system_clock::time_point next_non_wspr_schedule_time(
+    const ArgParserConfig &cfg)
+{
+    return next_non_wspr_schedule_time_for_test(
+        cfg,
+        std::chrono::system_clock::now());
 }
 
 static std::string format_local_schedule_time(
@@ -2498,6 +2512,10 @@ static void schedule_next_non_wspr_launch(const ArgParserConfig &cfg)
     llog.logS(DEBUG,
               "- Start minute: ",
               cfg.schedule_start_minute);
+
+    llog.logS(DEBUG,
+              "- Start second: ",
+              cfg.schedule_start_second);
 
     llog.logS(DEBUG,
               "- Repeat interval (minutes): ",

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -344,6 +344,10 @@ bool start_non_wspr_transmission_now_for_test(const ArgParserConfig &cfg);
 bool validate_non_wspr_repeat_interval_policy(
     const ArgParserConfig &cfg,
     std::string *error_message = nullptr);
+std::chrono::system_clock::time_point next_non_wspr_schedule_time_for_test(
+    const ArgParserConfig &cfg,
+    const std::chrono::system_clock::time_point &now);
+std::uint64_t non_wspr_schedule_generation_for_test() noexcept;
 bool web_server_start_enabled(const ArgParserConfig &cfg) noexcept;
 bool websocket_server_start_enabled(const ArgParserConfig &cfg) noexcept;
 bool transmitter_reload_should_defer() noexcept;

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -13,6 +13,7 @@
 #include <getopt.h>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <limits.h>
 #include <map>
 #include <optional>
@@ -5359,7 +5360,7 @@ int main(int argc, char *argv[])
         std::string validation_error;
         require(
             !validate_config_candidate(invalid_gap_candidate, &validation_error) &&
-                validation_error == "CW gap settings must be greater than 0.",
+                validation_error == "CW gap settings must be finite and greater than 0.",
             "validation must reject non-positive CW gap settings");
 
         ArgParserConfig invalid_dfcw_gap_candidate;
@@ -5367,8 +5368,35 @@ int main(int argc, char *argv[])
         validation_error.clear();
         require(
             !validate_config_candidate(invalid_dfcw_gap_candidate, &validation_error) &&
-                validation_error == "DFCW gap settings must be greater than 0.",
+                validation_error == "DFCW gap settings must be finite and greater than 0.",
             "validation must reject non-positive DFCW gap settings");
+
+        ArgParserConfig non_finite_dot_candidate;
+        non_finite_dot_candidate.modulation_dot_seconds =
+            std::numeric_limits<double>::infinity();
+        validation_error.clear();
+        require(
+            !validate_config_candidate(non_finite_dot_candidate, &validation_error) &&
+                validation_error == "Modulation dot_seconds must be finite and greater than 0.",
+            "validation must reject non-finite shared CW dot timing");
+
+        ArgParserConfig non_finite_cw_gap_candidate;
+        non_finite_cw_gap_candidate.cw_inter_character_gap =
+            std::numeric_limits<double>::quiet_NaN();
+        validation_error.clear();
+        require(
+            !validate_config_candidate(non_finite_cw_gap_candidate, &validation_error) &&
+                validation_error == "CW gap settings must be finite and greater than 0.",
+            "validation must reject non-finite conventional CW gaps");
+
+        ArgParserConfig non_finite_dfcw_gap_candidate;
+        non_finite_dfcw_gap_candidate.dfcw_intra_element_gap =
+            std::numeric_limits<double>::infinity();
+        validation_error.clear();
+        require(
+            !validate_config_candidate(non_finite_dfcw_gap_candidate, &validation_error) &&
+                validation_error == "DFCW gap settings must be finite and greater than 0.",
+            "validation must reject non-finite DFCW gaps");
 
         ArgParserConfig invalid_shift_candidate;
         invalid_shift_candidate.mode = ModeType::FSKCW;

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -17,6 +17,7 @@
 #include <limits.h>
 #include <map>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -29,6 +30,74 @@
 
 namespace
 {
+    std::vector<std::string> &scoped_temp_cleanup_paths()
+    {
+        static std::vector<std::string> paths;
+        return paths;
+    }
+
+    void cleanup_scoped_temp_files_at_exit()
+    {
+        for (const std::string &path : scoped_temp_cleanup_paths())
+        {
+            if (!path.empty())
+            {
+                unlink(path.c_str());
+            }
+        }
+    }
+
+    class ScopedTemporaryFile
+    {
+    public:
+        explicit ScopedTemporaryFile(const std::string &name_template)
+        {
+            std::vector<char> path_buffer(name_template.begin(), name_template.end());
+            path_buffer.push_back('\0');
+            const int fd = mkstemp(path_buffer.data());
+            if (fd < 0)
+            {
+                throw std::runtime_error("Failed to create scoped temporary file.");
+            }
+            close(fd);
+            path_ = path_buffer.data();
+
+            auto &cleanup_paths = scoped_temp_cleanup_paths();
+            static const bool exit_cleanup_registered =
+                std::atexit(cleanup_scoped_temp_files_at_exit) == 0;
+            if (!exit_cleanup_registered)
+            {
+                unlink(path_.c_str());
+                throw std::runtime_error("Failed to register temporary-file cleanup.");
+            }
+            cleanup_paths.push_back(path_);
+        }
+
+        ScopedTemporaryFile(const ScopedTemporaryFile &) = delete;
+        ScopedTemporaryFile &operator=(const ScopedTemporaryFile &) = delete;
+
+        ~ScopedTemporaryFile()
+        {
+            unlink(path_.c_str());
+            for (std::string &registered_path : scoped_temp_cleanup_paths())
+            {
+                if (registered_path == path_)
+                {
+                    registered_path.clear();
+                    break;
+                }
+            }
+        }
+
+        const std::string &path() const noexcept
+        {
+            return path_;
+        }
+
+    private:
+        std::string path_;
+    };
+
     void require(bool condition, const std::string &message)
     {
         if (!condition)
@@ -3365,6 +3434,7 @@ int main(int argc, char *argv[])
         config.mode = ModeType::QRSS;
         config.transmit = false;
         config.schedule_start_minute = 0;
+        config.schedule_start_second = 17;
         config.schedule_repeat_minutes = 10;
         config.qrss.message = "A A";
         config.qrss.frequency_hz = 3572000.0;
@@ -3394,6 +3464,10 @@ int main(int argc, char *argv[])
         require(
             !enabled_snapshot.next_transmission_at.empty(),
             "idle CW runtime snapshots must expose the next scheduled message time once transmissions are enabled");
+        require(
+            enabled_snapshot.next_transmission_at.size() >= 19U &&
+                enabled_snapshot.next_transmission_at.substr(17, 2) == "17",
+            "runtime next_transmission_at must include the configured CW start second");
 
         config.mode = ModeType::FSKCW;
         config.fskcw.space_frequency_hz = 10140100.0;
@@ -5583,6 +5657,231 @@ int main(int argc, char *argv[])
             "INI reload callback must not queue reload work after shutdown starts");
 
         exiting_wspr.store(false, std::memory_order_relaxed);
+    }
+
+    std::string cw_start_second_persistence_path;
+    {
+        init_config_json();
+        jConfig["CW"].erase("Start Second");
+        json_to_config();
+        require(
+            config.schedule_start_second == 5,
+            "missing CW.Start Second must default to 5");
+
+        for (const int value : {0, 5, 59})
+        {
+            jConfig["CW"]["Start Second"] = value;
+            json_to_config();
+            require(
+                config.schedule_start_second == value,
+                "json_to_config must preserve valid CW.Start Second values");
+            config_to_json();
+            require(
+                jConfig.at("CW").at("Start Second") == value &&
+                    get_public_config_json().at("CW").at("Start Second") == value,
+                "config and public JSON must round-trip CW.Start Second");
+        }
+
+        for (const auto &invalid : {
+                 nlohmann::json(-1),
+                 nlohmann::json(60),
+                 nlohmann::json(5.5),
+                 nlohmann::json("5"),
+                 nlohmann::json("invalid")})
+        {
+            init_config_json();
+            jConfig["CW"]["Start Second"] = invalid;
+            bool rejected = false;
+            try
+            {
+                json_to_config();
+                std::string validation_error;
+                rejected = !validate_config_candidate(config, &validation_error);
+            }
+            catch (const std::exception &)
+            {
+                rejected = true;
+            }
+            require(rejected, "invalid CW.Start Second JSON must be rejected");
+        }
+
+        init_config_json();
+        json_to_config();
+        config.transmit = false;
+        config_to_json();
+        patch_all_from_web({{"CW", {{"Start Second", 59}}}});
+        require(
+            config.schedule_start_second == 59 &&
+                jConfig.at("CW").at("Start Second") == 59,
+            "web PATCH must preserve CW.Start Second");
+        const nlohmann::json before_rejected_patch = jConfig;
+        bool patch_rejected = false;
+        try
+        {
+            patch_all_from_web({{"CW", {{"Start Second", 60}}}});
+        }
+        catch (const std::exception &)
+        {
+            patch_rejected = true;
+        }
+        require(
+            patch_rejected && config.schedule_start_second == 59 &&
+                jConfig == before_rejected_patch,
+            "rejected web CW.Start Second updates must not mutate live or persisted config");
+
+        ScopedTemporaryFile persistence_file(
+            "/tmp/wsprrypi_cw_start_second_persist.XXXXXX");
+        cw_start_second_persistence_path = persistence_file.path();
+        config.use_ini = true;
+        config.ini_filename = cw_start_second_persistence_path;
+        iniFile.set_filename(config.ini_filename);
+        config_to_json();
+        json_to_ini();
+        iniFile.load();
+        require(
+            iniFile.getData().at("CW").at("Start Second") == "59",
+            "INI persistence must preserve CW.Start Second");
+        config.use_ini = false;
+        config.ini_filename.clear();
+    }
+    require(
+        access(cw_start_second_persistence_path.c_str(), F_OK) != 0,
+        "scoped CW.Start Second persistence file must be removed after the test block");
+
+    {
+        auto local_time = [](int year, int month, int day, int hour, int minute, int second)
+        {
+            std::tm value{};
+            value.tm_year = year - 1900;
+            value.tm_mon = month - 1;
+            value.tm_mday = day;
+            value.tm_hour = hour;
+            value.tm_min = minute;
+            value.tm_sec = second;
+            value.tm_isdst = -1;
+            return std::chrono::system_clock::from_time_t(std::mktime(&value));
+        };
+        auto require_launch = [&](int now_hour,
+                                  int now_minute,
+                                  int now_second,
+                                  int start_second,
+                                  int expected_day,
+                                  int expected_hour,
+                                  int expected_minute,
+                                  int expected_second)
+        {
+            ArgParserConfig candidate;
+            candidate.schedule_start_minute = 0;
+            candidate.schedule_start_second = start_second;
+            candidate.schedule_repeat_minutes = 10;
+            const auto launch = next_non_wspr_schedule_time_for_test(
+                candidate,
+                local_time(2026, 7, 27, now_hour, now_minute, now_second));
+            const std::time_t launch_time = std::chrono::system_clock::to_time_t(launch);
+            std::tm actual{};
+            localtime_r(&launch_time, &actual);
+            require(
+                actual.tm_mday == expected_day &&
+                    actual.tm_hour == expected_hour &&
+                    actual.tm_min == expected_minute &&
+                    actual.tm_sec == expected_second,
+                "deterministic CW scheduler must select the expected strict-future launch");
+        };
+
+        require_launch(12, 0, 4, 5, 27, 12, 0, 5);
+        require_launch(12, 0, 5, 5, 27, 12, 10, 5);
+        require_launch(12, 0, 6, 5, 27, 12, 10, 5);
+        require_launch(12, 59, 59, 5, 27, 13, 0, 5);
+        require_launch(23, 59, 59, 5, 28, 0, 0, 5);
+        require_launch(12, 0, 0, 0, 27, 12, 10, 0);
+        require_launch(12, 0, 58, 59, 27, 12, 0, 59);
+
+        ArgParserConfig shared;
+        shared.schedule_start_minute = 20;
+        shared.schedule_start_second = 5;
+        shared.schedule_repeat_minutes = 10;
+        const auto now = local_time(2026, 7, 27, 12, 20, 4);
+        std::optional<std::chrono::system_clock::time_point> common;
+        for (const ModeType mode : {ModeType::QRSS, ModeType::FSKCW, ModeType::DFCW})
+        {
+            shared.mode = mode;
+            const auto launch = next_non_wspr_schedule_time_for_test(shared, now);
+            require(!common.has_value() || *common == launch,
+                    "QRSS, FSKCW, and DFCW must share the CW schedule calculation");
+            common = launch;
+        }
+
+        init_default_config();
+        config.use_ini = false;
+        config.mode = ModeType::QRSS;
+        config.transmit = true;
+        config.transmit_backend = TransmitBackendKind::SI5351;
+        config.si5351_i2c_bus = 1;
+        config.si5351_i2c_address = 0x60;
+        config.si5351_reference_hz = 27000000;
+        config.si5351_tx_output = 0;
+        config.si5351_power_level = 1;
+        resolve_backend_specific_config(config);
+        config.qrss.message = "TEST";
+        config.qrss.frequency_hz = 14096900.0;
+        config.qrss.dot_seconds = 1.0;
+        set_scheduler_execution_suppressed_for_test(true);
+        const auto generation = non_wspr_schedule_generation_for_test();
+        require(set_config(true),
+                "CW configuration change must apply through the production scheduler path");
+        require(
+            non_wspr_schedule_generation_for_test() > generation,
+            "schedule changes must invalidate the previous sleeping generation");
+        set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    {
+        init_config_json();
+        json_to_config();
+        reset_getopt_state();
+        std::vector<std::string> args = {
+            "wsprrypi", "--mode", "QRSS", "--cw-message", "TEST",
+            "--cw-base-frequency", "14096900", "--cw-dot-seconds", "1",
+            "--cw-start-second", "0"};
+        std::vector<char *> argv = argv_for(args);
+        require(
+            parse_command_line(static_cast<int>(argv.size()), argv.data()) &&
+                config.schedule_start_second == 0,
+            "CLI --cw-start-second must accept and preserve zero");
+
+        init_config_json();
+        json_to_config();
+        reset_getopt_state();
+        args = {
+            "wsprrypi", "--mode", "QRSS", "--cw-message", "TEST",
+            "--cw-base-frequency", "14096900", "--cw-dot-seconds", "1",
+            "--cw-start-second", "59"};
+        argv = argv_for(args);
+        require(
+            parse_command_line(static_cast<int>(argv.size()), argv.data()) &&
+                config.schedule_start_second == 59,
+            "CLI --cw-start-second must accept 59");
+
+        require_cli_parse_rejected(
+            {"--mode", "QRSS", "--cw-message", "TEST", "--cw-base-frequency", "14096900",
+             "--cw-dot-seconds", "1", "--cw-start-second", "60"},
+            "CLI --cw-start-second above 59");
+        require_cli_parse_rejected(
+            {"--mode", "QRSS", "--cw-message", "TEST", "--cw-base-frequency", "14096900",
+             "--cw-dot-seconds", "1", "--cw-start-second=-1"},
+            "negative CLI --cw-start-second");
+        require_cli_parse_rejected(
+            {"--mode", "QRSS", "--cw-message", "TEST", "--cw-base-frequency", "14096900",
+             "--cw-dot-seconds", "1", "--cw-start-second", "5.5"},
+            "fractional CLI --cw-start-second");
+        require_cli_parse_rejected(
+            {"--mode", "QRSS", "--cw-message", "TEST", "--cw-base-frequency", "14096900",
+             "--cw-dot-seconds", "1", "--cw-start-second", "invalid"},
+            "nonnumeric CLI --cw-start-second");
+        require_cli_parse_rejected(
+            {"--qrss-message", "TEST", "--qrss-frequency", "14096900",
+             "--qrss-dot-seconds", "1", "--cw-start-second", "5"},
+            "scheduled seconds with transient QRSS startup");
     }
 
     std::cout << "dial_frequency_semantics_test passed" << std::endl;

--- a/src/tests/non_wspr_repeat_policy_test.cpp
+++ b/src/tests/non_wspr_repeat_policy_test.cpp
@@ -1,6 +1,7 @@
 #include "arg_parser.hpp"
 #include "config_handler.hpp"
 #include "scheduling.hpp"
+#include "version.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -116,6 +117,7 @@ int main()
 {
     set_patch_all_from_web_runtime_apply_suppressed_for_test(true);
     set_si5351_detection_override_for_test(true);
+    set_raspberry_pi_generation_override_for_test(4);
 
     {
         std::chrono::nanoseconds qrss_duration{};
@@ -331,6 +333,7 @@ int main()
             "web patch rejection must not mutate the live mode");
     }
 
+    clear_raspberry_pi_generation_override_for_test();
     std::cout << "Non-WSPR repeat policy regression tests passed." << std::endl;
     return EXIT_SUCCESS;
 }

--- a/src/tests/non_wspr_repeat_policy_test.cpp
+++ b/src/tests/non_wspr_repeat_policy_test.cpp
@@ -275,7 +275,7 @@ int main()
 
         require(
             !set_config(true),
-            "scheduler must reject an overlong QRSS configuration before committing execution");
+            "scheduler runtime path must reject an overlong QRSS configuration before committing execution");
         require(
             current_transmission_request_for_test().actual_rf_frequency_hz == 0.0 &&
                 current_transmission_request_for_test().payload.frames.empty(),
@@ -302,35 +302,63 @@ int main()
         clear_dfcw_startup_request();
         prime_valid_runtime_identity_config();
         const ModeType original_mode = config.mode;
-        bool threw_patch_error = false;
+        const nlohmann::json original_json = jConfig;
 
-        try
+        for (const std::string mode : {"QRSS", "FSKCW", "DFCW"})
         {
-            patch_all_from_web({
-                {"Operation",
-                 {{"Mode", "QRSS"},
-                  {"Transmit", true}}},
-                {"CW",
-                 {{"Message", "E"},
-                  {"Base Frequency", 10140100.0},
-                  {"Dot Seconds", 61.0},
-                  {"Repeat Minutes", 1}}}});
-        }
-        catch (const std::exception &e)
-        {
-            threw_patch_error = true;
+            bool threw_patch_error = false;
+            try
+            {
+                patch_all_from_web({
+                    {"Operation",
+                     {{"Mode", mode},
+                      {"Transmit", false}}},
+                    {"CW",
+                     {{"Message", "E"},
+                      {"Base Frequency", 10140100.0},
+                      {"Shift Hz", 5.0},
+                      {"Dot Seconds", 61.0},
+                      {"Repeat Minutes", 1}}}});
+            }
+            catch (const ConfigValidationError &e)
+            {
+                threw_patch_error = true;
+                require(
+                    std::string(e.what()).find(
+                        "Configured " + mode + " message duration") !=
+                        std::string::npos,
+                    "web patch validation must expose the mode-specific repeat policy error");
+                require(
+                    e.details().value("policy", "") ==
+                            "cw_duration_repeat_interval" &&
+                        e.details().value("field", "") == "CW.Message" &&
+                        e.details().value("mode", "") == mode,
+                    "web patch duration rejection must provide structured field policy details");
+            }
+
             require(
-                std::string(e.what()).find("Configured QRSS message duration") !=
-                    std::string::npos,
-                "web patch validation must expose the repeat_every policy error");
+                threw_patch_error,
+                "web patch validation must reject an overlong " + mode +
+                    " configuration even while transmission is disabled");
+            require(
+                config.mode == original_mode && jConfig == original_json,
+                "web patch rejection must preserve the previous live and persisted candidates");
         }
 
+        patch_all_from_web({
+            {"Operation",
+             {{"Mode", "QRSS"},
+              {"Transmit", false}}},
+            {"CW",
+             {{"Message", "E"},
+              {"Base Frequency", 10140100.0},
+              {"Dot Seconds", 60.0},
+              {"Repeat Minutes", 1}}}});
         require(
-            threw_patch_error,
-            "web patch validation must reject an overlong QRSS configuration");
-        require(
-            config.mode == original_mode,
-            "web patch rejection must not mutate the live mode");
+            config.mode == ModeType::QRSS &&
+                config.schedule_repeat_minutes == 1 &&
+                config.modulation_dot_seconds == 60.0,
+            "web patch duration equal to repeat interval must be accepted");
     }
 
     clear_raspberry_pi_generation_override_for_test();

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -96,6 +96,10 @@ int main()
                 scheduling_source.find("send_ws_message(\"transmit\", \"starting\");", scheduling_source.find("void transmitter_cb(")),
         "test tone start must rely on transmitter callback websocket ownership only");
     require(
+        scheduling_source.find("validate_non_wspr_repeat_interval_policy(\n                    working_config") != std::string::npos &&
+            scheduling_source.find("\"reload_failed\",\n                        policy_error") != std::string::npos,
+        "managed non-web reloads must retain runtime CW duration-policy validation and reload failure reporting");
+    require(
         scheduling_source.find("TestToneStopResult end_test_tone()") != std::string::npos &&
             scheduling_source.find("send_ws_message(\"transmit\", \"finished\");") ==
                 scheduling_source.find("send_ws_message(\"transmit\", \"finished\");", scheduling_source.find("void transmitter_cb(")),
@@ -245,15 +249,16 @@ int main()
             ui_source.find("Enter a positive finite DFCW intra-element gap.") != std::string::npos &&
             ui_source.find("Enter a positive finite DFCW inter-character gap.") != std::string::npos &&
             ui_source.find("Enter a positive finite DFCW inter-word gap.") != std::string::npos &&
-            ui_source.find("const CW_MESSAGE_MORSE_TABLE = Object.freeze({") != std::string::npos &&
+            ui_source.find("const CW_MESSAGE_MORSE_TABLE = CwTimingState.MORSE_TABLE;") != std::string::npos &&
             ui_source.find("function estimateCwMessageSeconds(message, mode, timing)") != std::string::npos &&
+            ui_source.find("return CwTimingState.estimateMessageSeconds(message, mode, timing);") != std::string::npos &&
             ui_source.find("function updateCwMessageLengthEstimate()") != std::string::npos &&
             ui_source.find("function formatCwMessageLengthEstimate(seconds)") != std::string::npos &&
-            ui_source.find("const normalizedMode = [\"QRSS\", \"FSKCW\", \"DFCW\"].includes(mode) ? mode : \"\";") != std::string::npos &&
-            ui_source.find("normalizedMode === \"DFCW\" ? timing.dotSeconds : timing.dotSeconds * 3") != std::string::npos &&
-            ui_source.find("timing.intraElementGapSeconds") != std::string::npos &&
-            ui_source.find("timing.interCharacterGapSeconds") != std::string::npos &&
-            ui_source.find("timing.interWordGapSeconds") != std::string::npos &&
+            cw_timing_source.find("function estimateMessageSeconds(message, mode, timing)") != std::string::npos &&
+            cw_timing_source.find("normalizedMode === \"DFCW\"") != std::string::npos &&
+            cw_timing_source.find("timing.intraElementGapSeconds") != std::string::npos &&
+            cw_timing_source.find("timing.interCharacterGapSeconds") != std::string::npos &&
+            cw_timing_source.find("timing.interWordGapSeconds") != std::string::npos &&
             ui_source.find("parsePositiveFormNumber(\"cw_intra_element_gap\")") != std::string::npos &&
             ui_source.find("parsePositiveFormNumber(\"cw_inter_character_gap\")") != std::string::npos &&
             ui_source.find("parsePositiveFormNumber(\"cw_inter_word_gap\")") != std::string::npos &&
@@ -261,7 +266,7 @@ int main()
             ui_source.find("parsePositiveFormNumber(\"dfcw_inter_character_gap\")") != std::string::npos &&
             ui_source.find("parsePositiveFormNumber(\"dfcw_inter_word_gap\")") != std::string::npos &&
             ui_source.find("Estimated Message Length: not applicable") != std::string::npos &&
-            ui_source.find("reason: `unavailable: unsupported character ${ch}`,") != std::string::npos &&
+            cw_timing_source.find("reason: `unavailable: unsupported character ${ch}`") != std::string::npos &&
             ui_source.find("$(\"#qrss_message\").on(\"input change blur\", function ()") != std::string::npos &&
             ui_source.find("$(\"#dot_length\").on(\"input blur\", function ()") != std::string::npos &&
             ui_source.find("updateCwMessageLengthEstimate();") != std::string::npos &&
@@ -341,6 +346,20 @@ int main()
 
     const std::string site_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/site.js");
+    require(
+        ui_source.find("let cwDurationPolicyLatched = false;") != std::string::npos &&
+            ui_source.find("function updateCwDurationPolicyLatch(options = {})") != std::string::npos &&
+            ui_source.find("overLimit: estimate.seconds > repeatSeconds") != std::string::npos &&
+            ui_source.find("\"Save failed\",") != std::string::npos &&
+            ui_source.find("Shorten the message, shorten the dot length or active spacing, or increase the repeat interval.") != std::string::npos &&
+            ui_source.find("fld.setCustomValidity(") != std::string::npos &&
+            ui_source.find("setFieldValidationState(fld, valid);") != std::string::npos &&
+            ui_source.find("if (durationConstraint.applicable && durationConstraint.overLimit) {") != std::string::npos &&
+            ui_source.find("function handleCwDurationPolicyFailure(messageOrData)") != std::string::npos &&
+            ui_source.find("data.policy === \"cw_duration_repeat_interval\"") != std::string::npos &&
+            site_source.find("handleCwDurationPolicyFailure(message)") != std::string::npos &&
+            site_source.find("title: \"Configuration Reload Failed\"") != std::string::npos,
+        "Setup must latch CW duration failures inline, suppress overlong autosaves and mapped reload modals, preserve field validity semantics, and retain the modal fallback for unrelated reload failures");
     const std::string stock_ini_source =
         read_text_file("/home/pi/WsprryPi/config/wsprrypi.ini");
     const std::string transmit_branch = "if (msg.type === \"transmit\")";

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -111,6 +111,8 @@ int main()
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/index.js");
     const std::string config_view_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/views/config.php");
+    const std::string cw_timing_source =
+        read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/cw_timing_state.js");
     const std::string maintenance_script_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/maintenance.js");
     const std::string operation_script_source =
@@ -126,6 +128,18 @@ int main()
             config_view_source.find("Estimated Message Length: unavailable") != std::string::npos &&
             config_view_source.find("aria-live=\"polite\"") != std::string::npos,
         "configuration view must expose a live CW message length estimate near the CW message field");
+    require(
+        config_view_source.find("name=\"cw_speed\"") != std::string::npos &&
+            config_view_source.find("['QRSS1', 'QRSS3', 'QRSS6', 'Advanced']") != std::string::npos &&
+            config_view_source.find("name=\"cw_spacing\"") != std::string::npos &&
+            config_view_source.find("Review QRSS/FSKCW spacing") != std::string::npos &&
+            config_view_source.find("Review DFCW spacing") != std::string::npos &&
+            config_view_source.find("id=\"cw_frequency_controls\"") != std::string::npos &&
+            config_view_source.find("id=\"cw_schedule_controls\"") != std::string::npos &&
+            ui_source.find("detailActionControls") != std::string::npos &&
+            ui_source.find("actionButton.setAttribute(\"aria-controls\", detailActionControls)") != std::string::npos &&
+            ui_source.find("actionButton.setAttribute(\"aria-expanded\", \"false\")") != std::string::npos,
+        "CW Control must expose accessible speed, mode-aware spacing, inactive-repair, frequency, and schedule groups");
     require(
         ui_source.find("persist_transmit: persistTransmit") !=
                 std::string::npos,
@@ -221,16 +235,16 @@ int main()
             ui_source.find("function validatePositiveCwField(fieldId, errorMessage)") != std::string::npos &&
             ui_source.find("function parseFrequencyWithOptionalUnits(rawValue)") != std::string::npos &&
             ui_source.find("Enter CW base frequency as whole-number Hz or as a value with Hz, kHz, MHz, or GHz.") != std::string::npos &&
-            ui_source.find("Enter a positive CW dot length.") != std::string::npos &&
+            ui_source.find("Enter a positive finite CW base duration.") != std::string::npos &&
             ui_source.find("CW message is required.") != std::string::npos &&
             ui_source.find("Enter a whole-number CW frequency offset in Hz.") != std::string::npos &&
             ui_source.find("Enter a repeat interval of at least 1 minute.") != std::string::npos &&
-            ui_source.find("Enter a positive CW intra-element gap.") != std::string::npos &&
-            ui_source.find("Enter a positive CW inter-character gap.") != std::string::npos &&
-            ui_source.find("Enter a positive CW inter-word gap.") != std::string::npos &&
-            ui_source.find("Enter a positive DFCW intra-element gap.") != std::string::npos &&
-            ui_source.find("Enter a positive DFCW inter-character gap.") != std::string::npos &&
-            ui_source.find("Enter a positive DFCW inter-word gap.") != std::string::npos &&
+            ui_source.find("Enter a positive finite QRSS/FSKCW intra-element gap.") != std::string::npos &&
+            ui_source.find("Enter a positive finite QRSS/FSKCW inter-character gap.") != std::string::npos &&
+            ui_source.find("Enter a positive finite QRSS/FSKCW inter-word gap.") != std::string::npos &&
+            ui_source.find("Enter a positive finite DFCW intra-element gap.") != std::string::npos &&
+            ui_source.find("Enter a positive finite DFCW inter-character gap.") != std::string::npos &&
+            ui_source.find("Enter a positive finite DFCW inter-word gap.") != std::string::npos &&
             ui_source.find("const CW_MESSAGE_MORSE_TABLE = Object.freeze({") != std::string::npos &&
             ui_source.find("function estimateCwMessageSeconds(message, mode, timing)") != std::string::npos &&
             ui_source.find("function updateCwMessageLengthEstimate()") != std::string::npos &&
@@ -254,20 +268,20 @@ int main()
             ui_source.find("let cw_message = String($('#qrss_message').val() || \"\").trim();") != std::string::npos &&
             ui_source.find("\"Message\": cw_message,") != std::string::npos &&
             ui_source.find("let cw_base_frequency = parseFrequencyWithOptionalUnits($('#qrss_frequency').val());") != std::string::npos &&
-            ui_source.find("let cw_intra_element_gap = parseFloat($('#cw_intra_element_gap').val());") != std::string::npos &&
-            ui_source.find("let cw_inter_character_gap = parseFloat($('#cw_inter_character_gap').val());") != std::string::npos &&
-            ui_source.find("let cw_inter_word_gap = parseFloat($('#cw_inter_word_gap').val());") != std::string::npos &&
-            ui_source.find("let dfcw_intra_element_gap = parseFloat($('#dfcw_intra_element_gap').val());") != std::string::npos &&
-            ui_source.find("let dfcw_inter_character_gap = parseFloat($('#dfcw_inter_character_gap').val());") != std::string::npos &&
-            ui_source.find("let dfcw_inter_word_gap = parseFloat($('#dfcw_inter_word_gap').val());") != std::string::npos &&
+            ui_source.find("let cw_intra_element_gap = Number(String($('#cw_intra_element_gap').val()") != std::string::npos &&
+            ui_source.find("let dfcw_intra_element_gap = Number(String($('#dfcw_intra_element_gap').val()") != std::string::npos &&
             ui_source.find("\"Intra Element Gap\": cw_intra_element_gap") != std::string::npos &&
             ui_source.find("\"Inter Character Gap\": cw_inter_character_gap") != std::string::npos &&
             ui_source.find("\"Inter Word Gap\": cw_inter_word_gap") != std::string::npos &&
             ui_source.find("\"DFCW Intra Element Gap\": dfcw_intra_element_gap") != std::string::npos &&
             ui_source.find("\"DFCW Inter Character Gap\": dfcw_inter_character_gap") != std::string::npos &&
             ui_source.find("\"DFCW Inter Word Gap\": dfcw_inter_word_gap") != std::string::npos &&
-            ui_source.find("$(\".cw-shared-gap-control\").toggleClass(\"d-none\", dfcwSelected);") != std::string::npos &&
-            ui_source.find("$(\".dfcw-gap-control\").toggleClass(\"d-none\", !dfcwSelected);") != std::string::npos &&
+            ui_source.find("function syncCwTimingControls(options = {})") != std::string::npos &&
+            ui_source.find("function inactiveInvalidCwTimingGroup()") != std::string::npos &&
+            ui_source.find("detailActionLabel: `Review ${label}`") != std::string::npos &&
+            cw_timing_source.find("function inferSpeed(value)") != std::string::npos &&
+            cw_timing_source.find("function inferSpacing(group, triplet)") != std::string::npos &&
+            cw_timing_source.find("intraElement: 0.333333") != std::string::npos &&
             ui_source.find("let cw_base_frequency = parseFloat($('#qrss_frequency').val());") == std::string::npos &&
             ui_source.find("normalizedValue = value * 1e6;") != std::string::npos &&
             ui_source.find("normalizedValue = value * 1e3;") != std::string::npos &&
@@ -397,12 +411,12 @@ int main()
             site_source.find("let cw_base_frequency = getConfigFloatValue(cw, \"CW\", \"Base Frequency\", 3572000.0);") == std::string::npos,
         "UI config loader must default CW.Base Frequency to 14096900 Hz to match backend normalization");
     require(
-        site_source.find("let cw_intra_element_gap = getConfigFloatValue(cw, \"CW\", \"Intra Element Gap\", 1.0);") != std::string::npos &&
-            site_source.find("let cw_inter_character_gap = getConfigFloatValue(cw, \"CW\", \"Inter Character Gap\", 3.0);") != std::string::npos &&
-            site_source.find("let cw_inter_word_gap = getConfigFloatValue(cw, \"CW\", \"Inter Word Gap\", 7.0);") != std::string::npos &&
-            site_source.find("let dfcw_intra_element_gap = getConfigFloatValue(cw, \"CW\", \"DFCW Intra Element Gap\", 0.333333);") != std::string::npos &&
-            site_source.find("let dfcw_inter_character_gap = getConfigFloatValue(cw, \"CW\", \"DFCW Inter Character Gap\", 1.0);") != std::string::npos &&
-            site_source.find("let dfcw_inter_word_gap = getConfigFloatValue(cw, \"CW\", \"DFCW Inter Word Gap\", 3.0);") != std::string::npos &&
+        site_source.find("let cw_intra_element_gap = getConfigTimingValue(cw, \"CW\", \"Intra Element Gap\", 1.0);") != std::string::npos &&
+            site_source.find("let cw_inter_character_gap = getConfigTimingValue(cw, \"CW\", \"Inter Character Gap\", 3.0);") != std::string::npos &&
+            site_source.find("let cw_inter_word_gap = getConfigTimingValue(cw, \"CW\", \"Inter Word Gap\", 7.0);") != std::string::npos &&
+            site_source.find("let dfcw_intra_element_gap = getConfigTimingValue(cw, \"CW\", \"DFCW Intra Element Gap\", 0.333333);") != std::string::npos &&
+            site_source.find("let dfcw_inter_character_gap = getConfigTimingValue(cw, \"CW\", \"DFCW Inter Character Gap\", 1.0);") != std::string::npos &&
+            site_source.find("let dfcw_inter_word_gap = getConfigTimingValue(cw, \"CW\", \"DFCW Inter Word Gap\", 3.0);") != std::string::npos &&
             site_source.find("$(\"#cw_intra_element_gap\").val(cw_intra_element_gap).trigger(\"change\");") != std::string::npos &&
             site_source.find("$(\"#cw_inter_character_gap\").val(cw_inter_character_gap).trigger(\"change\");") != std::string::npos &&
             site_source.find("$(\"#cw_inter_word_gap\").val(cw_inter_word_gap).trigger(\"change\");") != std::string::npos &&


### PR DESCRIPTION
## Summary

Adds configurable start seconds and mode-aware timing presets for scheduled QRSS, FSKCW, and DFCW transmissions.

Also prevents overlong CW configurations from being persisted and adds browser integration coverage for CW duration validation and failure-state latching.

## Changes

- Add configurable start seconds for scheduled CW transmissions
- Add mode-aware CW timing presets
- Reject overlong CW web configurations before persistence
- Preserve rejected settings and validation feedback in the browser
- Add browser integration coverage
- Clarify CW timing and repository workflow documentation