### PR TITLE
Validate shared Band GPIO assignments

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -128,6 +128,7 @@ NON_WSPR_REPEAT_POLICY_TEST_OUT := non_wspr_repeat_policy_test
 QRSS_EXECUTION_REGRESSION_TEST_OUT := qrss_execution_regression_test
 WSPR_TONE_REGRESSION_TEST_OUT := wspr_tone_regression_test
 SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT := selector_shutdown_cleanup_test
+QUALIFICATION_GPIO_TEST_MODE_TEST_OUT := qualification_gpio_test_mode_test
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Output directories
@@ -195,6 +196,9 @@ WSPR_TONE_REGRESSION_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_
 SELECTOR_SHUTDOWN_CLEANUP_TEST_SRC := tests/selector_shutdown_cleanup_test.cpp
 SELECTOR_SHUTDOWN_CLEANUP_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/selector_shutdown_cleanup_test.o
 SELECTOR_SHUTDOWN_CLEANUP_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
+QUALIFICATION_GPIO_TEST_MODE_TEST_SRC := tests/qualification_gpio_test_mode_test.cpp
+QUALIFICATION_GPIO_TEST_MODE_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/qualification_gpio_test_mode_test.o
+QUALIFICATION_GPIO_TEST_MODE_TEST_DEPS := $(QUALIFICATION_GPIO_TEST_MODE_TEST_OBJ)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Dependency includes
@@ -502,6 +506,17 @@ $(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT): $(SELECTOR_SHUTDOWN_CLEANUP_TE
 	$(Q)echo "Linking debug: $(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)"
 	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
 
+$(QUALIFICATION_GPIO_TEST_MODE_TEST_OBJ): $(QUALIFICATION_GPIO_TEST_MODE_TEST_SRC)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)mkdir -p $(DEP_DIR)/tests
+	$(Q)echo "Compiling (debug) $< into $@"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) -MF $(DEP_DIR)/tests/qualification_gpio_test_mode_test.d -c $< -o $@
+
+$(BIN_DIR)/$(QUALIFICATION_GPIO_TEST_MODE_TEST_OUT): $(QUALIFICATION_GPIO_TEST_MODE_TEST_DEPS)
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)echo "Linking debug: $(QUALIFICATION_GPIO_TEST_MODE_TEST_OUT)"
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
+
 ifeq ($(GPIOD_HAS_V2),1)
 $(GPIO_LOOPBACK_TEST_OBJ): $(GPIO_LOOPBACK_TEST_SRC)
 	$(Q)mkdir -p $(dir $@)
@@ -555,7 +570,7 @@ $(BIN_DIR)/$(OUT): $(CPP_OBJECTS)
 # Phony targets
 # ─────────────────────────────────────────────────────────────────────────────
 
-.PHONY: clean release debug test test-tone test-oneshot semantics-test build-dependency-regression-test update-check-comparison-test guarded-mode-change-persistence-test band-gpio-default-convergence-test band-gpio-rotation-test selector-shutdown-cleanup-test monitor-file-regression-test gpio-line-resolver-test non-wspr-repeat-policy-test qrss-execution-regression-test qrss_execution_regression_test wspr-tone-regression-test wspr_tone_regression_test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
+.PHONY: clean release debug test test-tone test-oneshot semantics-test build-dependency-regression-test update-check-comparison-test guarded-mode-change-persistence-test band-gpio-default-convergence-test band-gpio-rotation-test selector-shutdown-cleanup-test qualification-gpio-test-mode-test monitor-file-regression-test gpio-line-resolver-test non-wspr-repeat-policy-test qrss-execution-regression-test qrss_execution_regression_test wspr-tone-regression-test wspr_tone_regression_test gpio-loopback-test band-gpio-live-monitor gdb install debuginstall uninstall lint macros help
 DEBUG: debug
 RELEASE: release
 
@@ -614,6 +629,10 @@ band-gpio-rotation-test: $(BIN_DIR)/$(BAND_GPIO_ROTATION_TEST_OUT)
 selector-shutdown-cleanup-test: $(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)
 	$(Q)echo "Running selector shutdown cleanup regression tests."
 	$(Q)./$(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)
