### PR TITLE
Quiesce transmitter hardware during startup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -164,7 +164,10 @@ LOCAL_CPP_SOURCES := $(shell find . -maxdepth 1 -type f -name '*.cpp' ! -name '.
 SUBMODULE_CPP_SOURCES := $(shell find $(SUBMODULE_SRCDIRS) -type f -name '*.cpp' ! -name '._*' ! -name 'main.cpp' 2>/dev/null)
 SI5351_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_backend_harness.cpp
 STARTUP_QUIESCE_TEST_SOURCE := ./WSPR-Transmitter/src/startup_quiesce_test.cpp
-SUBMODULE_CPP_SOURCES := $(filter-out $(SI5351_TEST_SOURCE) $(STARTUP_QUIESCE_TEST_SOURCE),$(SUBMODULE_CPP_SOURCES))
+SI5351_QUALIFICATION_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification.cpp
+SI5351_QUALIFICATION_MAIN_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification_main.cpp
+SI5351_QUALIFICATION_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification_test.cpp
+SUBMODULE_CPP_SOURCES := $(filter-out $(SI5351_TEST_SOURCE) $(STARTUP_QUIESCE_TEST_SOURCE) $(SI5351_QUALIFICATION_SOURCE) $(SI5351_QUALIFICATION_MAIN_SOURCE) $(SI5351_QUALIFICATION_TEST_SOURCE),$(SUBMODULE_CPP_SOURCES))
 
 CPP_SOURCES := $(LOCAL_CPP_SOURCES) $(SUBMODULE_CPP_SOURCES)
 REL_CPP_SOURCES := $(patsubst ../../%,%,$(CPP_SOURCES))

--- a/src/Makefile
+++ b/src/Makefile
@@ -163,7 +163,8 @@ BIN_DIR         := build/bin
 LOCAL_CPP_SOURCES := $(shell find . -maxdepth 1 -type f -name '*.cpp' ! -name '._*' 2>/dev/null)
 SUBMODULE_CPP_SOURCES := $(shell find $(SUBMODULE_SRCDIRS) -type f -name '*.cpp' ! -name '._*' ! -name 'main.cpp' 2>/dev/null)
 SI5351_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_backend_harness.cpp
-SUBMODULE_CPP_SOURCES := $(filter-out $(SI5351_TEST_SOURCE),$(SUBMODULE_CPP_SOURCES))
+STARTUP_QUIESCE_TEST_SOURCE := ./WSPR-Transmitter/src/startup_quiesce_test.cpp
+SUBMODULE_CPP_SOURCES := $(filter-out $(SI5351_TEST_SOURCE) $(STARTUP_QUIESCE_TEST_SOURCE),$(SUBMODULE_CPP_SOURCES))
 
 CPP_SOURCES := $(LOCAL_CPP_SOURCES) $(SUBMODULE_CPP_SOURCES)
 REL_CPP_SOURCES := $(patsubst ../../%,%,$(CPP_SOURCES))
@@ -213,6 +214,9 @@ WSPR_TONE_REGRESSION_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_
 SELECTOR_SHUTDOWN_CLEANUP_TEST_SRC := tests/selector_shutdown_cleanup_test.cpp
 SELECTOR_SHUTDOWN_CLEANUP_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/selector_shutdown_cleanup_test.o
 SELECTOR_SHUTDOWN_CLEANUP_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
+STARTUP_QUIESCE_PARENT_TEST_SRC := tests/startup_quiesce_parent_test.cpp
+STARTUP_QUIESCE_PARENT_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/startup_quiesce_parent_test.o
+STARTUP_QUIESCE_PARENT_TEST_DEPS := $(filter-out $(MAIN_DEBUG_OBJECT),$(CPP_DEBUG_OBJECTS))
 QUALIFICATION_GPIO_TEST_MODE_TEST_SRC := tests/qualification_gpio_test_mode_test.cpp
 QUALIFICATION_GPIO_TEST_MODE_TEST_OBJ := $(OBJ_DIR_DEBUG)/tests/qualification_gpio_test_mode_test.o
 QUALIFICATION_GPIO_TEST_MODE_TEST_DEPS := $(QUALIFICATION_GPIO_TEST_MODE_TEST_OBJ)
@@ -566,6 +570,15 @@ $(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT): $(SELECTOR_SHUTDOWN_CLEANUP_TE
 	$(Q)echo "Linking debug: $(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)"
 	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
 
+$(STARTUP_QUIESCE_PARENT_TEST_OBJ): $(STARTUP_QUIESCE_PARENT_TEST_SRC)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)mkdir -p $(DEP_DIR)/tests
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) -MF $(DEP_DIR)/tests/startup_quiesce_parent_test.d -c $< -o $@
+
+$(BIN_DIR)/startup_quiesce_parent_test: $(STARTUP_QUIESCE_PARENT_TEST_OBJ) $(STARTUP_QUIESCE_PARENT_TEST_DEPS)
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)$(CXX) $(CXX_DEBUG_FLAGS) $^ -o $@ $(LDFLAGS)
+
 $(QUALIFICATION_GPIO_TEST_MODE_TEST_OBJ): $(QUALIFICATION_GPIO_TEST_MODE_TEST_SRC)
 	$(Q)mkdir -p $(dir $@)
 	$(Q)mkdir -p $(DEP_DIR)/tests