+
+qualification-gpio-test-mode-test: $(BIN_DIR)/$(QUALIFICATION_GPIO_TEST_MODE_TEST_OUT)
+	$(Q)echo "Running qualification GPIO test mode value semantics test."
+	$(Q)./$(BIN_DIR)/$(QUALIFICATION_GPIO_TEST_MODE_TEST_OUT)
 
 monitor-file-regression-test: $(BIN_DIR)/$(MONITOR_FILE_REGRESSION_TEST_OUT)
 	$(Q)echo "Running MonitorFile regression tests."

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -371,6 +371,103 @@ static std::string transmit_gpio_validation_message()
     return oss.str();
 }
 
+static bool validate_pi_io_gpio_assignments(
+    const ArgParserConfig &candidate,
+    std::string *error_message)
+{
+    struct ReservedAssignment
+    {
+        int gpio;
+        const char *label;
+    };
+
+    std::vector<ReservedAssignment> reserved_assignments;
+    if (candidate.use_led && candidate.led_pin >= 0)
+    {
+        reserved_assignments.push_back({candidate.led_pin, "Transmit LED"});
+    }
+    if (candidate.use_shutdown && candidate.shutdown_pin >= 0)
+    {
+        reserved_assignments.push_back({candidate.shutdown_pin, "Shutdown Button"});
+    }
+    if (candidate.use_amp && candidate.amp_pin >= 0)
+    {
+        reserved_assignments.push_back({candidate.amp_pin, "Amp Control"});
+    }
+
+    for (std::size_t i = 0; i < reserved_assignments.size(); ++i)
+    {
+        for (std::size_t j = i + 1; j < reserved_assignments.size(); ++j)
+        {
+            if (reserved_assignments[i].gpio != reserved_assignments[j].gpio)
+            {
+                continue;
+            }
+
+            if (error_message != nullptr)
+            {
+                *error_message =
+                    "GPIO" + std::to_string(reserved_assignments[i].gpio) +
+                    " is assigned to both " + reserved_assignments[i].label +
+                    " and " + reserved_assignments[j].label + ".";
+            }
+            return false;
+        }
+    }
+
+    for (const BandGPIOConfig &band_config : candidate.band_gpio)
+    {
+        if (!band_config.enabled || band_config.gpio < 0)
+        {
+            continue;
+        }
+
+        for (const ReservedAssignment &reserved : reserved_assignments)
+        {
+            if (band_config.gpio != reserved.gpio)
+            {
+                continue;
+            }
+
+            if (error_message != nullptr)
+            {
+                *error_message = "GPIO" + std::to_string(band_config.gpio) +
+                                 " is reserved by " + reserved.label + ".";
+            }
+            return false;
+        }
+    }
+
+    for (std::size_t i = 0; i < candidate.band_gpio.size(); ++i)
+    {
+        const BandGPIOConfig &first = candidate.band_gpio[i];
+        if (!first.enabled || first.gpio < 0)
+        {
+            continue;
+        }
+
+        for (std::size_t j = i + 1; j < candidate.band_gpio.size(); ++j)
+        {
+            const BandGPIOConfig &second = candidate.band_gpio[j];
+            if (!second.enabled || second.gpio != first.gpio ||
+                second.active_high == first.active_high)
+            {
+                continue;
+            }
+
+            if (error_message != nullptr)
+            {
+                *error_message = "Bands sharing GPIO" +
+                                 std::to_string(first.gpio) +
+                                 " must use the same Active High setting.";
+            }
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool backend_ready_for_transmission(
     const ArgParserConfig &candidate,
     std::string *error_message)
@@ -1561,6 +1658,11 @@ bool validate_config_candidate(
             *error_message = "Invalid Amp Pin. Expected -1 or GPIO 0 through 27.";
         }
 
+        return false;
+    }
+
+    if (!validate_pi_io_gpio_assignments(candidate, error_message))
+    {
         return false;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,10 @@
 
 // Project headers
 #include "arg_parser.hpp"
+#include "gpio_output.hpp"
+#ifdef DEBUG_WSPR
+#include "qualification_gpio_test_mode.hpp"
+#endif
 #include "scheduling.hpp"
 #include "signal_handler.hpp"
 #include "version.hpp"
@@ -42,6 +46,7 @@
 #include <atomic>
 #include <cerrno>
 #include <csignal>
+#include <cstdlib>
 #include <mutex>
 #include <string_view>
 #include <thread>
@@ -218,6 +223,15 @@ int main(int argc, char *argv[])
     // Maintain retval for main()
     int retval = EXIT_SUCCESS;
 
+#ifdef DEBUG_WSPR
+    const char *qualification_gpio_test_mode =
+        std::getenv("WSPRRYPI_QUALIFICATION_GPIO_TEST_MODE");
+    if (qualification_gpio_test_mode_requested(qualification_gpio_test_mode))
+    {
+        GPIOOutput::setTestMode(true);
+    }
+#endif
+
     if (!install_async_shutdown_handlers())
     {
         std::perror("sigaction/pipe");
@@ -311,6 +325,15 @@ int main(int argc, char *argv[])
         config.use_journald,
         config.date_time_log,
         config.debug_logging);
+
+#ifdef DEBUG_WSPR
+    if (qualification_gpio_test_mode_requested(qualification_gpio_test_mode))
+    {
+        llog.logS(
+            WARN,
+            "Qualification GPIO test mode enabled: physical GPIO output requests, writes, and releases are suppressed. Hardware is not qualified.");
+    }
+#endif
 
     // Display version, Raspberry Pi model, and process ID after CLI parsing so
     // the first backend banner matches the requested logging mode.

--- a/src/qualification_gpio_test_mode.hpp
+++ b/src/qualification_gpio_test_mode.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstring>
+
+inline bool qualification_gpio_test_mode_requested(const char *value) noexcept
+{
+    return value != nullptr && std::strcmp(value, "1") == 0;
+}

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 #include <string>
 #include <sys/wait.h>
+#include <tuple>
 #include <unistd.h>
 #include <unordered_map>
 #include <vector>
@@ -638,6 +639,126 @@ int main(int argc, char *argv[])
                 stock_ini.find("2m =\n2m Active High = false") != std::string::npos &&
                 stock_ini.find("Active High = true") == std::string::npos,
             "stock INI must declare explicit disabled Band GPIO defaults for every band");
+    }
+
+    {
+        const auto configure_shared_band_gpio = [](ArgParserConfig &candidate,
+                                                    bool active_high) {
+            candidate.band_gpio[ham_band_index(HamBand::BAND_20M)] =
+                BandGPIOConfig{.gpio = 5, .enabled = true, .active_high = active_high};
+            candidate.band_gpio[ham_band_index(HamBand::BAND_40M)] =
+                BandGPIOConfig{.gpio = 5, .enabled = true, .active_high = active_high};
+        };
+
+        prime_valid_runtime_identity_config();
+        configure_shared_band_gpio(config, true);
+        std::string validation_error;
+        require(
+            validate_config_candidate(config, &validation_error),
+            "two enabled bands may share one GPIO when their polarity matches");
+
+        config.band_gpio[ham_band_index(HamBand::BAND_80M)] =
+            BandGPIOConfig{.gpio = 5, .enabled = true, .active_high = true};
+        require(
+            validate_config_candidate(config, &validation_error),
+            "three enabled bands may share one GPIO when their polarity matches");
+
+        config.band_gpio[ham_band_index(HamBand::BAND_80M)].active_high = false;
+        require(
+            !validate_config_candidate(config, &validation_error) &&
+                validation_error ==
+                    "Bands sharing GPIO5 must use the same Active High setting.",
+            "bands sharing a GPIO with conflicting polarity must be rejected");
+
+        prime_valid_runtime_identity_config();
+        configure_shared_band_gpio(config, true);
+        config_to_json();
+        json_to_config();
+        require(
+            validate_config_candidate(config, &validation_error),
+            "JSON configuration must retain valid shared Band GPIO assignments");
+
+        for (const auto &[use_led, use_shutdown, use_amp, pin, label] :
+             std::vector<std::tuple<bool, bool, bool, int, std::string>>{
+                 {true, false, false, 5, "Transmit LED"},
+                 {false, true, false, 5, "Shutdown Button"},
+                 {false, false, true, 5, "Amp Control"}})
+        {
+            prime_valid_runtime_identity_config();
+            configure_shared_band_gpio(config, true);
+            config.use_led = use_led;
+            config.led_pin = use_led ? pin : -1;
+            config.use_shutdown = use_shutdown;
+            config.shutdown_pin = use_shutdown ? pin : -1;
+            config.use_amp = use_amp;
+            config.amp_pin = use_amp ? pin : -1;
+            require(
+                !validate_config_candidate(config, &validation_error) &&
+                    validation_error == "GPIO5 is reserved by " + label + ".",
+                "Band GPIO must reject an enabled " + label + " assignment");
+        }
+
+        prime_valid_runtime_identity_config();
+        configure_shared_band_gpio(config, true);
+        config.use_led = false;
+        config.led_pin = 5;
+        config.use_shutdown = false;
+        config.shutdown_pin = 5;
+        config.use_amp = false;
+        config.amp_pin = 5;
+        require(
+            validate_config_candidate(config, &validation_error),
+            "disabled Pi I/O features must not reserve their retained GPIO values");
+
+        config.use_led = true;
+        config.led_pin = 6;
+        config.use_shutdown = true;
+        config.shutdown_pin = 6;
+        require(
+            !validate_config_candidate(config, &validation_error) &&
+                validation_error ==
+                    "GPIO6 is assigned to both Transmit LED and Shutdown Button.",
+            "enabled LED, shutdown, and amplifier roles must remain mutually exclusive");
+
+        auto managed_ini = make_managed_ini_data("AA0NT", "EM18", "20m", true);
+        managed_ini["Band GPIO"]["20m"] = "5";
+        managed_ini["Band GPIO"]["20m Active High"] = "true";
+        managed_ini["Band GPIO"]["40m"] = "5";
+        managed_ini["Band GPIO"]["40m Active High"] = "true";
+        iniFile.setData(managed_ini);
+        PreparedConfigCandidate ini_candidate;
+        prepare_ini_config_candidate("/tmp/shared_band_gpio.ini", ini_candidate);
+        require(
+            ini_candidate.valid,
+            "INI configuration must accept matching shared Band GPIO assignments");
+
+        managed_ini["Band GPIO"]["40m Active High"] = "false";
+        iniFile.setData(managed_ini);
+        prepare_ini_config_candidate("/tmp/conflicting_band_gpio.ini", ini_candidate);
+        require(
+            !ini_candidate.valid && ini_candidate.error_reason ==
+                "Bands sharing GPIO5 must use the same Active High setting.",
+            "INI configuration must reject conflicting shared Band GPIO polarity");
+
+        prime_valid_runtime_identity_config();
+        config.use_led = true;
+        config.led_pin = 5;
+        config_to_json();
+        const nlohmann::json before_invalid_patch = jConfig;
+        bool patch_rejected = false;
+        try
+        {
+            patch_all_from_web({
+                {"Band GPIO",
+                 {{"20m", {{"GPIO", 5}, {"Enabled", true}, {"Active High", true}}}}}});
+        }
+        catch (const std::exception &)
+        {
+            patch_rejected = true;
+        }
+        require(
+            patch_rejected && jConfig == before_invalid_patch,
+            "web patches must reject reserved Band GPIO assignments without changing config");
     }
 
     for (const std::string &removed_alias : {

--- a/src/tests/qualification_gpio_test_mode_test.cpp
+++ b/src/tests/qualification_gpio_test_mode_test.cpp
@@ -1,0 +1,35 @@
+#include "qualification_gpio_test_mode.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace
+{
+    void require(bool condition, const std::string &message)
+    {
+        if (!condition)
+        {
+            std::cerr << "FAIL: " << message << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+}
+
+int main()
+{
+    require(!qualification_gpio_test_mode_requested(nullptr),
+            "an absent qualification GPIO test mode value must be disabled");
+
+    for (const char *value : {"", "0", "true", "yes", "invalid", "01", "1 ", " 1"})
+    {
+        require(!qualification_gpio_test_mode_requested(value),
+                std::string("qualification GPIO test mode must reject '") + value + "'");
+    }
+
+    require(qualification_gpio_test_mode_requested("1"),
+            "only exact value 1 must enable qualification GPIO test mode");
+
+    std::cout << "qualification GPIO test mode value semantics passed" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -113,6 +113,10 @@ int main()
 
     const std::string ui_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/index.js");
+    const std::string ui_stylesheet_source =
+        read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/index.css");
+    const std::string main_source =
+        read_text_file("/home/pi/WsprryPi/src/main.cpp");
     const std::string config_view_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/views/config.php");
     const std::string cw_timing_source =
@@ -123,6 +127,24 @@ int main()
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/operation.js");
     const std::string cw_message_input =
         extract_input_tag_by_id(config_view_source, "qrss_message");
+    require(
+        main_source.find("#ifdef DEBUG_WSPR\n    const char *qualification_gpio_test_mode") !=
+                std::string::npos &&
+            main_source.find("WSPRRYPI_QUALIFICATION_GPIO_TEST_MODE") !=
+                std::string::npos &&
+            main_source.find("GPIOOutput::setTestMode(true);") !=
+                std::string::npos &&
+            main_source.find("physical GPIO output requests, writes, and releases are suppressed") !=
+                std::string::npos,
+        "the debug-only qualification GPIO seam must require explicit activation and clearly state that physical output operations are suppressed");
+    require(
+        ui_source.find("if (!valid && reservedAssignment.field) {") !=
+                std::string::npos &&
+            ui_source.find("setFieldValidationState(reservedAssignment.field, false);") !=
+                std::string::npos &&
+            ui_stylesheet_source.find(".pin-dropdown-btn.is-invalid") !=
+                std::string::npos,
+        "Band GPIO conflicts with enabled reserved controls must mark both affected fields invalid");
     require(
         cw_message_input.find("type=\"text\"") != std::string::npos &&
             cw_message_input.find("step=") == std::string::npos,
@@ -1097,6 +1119,19 @@ int main()
             ui_source.find("getUseAmp() ? getAmpPin() : null") != std::string::npos &&
             ui_source.find("function validateGpioConflictFields()") != std::string::npos,
         "index.js must serialize Use Amp, retain Amp Pin as data, include Amp Pin Active High, and validate Amp GPIO conflicts only when enabled");
+    require(
+        ui_source.find("const reservedAssignments = [];") != std::string::npos &&
+            ui_source.find("const bandAssignments = [];") != std::string::npos &&
+            ui_source.find("GPIO${assignment.pin} is reserved by ${reservedAssignment.label}.") !=
+                std::string::npos &&
+            ui_source.find("Bands sharing GPIO${pin} must use the same Active High setting.") !=
+                std::string::npos &&
+            ui_source.find("Bands sharing a GPIO with matching polarity") == std::string::npos,
+        "Pi I/O validation must classify reserved controls separately, retain invalid selections, and allow only matching-polarity shared Band GPIO rows");
+    require(
+        ui_source.find("function handleBandGpioInputChange() {\n    refreshGpioConflictOptions();\n    validateBandGpioFields();\n    scheduleAutosave();") !=
+            std::string::npos,
+        "Band GPIO pin and polarity changes must schedule autosave after revalidation");
     const std::string footer_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/footer.php");
     const std::string site_css_source =


### PR DESCRIPTION
## Summary

- allow multiple enabled bands to share a selector GPIO when Active High polarity matches
- reject conflicting shared-band polarity and collisions with enabled LED, shutdown, or amplifier controls
- apply the same validation to JSON, INI reloads, and web patches without silently normalizing assignments
- update the UI submodule to WsprryPi/WsprryPi-UI#21
- add a debug-only, exact-opt-in GPIO suppression seam for safe live qualification, excluded from release builds

## Validation

- `make qualification-gpio-test-mode-test`
- `make semantics-test`
- `make band-gpio-rotation-test`
- `make selector-shutdown-cleanup-test`
- UI JavaScript and GPIO dropdown checks
- debug and release builds
- live REST, WebSocket, autosave, persistence, and fresh-page repopulation qualification with physical GPIO suppressed
- `git diff --check` in the parent and UI repositories

No physical GPIO, Si5351, amplifier, transmitter, test-tone, or RF activity was performed.

References #348. This PR intentionally does not close the issue.