@@ -790,6 +803,9 @@ band-gpio-rotation-test: $(BIN_DIR)/$(BAND_GPIO_ROTATION_TEST_OUT)
 selector-shutdown-cleanup-test: $(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)
 	$(Q)echo "Running selector shutdown cleanup regression tests."
 	$(Q)./$(BIN_DIR)/$(SELECTOR_SHUTDOWN_CLEANUP_TEST_OUT)
+
+startup-quiesce-parent-test: $(BIN_DIR)/startup_quiesce_parent_test
+	$(Q)./$(BIN_DIR)/startup_quiesce_parent_test
 
 qualification-gpio-test-mode-test: $(BIN_DIR)/$(QUALIFICATION_GPIO_TEST_MODE_TEST_OUT)
 	$(Q)echo "Running qualification GPIO test mode value semantics test."

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -224,6 +224,10 @@ static std::mutex tx_led_state_mtx;
 static std::condition_variable tx_led_state_cv;
 static bool tx_led_active = false;
 static std::mutex transmit_gpio_lifecycle_mtx;
+static std::atomic<bool> startup_quiesce_inhibited{false};
+static std::mutex startup_quiesce_error_mtx;
+static std::string startup_quiesce_error;
+static StartupQuiesceInvokerForTest startup_quiesce_invoker_for_test{};
 
 /**
  * @brief File-scope self-pipe descriptors for signal notifications.
@@ -1369,6 +1373,39 @@ static void log_transmit_disabled_skip()
     llog.logS(INFO, "Transmit disabled, skipping transmission and scheduling.");
 }
 
+static void log_startup_quiesce_inhibited_skip()
+{
+    std::lock_guard<std::mutex> lock(startup_quiesce_error_mtx);
+    llog.logS(
+        ERROR,
+        "Transmit is configured on but inhibited because startup hardware could not be quiesced: ",
+        startup_quiesce_error);
+}
+
+static wsprrypi::StartupQuiesceResult invoke_startup_quiesce()
+{
+    if (startup_quiesce_invoker_for_test)
+        return startup_quiesce_invoker_for_test();
+    return wsprTransmitter.quiesceForStartup();
+}
+
+static bool run_startup_quiesce_gate(const ArgParserConfig &cfg)
+{
+    const wsprrypi::StartupQuiesceResult result = invoke_startup_quiesce();
+    if (!result.ok)
+    {
+        std::lock_guard<std::mutex> lock(startup_quiesce_error_mtx);
+        startup_quiesce_error = result.error.empty()
+            ? "The selected transmission backend did not report a reason."
+            : result.error;
+        startup_quiesce_inhibited.store(true, std::memory_order_release);
+    }
+
+    deassert_transmit_gpio_outputs(&cfg, false, "startup hardware quiesce");
+    shutdown_all_configured_selector_gpios(cfg);
+    return result.ok;
+}
+
 static bool runtime_transmit_requested(const ArgParserConfig &cfg) noexcept
 {
     if (!cfg.use_ini)
@@ -1395,7 +1432,9 @@ static bool runtime_transmit_requested(const ArgParserConfig &cfg) noexcept
 
 static bool runtime_transmit_enabled(const ArgParserConfig &cfg) noexcept
 {
-    return runtime_transmit_requested(cfg) && !managed_reload_tx_inhibited;
+    return runtime_transmit_requested(cfg) &&
+           !managed_reload_tx_inhibited &&
+           !startup_quiesce_inhibited.load(std::memory_order_acquire);
 }
 
 bool web_server_start_enabled(const ArgParserConfig &cfg) noexcept
@@ -2289,9 +2328,12 @@ bool validate_non_wspr_repeat_interval_policy(
 
 static bool start_non_wspr_transmission_now(const ArgParserConfig &cfg)
 {
-    if (!runtime_transmit_requested(cfg))
+    if (!runtime_transmit_enabled(cfg))
     {
-        log_transmit_disabled_skip();
+        if (startup_quiesce_inhibited.load(std::memory_order_acquire))
+            log_startup_quiesce_inhibited_skip();
+        else
+            log_transmit_disabled_skip();
         return true;
     }
 
@@ -2492,10 +2534,13 @@ static void schedule_next_non_wspr_launch(const ArgParserConfig &cfg)
         return;
     }
 
-    if (!runtime_transmit_requested(cfg))
+    if (!runtime_transmit_enabled(cfg))
     {
         non_wspr_schedule_generation.fetch_add(1, std::memory_order_acq_rel);
-        log_transmit_disabled_skip();
+        if (startup_quiesce_inhibited.load(std::memory_order_acquire))
+            log_startup_quiesce_inhibited_skip();
+        else
+            log_transmit_disabled_skip();
         return;
     }
 
@@ -3514,11 +3559,16 @@ TestToneStopResult end_test_tone()
     }
 
     validate_config_data();
-    if (!runtime_transmit_requested(config))
+    if (!runtime_transmit_enabled(config))
     {
-        log_transmit_disabled_skip();
+        if (startup_quiesce_inhibited.load(std::memory_order_acquire))
+            log_startup_quiesce_inhibited_skip();
+        else
+            log_transmit_disabled_skip();
         result.stopped = true;
-        result.message = "Test tone stopped with transmit disabled.";
+        result.message = startup_quiesce_inhibited.load(std::memory_order_acquire)
+            ? "Test tone is inhibited because startup hardware could not be quiesced."
+            : "Test tone stopped with transmit disabled.";
         return result;
     }
 
@@ -3723,6 +3773,19 @@ bool wspr_loop()
         }
     }
 
+    // Backend selection occurs while loading the validated runtime
+    // configuration.  Quiesce it before any service, scheduler, selector, or
+    // automatic-transmit path can run.  This latch is process-lifetime by
+    // design: ordinary reloads and toggles cannot clear a hardware-safety
+    // failure; a deliberate process restart reinitializes the backend.
+    if (!run_startup_quiesce_gate(config))
+    {
+        llog.logS(
+            ERROR,
+            "Startup transmission inhibition latched: ",
+            startup_quiesce_error);
+    }
+
     if (!config.enable_web)
     {
         llog.logS(INFO, "Web UI disabled via CLI (--no-web)");
@@ -3797,9 +3860,12 @@ bool wspr_loop()
             return false;
         }
 
-        if (!runtime_transmit_requested(config))
+        if (!runtime_transmit_enabled(config))
         {
-            log_transmit_disabled_skip();
+            if (startup_quiesce_inhibited.load(std::memory_order_acquire))
+                log_startup_quiesce_inhibited_skip();
+            else
+                log_transmit_disabled_skip();
         }
         else
         {
@@ -5448,4 +5514,33 @@ void reset_current_transmission_request_for_test() noexcept
 void reset_current_controller_request_for_test() noexcept
 {
     current_controller_request_for_test_storage.reset();
+}
+
+void set_startup_quiesce_invoker_for_test(StartupQuiesceInvokerForTest invoker)
+{
+    startup_quiesce_invoker_for_test = std::move(invoker);
+}
+
+void reset_startup_quiesce_for_test() noexcept
+{
+    startup_quiesce_invoker_for_test = {};
+    startup_quiesce_inhibited.store(false, std::memory_order_release);
+    std::lock_guard<std::mutex> lock(startup_quiesce_error_mtx);
+    startup_quiesce_error.clear();
+}
+
+bool run_startup_quiesce_gate_for_test(const ArgParserConfig &cfg)
+{
+    return run_startup_quiesce_gate(cfg);
+}
+
+bool startup_quiesce_inhibited_for_test() noexcept
+{
+    return startup_quiesce_inhibited.load(std::memory_order_acquire);
+}
+
+std::string startup_quiesce_error_for_test()
+{
+    std::lock_guard<std::mutex> lock(startup_quiesce_error_mtx);
+    return startup_quiesce_error;
 }

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -43,6 +43,7 @@
 #include "arg_parser.hpp"
 #include "ppm_manager.hpp"
 #include "transmission_request.hpp"
+#include "transmission_backend.hpp"
 #include "wspr_transmit_types.hpp"
 
 // Standard library headers
@@ -51,6 +52,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <condition_variable>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -407,5 +409,13 @@ void set_current_transmission_request_for_test(
 std::optional<wsprrypi::TransmissionRequest> current_controller_request_for_test();
 void reset_current_transmission_request_for_test() noexcept;
 void reset_current_controller_request_for_test() noexcept;
+
+using StartupQuiesceInvokerForTest =
+    std::function<wsprrypi::StartupQuiesceResult()>;
+void set_startup_quiesce_invoker_for_test(StartupQuiesceInvokerForTest invoker);
+void reset_startup_quiesce_for_test() noexcept;
+bool run_startup_quiesce_gate_for_test(const ArgParserConfig &cfg);
+bool startup_quiesce_inhibited_for_test() noexcept;
+std::string startup_quiesce_error_for_test();
 
 #endif // _SCHEDULING_HPP

--- a/src/tests/startup_quiesce_parent_test.cpp
+++ b/src/tests/startup_quiesce_parent_test.cpp
@@ -1,0 +1,13 @@
+#include "config_handler.hpp"
+#include "gpio_output.hpp"
+#include "scheduling.hpp"
+#include <cstdlib>
+#include <iostream>
+
+namespace { void require(bool v, const char *m) { if (!v) { std::cerr << m << '\n'; std::exit(1); } }
+ArgParserConfig cfg_for(EnableOnBootBehavior policy) { init_default_config(); auto cfg = config; cfg.use_ini = true; cfg.transmit = true; cfg.enable_on_boot = policy; cfg.use_led = true; cfg.led_pin = 5; config = cfg; return cfg; }
+void reset() { reset_startup_quiesce_for_test(); GPIOOutput::setTestMode(true); set_scheduler_execution_suppressed_for_test(true); reset_tx_led_request_counts_for_test(); }
+}
+int main() {
+ for (auto policy : {EnableOnBootBehavior::Never, EnableOnBootBehavior::Follow, EnableOnBootBehavior::Always}) { reset(); int calls=0; set_startup_quiesce_invoker_for_test([&calls]{ ++calls; return wsprrypi::StartupQuiesceResult{true,{}}; }); auto cfg=cfg_for(policy); require(run_startup_quiesce_gate_for_test(cfg), "success gate"); require(calls==1, "one quiesce per policy"); require(!startup_quiesce_inhibited_for_test(), "success not inhibited"); require(tx_led_deassert_request_count_for_test()>0, "outputs deasserted"); }
+ reset(); int calls=0; set_startup_quiesce_invoker_for_test([&calls]{ ++calls; return wsprrypi::StartupQuiesceResult{false,"fake quiesce failure"}; }); auto cfg=cfg_for(EnableOnBootBehavior::Follow); const bool tx=cfg.transmit; const auto policy=cfg.enable_on_boot; require(!run_startup_quiesce_gate_for_test(cfg), "failure gate"); require(calls==1, "one failed quiesce"); require(startup_quiesce_inhibited_for_test(), "failure inhibited"); require(startup_quiesce_error_for_test()=="fake quiesce failure", "error retained"); require(cfg.transmit==tx && cfg.enable_on_boot==policy, "policy preserved"); require(start_non_wspr_transmission_now_for_test(cfg), "blocked launch returns safely"); require(!current_controller_request_for_test().has_value(), "manual launch must not configure transmitter"); require(startup_quiesce_inhibited_for_test(), "latch retained"); reset_startup_quiesce_for_test(); GPIOOutput::setTestMode(false); set_scheduler_execution_suppressed_for_test(false); std::cout << "startup_quiesce_parent_test passed\n"; }


### PR DESCRIPTION
## What changed

- add backend-neutral startup quiescence before services and scheduling
- actively disable Si5351 outputs or stop the GPIO DMA/GPCLK path and return the transmit pin to input
- latch startup failures as a process-lifetime transmission inhibition while retaining operator access
- add fake-hardware, parent orchestration, and guarded qualification coverage

## Why

Disabling the saved transmission policy did not actively place already-configured transmitter hardware in a safe state after daemon or host restart.

## Validation

- source and fake-hardware suites passed
- bounded live Si5351 qualification passed on wspr5
- bounded GPIO4 and integrated daemon qualification passed on wspr4
- RF silence was not instrumentally measured; GPIO20 was not live-qualified

Closes #347
