### PR TITLE
Add process snapshots to support bundles

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,14 @@ I2C probe state, and whether unprivileged execution may have omitted privileged
 diagnostics. The JSON and console output intentionally contain no configuration
 secrets.
 
+Every bundle also contains a point-in-time process/resource snapshot: a wide
+system process list, process tree, systemd cgroup view when available, and
+WsprryPi `/proc` evidence resolved from the service's systemd `MainPID`. The
+summary reports current RSS, virtual size, PSS when readable, threads, tasks,
+and open-file-descriptor count. Unavailable, stopped, permission, and process
+race states are labeled explicitly rather than reported as zero. This snapshot
+does not provide historical resource monitoring.
+
 I2C bus scanning is opt-in: `--probe-i2c` permits only `i2cdetect -y 1`.
 Without it, the collector gathers passive I2C details but records that active
 probing was skipped. Running as a non-root user is supported; restricted system

--- a/scripts/collect-support-bundle.sh
+++ b/scripts/collect-support-bundle.sh
@@ -707,7 +707,7 @@ if [[ -n "$PROJECT_PATH" && -d "$PROJECT_PATH" ]]; then
       -name "*.service" \
     \) -print0 2>/dev/null |
       while IFS= read -r -d '' file; do
-        rel="${file#$PROJECT_PATH/}"
+        rel="${file#"$PROJECT_PATH"/}"
         mkdir -p "${OUT_DIR}/configs/project/$(dirname "$rel")"
         cp "$file" "${OUT_DIR}/configs/project/$rel" 2>/dev/null || true
       done
@@ -819,7 +819,7 @@ tail_or_copy_log /var/log/messages "${OUT_DIR}/logs/messages"
 if [[ -d "$LEGACY_LOG_DIR" ]]; then
   find "$LEGACY_LOG_DIR" -maxdepth 2 -type f -print0 2>/dev/null |
     while IFS= read -r -d '' file; do
-      rel="${file#$LEGACY_LOG_DIR/}"
+      rel="${file#"$LEGACY_LOG_DIR"/}"
       tail_or_copy_log "$file" "${OUT_DIR}/logs/legacy-wsprrypi/$rel"
     done
 else

--- a/scripts/collect-support-bundle.sh
+++ b/scripts/collect-support-bundle.sh
@@ -171,7 +171,7 @@ fi
 OUT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/${PROJECT_NAME}-support-${STAMP}.XXXXXX")" || fail "Unable to create private temporary work directory."
 chmod 700 "$OUT_ROOT" || fail "Unable to secure temporary work directory."
 OUT_DIR="${OUT_ROOT}/bundle"
-mkdir -p "$OUT_DIR"/{system,project,logs,configs,hardware,web,network,commands} || fail "Unable to create support-bundle work directory."
+mkdir -p "$OUT_DIR"/{system,project,logs,configs,hardware,web,network,commands,processes} || fail "Unable to create support-bundle work directory."
 
 cleanup() {
   [[ -n "$ARCHIVE_TMP" ]] && rm -f "$ARCHIVE_TMP"
@@ -295,6 +295,7 @@ redact_file_in_place() {
     s#([A-Za-z][A-Za-z0-9+.-]*://)[^/\s:@]+:[^/\s@]+@#${1}[REDACTED]@#g;
     s#("(?:password|pass|passwd|token|secret|api[_-]?key|access[_-]?key|upload[_-]?key|wsprnet[_-]?password|reporter[_-]?password)"\s*:\s*")[^"]*(")#${1}[REDACTED]${2}#gi;
     s#((?:password|pass|passwd|token|secret|api[_-]?key|access[_-]?key|upload[_-]?key|wsprnet[_-]?password|reporter[_-]?password)\s*[:=]\s*)\S+#${1}[REDACTED]#gi;
+    s#((?:--?)(?:password|pass|passwd|token|secret|api[_-]?key|access[_-]?key|upload[_-]?key|wsprnet[_-]?password|reporter[_-]?password)\s+)\S+#${1}[REDACTED]#gi;
   ' "$file" 2>/dev/null || true
 }
 
@@ -312,6 +313,189 @@ redact_tree() {
     while IFS= read -r -d '' file; do
       redact_file_in_place "$file"
     done
+}
+
+availability_reason() {
+  local error_file="$1"
+  if grep -qi 'permission denied' "$error_file" 2>/dev/null; then
+    printf 'permission denied'
+  elif grep -qiE 'no such file|not found' "$error_file" 2>/dev/null; then
+    printf 'file unavailable'
+  else
+    printf 'unavailable'
+  fi
+}
+
+capture_optional_command() {
+  local output="$1" command_name="$2"
+  shift 2
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    printf 'Collection status: command unavailable (%s)\n' "$command_name" > "$output"
+    return
+  fi
+  "$@" > "$output" 2>&1
+  local status=$?
+  if [[ "$status" -ne 0 ]]; then
+    printf '\nCollection status: command unavailable or failed (exit status %s)\n' "$status" >> "$output"
+  fi
+}
+
+proc_start_time() {
+  sed -E 's/^[0-9]+ \(.*\) //' "$1" 2>/dev/null | awk '{print $20}'
+}
+
+capture_proc_file() {
+  local source="$1" output="$2" error_file
+  error_file="${output}.error"
+  if cat "$source" > "$output" 2> "$error_file"; then
+    rm -f "$error_file"
+    return 0
+  fi
+  local reason
+  reason="$(availability_reason "$error_file")"
+  {
+    printf 'Collection status: %s\n' "$reason"
+    [[ -s "$error_file" ]] && cat "$error_file"
+  } > "$output"
+  rm -f "$error_file"
+  return 1
+}
+
+count_proc_entries() {
+  local directory="$1" output_variable="$2" error_file result
+  error_file="${OUT_DIR}/processes/.count-error.$$"
+  if result="$(find "$directory" -mindepth 1 -maxdepth 1 -printf '.' 2> "$error_file")"; then
+    printf -v "$output_variable" '%s' "${#result}"
+    rm -f "$error_file"
+    return 0
+  fi
+  printf -v "$output_variable" '%s' "unavailable ($(availability_reason "$error_file"))"
+  rm -f "$error_file"
+  return 1
+}
+
+status_value() {
+  local field="$1" file="$2" value
+  value="$(awk -F: -v field="$field" '$1 == field {sub(/^[[:space:]]+/, "", $2); print $2; exit}' "$file" 2>/dev/null)"
+  [[ -n "$value" ]] && printf '%s' "$value" || printf 'unavailable'
+}
+
+smaps_value() {
+  status_value "$1" "$2"
+}
+
+collect_process_snapshot() {
+  local process_dir="${OUT_DIR}/processes"
+  local active_state main_pid initial_start final_start task_count fd_count cmdline_tmp
+  local active_error="${process_dir}/.active-state-error.txt"
+  local main_pid_error="${process_dir}/.main-pid-error.txt"
+  local detailed_status="unavailable"
+
+  capture_optional_command "${process_dir}/all-processes.txt" ps ps -ww -eo pid,ppid,user,stat,etime,rss,vsz,nlwp,comm,args
+  capture_optional_command "${process_dir}/process-tree.txt" pstree pstree -alp
+  capture_optional_command "${process_dir}/systemd-cgroups.txt" systemd-cgls systemd-cgls --all --no-pager
+
+  if ! command -v systemctl >/dev/null 2>&1; then
+    active_state="unavailable"
+    main_pid=""
+    detailed_status="systemd command unavailable"
+  else
+    if ! systemctl show wsprrypi --property=ActiveState --value > "${process_dir}/.active-state.txt" 2> "$active_error"; then
+      active_state="unavailable ($(availability_reason "$active_error"))"
+    else
+      active_state="$(cat "${process_dir}/.active-state.txt")"
+    fi
+    if ! systemctl show wsprrypi --property=MainPID --value > "${process_dir}/.main-pid.txt" 2> "$main_pid_error"; then
+      main_pid=""
+      detailed_status="MainPID unavailable ($(availability_reason "$main_pid_error"))"
+    else
+      main_pid="$(cat "${process_dir}/.main-pid.txt")"
+    fi
+    if [[ "$detailed_status" == MainPID\ unavailable* ]]; then
+      :
+    elif [[ ! "$main_pid" =~ ^[0-9]+$ ]]; then
+      detailed_status="invalid or empty MainPID"
+    elif [[ "$main_pid" == "0" ]]; then
+      if [[ "$active_state" == "inactive" || "$active_state" == "failed" ]]; then
+        detailed_status="service not running"
+      else
+        detailed_status="MainPID is zero; no active main process"
+      fi
+    elif [[ ! -d "/proc/${main_pid}" ]]; then
+      detailed_status="process missing before detailed collection"
+    else
+      if capture_proc_file "/proc/${main_pid}/stat" "${process_dir}/wsprrypi-stat.txt"; then
+        initial_start="$(proc_start_time "${process_dir}/wsprrypi-stat.txt")"
+        if [[ ! "$initial_start" =~ ^[0-9]+$ ]]; then
+          detailed_status="process identity unavailable"
+        else
+          capture_proc_file "/proc/${main_pid}/status" "${process_dir}/.status-full.txt" || true
+          if grep -q '^Name:' "${process_dir}/.status-full.txt" 2>/dev/null; then
+            awk -F: '$1 ~ /^(Name|State|Pid|PPid|Uid|Gid|VmPeak|VmSize|VmHWM|VmRSS|RssAnon|RssFile|RssShmem|Threads|voluntary_ctxt_switches|nonvoluntary_ctxt_switches)$/ {print}' \
+              "${process_dir}/.status-full.txt" > "${process_dir}/wsprrypi-status.txt"
+          else
+            cp "${process_dir}/.status-full.txt" "${process_dir}/wsprrypi-status.txt"
+          fi
+          capture_proc_file "/proc/${main_pid}/smaps_rollup" "${process_dir}/wsprrypi-smaps-rollup.txt" || true
+          capture_proc_file "/proc/${main_pid}/statm" "${process_dir}/wsprrypi-statm.txt" || true
+          capture_proc_file "/proc/${main_pid}/limits" "${process_dir}/wsprrypi-limits.txt" || true
+          capture_proc_file "/proc/${main_pid}/cgroup" "${process_dir}/wsprrypi-cgroup.txt" || true
+          cmdline_tmp="${process_dir}/.cmdline-raw.txt"
+          if capture_proc_file "/proc/${main_pid}/cmdline" "$cmdline_tmp"; then
+            tr '\0' ' ' < "$cmdline_tmp" > "${process_dir}/wsprrypi-cmdline.txt"
+            printf '\n' >> "${process_dir}/wsprrypi-cmdline.txt"
+          else
+            cp "$cmdline_tmp" "${process_dir}/wsprrypi-cmdline.txt"
+          fi
+          count_proc_entries "/proc/${main_pid}/task" task_count || true
+          count_proc_entries "/proc/${main_pid}/fd" fd_count || true
+
+          if cat "/proc/${main_pid}/stat" > "${process_dir}/.stat-final.txt" 2>/dev/null; then
+            final_start="$(proc_start_time "${process_dir}/.stat-final.txt")"
+            if [[ "$final_start" != "$initial_start" ]]; then
+              detailed_status="process identity changed; PID may have been reused"
+            else
+              detailed_status="collected successfully"
+            fi
+          else
+            detailed_status="process disappeared during collection"
+          fi
+        fi
+      else
+        detailed_status="process disappeared or stat was unreadable before detailed collection"
+      fi
+    fi
+  fi
+
+  {
+    printf 'Collection status: %s\n' "$detailed_status"
+    printf 'Service ActiveState: %s\n' "${active_state:-unavailable}"
+    printf 'Systemd MainPID: %s\n' "${main_pid:-unavailable}"
+    if [[ "$detailed_status" == "collected successfully" ]]; then
+      printf 'Process start time (clock ticks since boot): %s\n' "$initial_start"
+      printf 'VmRSS: %s\n' "$(status_value VmRSS "${process_dir}/wsprrypi-status.txt")"
+      printf 'VmSize: %s\n' "$(status_value VmSize "${process_dir}/wsprrypi-status.txt")"
+      printf 'PSS: %s\n' "$(smaps_value Pss "${process_dir}/wsprrypi-smaps-rollup.txt")"
+      printf 'Threads (status): %s\n' "$(status_value Threads "${process_dir}/wsprrypi-status.txt")"
+      printf 'Task directory count: %s\n' "${task_count:-unavailable}"
+      printf 'Open file descriptor count: %s\n' "${fd_count:-unavailable}"
+    else
+      printf 'VmRSS: unavailable\nVmSize: unavailable\nPSS: unavailable\n'
+      printf 'Threads (status): unavailable\nTask directory count: unavailable\nOpen file descriptor count: unavailable\n'
+    fi
+  } > "${process_dir}/wsprrypi-summary.txt"
+
+  local artifact
+  for artifact in wsprrypi-status.txt wsprrypi-smaps-rollup.txt wsprrypi-stat.txt \
+    wsprrypi-statm.txt wsprrypi-limits.txt wsprrypi-cgroup.txt wsprrypi-cmdline.txt; do
+    if [[ ! -f "${process_dir}/${artifact}" ]]; then
+      printf 'Collection status: not collected (%s)\n' "$detailed_status" > "${process_dir}/${artifact}"
+    fi
+  done
+
+  rm -f "${process_dir}/.status-full.txt" "${process_dir}/.cmdline-raw.txt" \
+    "${process_dir}/.stat-final.txt" "${process_dir}/.count-error.$$" \
+    "${process_dir}/.active-state.txt" "$active_error" "${process_dir}/.main-pid.txt" "$main_pid_error"
 }
 
 detect_project_path() {
@@ -395,6 +579,7 @@ Bundle contents may include:
 - Installed and project WsprryPi INI files, redacted
 - Installed systemd unit, merged systemctl cat output, and service directive inspection
 - Journald logs for WsprryPi and Apache services
+- A point-in-time system process/tree/cgroup snapshot and WsprryPi memory, task, and file-descriptor counts
 - Installer log if present, usually ~/wsprrypi.log from scripts/install.sh
 - Legacy /var/log/wsprrypi logs only when present
 - GPIO, I2C, Si5351-adjacent, band-switching, boot, and timing diagnostics
@@ -595,6 +780,10 @@ systemctl show wsprrypi --no-pager > "${OUT_DIR}/configs/systemd/systemctl-show-
 systemctl show wsprrypi --no-pager --property=Id,Names,LoadState,ActiveState,SubState,FragmentPath,DropInPaths,UnitFileState,ExecStart,User,Group,WorkingDirectory,Environment,StandardOutput,StandardError,SyslogIdentifier,Restart,RestartUSec,Wants,Requires,After,Before > "${OUT_DIR}/configs/systemd/systemctl-show-wsprrypi-summary.txt" 2>&1 || true
 systemctl is-enabled wsprrypi > "${OUT_DIR}/logs/systemd-enabled-wsprrypi.txt" 2>&1 || true
 systemctl is-active wsprrypi > "${OUT_DIR}/logs/systemd-active-wsprrypi.txt" 2>&1 || true
+
+log "Collecting process and resource snapshot..."
+
+collect_process_snapshot
 
 for service in "${SERVICE_NAMES[@]}"; do
   systemctl status "$service" --no-pager > "${OUT_DIR}/logs/systemd-status-${service}.txt" 2>&1 || true

--- a/scripts/tests/collect-support-bundle_test.sh
+++ b/scripts/tests/collect-support-bundle_test.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 fail() { echo "FAIL: $*" >&2; exit 1; }
 assert_contains() { grep -Fq -- "$2" "$1" || fail "expected '$2' in $1"; }
 assert_not_contains() { ! grep -Fq -- "$2" "$1" || fail "did not expect '$2' in $1"; }
+assert_file() { [[ -f "$1" ]] || fail "expected file $1"; }
 command -v python3 >/dev/null 2>&1 || fail "python3 is required for JSON result validation"
 
 assert_valid_json() {
@@ -56,25 +57,86 @@ printf '%s\\n' "\$*" >> "\${I2C_CALL_LOG:?}"
 if [[ "\$1" == '-l' ]]; then exit 0; fi
 exit ${probe_exit}
 EOF
-  for command in raspi-config vcgencmd gpioinfo gpiodetect gpiofind pinout gpio curl systemctl journalctl dmesg sh; do
+  for command in raspi-config vcgencmd gpioinfo gpiodetect gpiofind pinout gpio curl journalctl dmesg sh; do
     cat > "$directory/$command" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
   done
+  cat > "$directory/systemctl" <<'EOF'
+#!/usr/bin/bash
+if [[ "$*" == 'show wsprrypi --property=ActiveState --value' ]]; then
+  printf '%s\n' "${MOCK_ACTIVE_STATE:-active}"
+elif [[ "$*" == 'show wsprrypi --property=MainPID --value' ]]; then
+  if [[ "${MOCK_SYSTEMCTL_MAINPID_FAILURE:-0}" == 1 ]]; then printf 'Failed to get properties: Permission denied\n' >&2; exit 1; fi
+  printf '%s' "${MOCK_MAIN_PID-0}"
+  [[ "${MOCK_MAIN_PID_NEWLINE:-1}" == 1 ]] && printf '\n'
+fi
+exit 0
+EOF
+  cat > "$directory/ps" <<'EOF'
+#!/usr/bin/bash
+printf '    PID    PPID USER     STAT     ELAPSED   RSS    VSZ NLWP COMMAND         COMMAND\n'
+printf '   4242       1 wsprrypi Sl         01:23 12345  67890    4 wsprrypi       /usr/local/bin/wsprrypi --token process-secret\n'
+printf '   5000    1000 www-data S          00:42  2048  12000    1 php             php /var/www/worker.php\n'
+EOF
+  cat > "$directory/pstree" <<'EOF'
+#!/usr/bin/bash
+printf 'systemd,1---apache2,1000---php,5000---journalctl,5001\n'
+EOF
+  cat > "$directory/systemd-cgls" <<'EOF'
+#!/usr/bin/bash
+printf 'Control group /: wsprrypi.service apache2.service\n'
+EOF
+  cat > "$directory/cat" <<'EOF'
+#!/usr/bin/bash
+source_path="${1:-}"
+if [[ "$source_path" != "/proc/${MOCK_PROC_PID:-none}/"* ]]; then exec /usr/bin/cat "$@"; fi
+name="${source_path##*/}"
+case "$name" in
+  stat)
+    count_file="${MOCK_STATE_DIR:?}/stat-count"
+    count=0; [[ -f "$count_file" ]] && count="$(/usr/bin/cat "$count_file")"
+    count=$((count + 1)); printf '%s\n' "$count" > "$count_file"
+    if [[ "${MOCK_PROC_SCENARIO:-success}" == disappear && "$count" -gt 1 ]]; then printf 'cat: %s: No such file or directory\n' "$source_path" >&2; exit 1; fi
+    start=777; [[ "${MOCK_PROC_SCENARIO:-success}" == reused && "$count" -gt 1 ]] && start=888
+    printf '%s (wsprrypi worker) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 %s 20 21\n' "${MOCK_PROC_PID}" "$start"
+    ;;
+  status) /usr/bin/cat "${MOCK_FIXTURE_DIR:?}/status" ;;
+  smaps_rollup)
+    if [[ "${MOCK_PROC_SCENARIO:-success}" == unreadable ]]; then printf 'cat: %s: Permission denied\n' "$source_path" >&2; exit 1; fi
+    /usr/bin/cat "${MOCK_FIXTURE_DIR:?}/smaps_rollup"
+    ;;
+  statm|limits|cgroup) /usr/bin/cat "${MOCK_FIXTURE_DIR:?}/$name" ;;
+  cmdline) printf '/usr/local/bin/wsprrypi\0--password\0cmdline-secret\0' ;;
+  *) exec /usr/bin/cat "$@" ;;
+esac
+EOF
+  cat > "$directory/find" <<'EOF'
+#!/usr/bin/bash
+if [[ "${1:-}" == "/proc/${MOCK_PROC_PID:-none}/task" ]]; then
+  [[ "${MOCK_PROC_SCENARIO:-success}" == unreadable ]] && { printf 'find: Permission denied\n' >&2; exit 1; }
+  printf '....'; exit 0
+fi
+if [[ "${1:-}" == "/proc/${MOCK_PROC_PID:-none}/fd" ]]; then
+  [[ "${MOCK_PROC_SCENARIO:-success}" == unreadable ]] && { printf 'find: Permission denied\n' >&2; exit 1; }
+  printf '.....'; exit 0
+fi
+exec /usr/bin/find "$@"
+EOF
   chmod 700 "$directory"/*
 }
 
 make_no_i2c_path() {
   local directory="$1" command
   mkdir -p "$directory"
-  for command in awk basename cat chmod cp cut df dirname file find free getconf getent grep gzip id ldd ln ls mkdir mktemp mount perl readelf rm sha256sum sh sort stat tail tar uname uptime; do
+  for command in awk basename chmod cp cut df dirname file free getconf getent grep gzip id ldd ln ls mkdir mktemp mount perl readelf rm sha256sum sh sort stat tail tar tr uname uptime wc; do
     ln -s "$(command -v "$command")" "$directory/$command"
   done
   rm "$directory/sh"
   cp "$TEST_ROOT/mocks/date" "$directory/date"
   cp "$TEST_ROOT/mocks/hostname" "$directory/hostname"
-  for command in raspi-config vcgencmd gpioinfo gpiodetect gpiofind pinout gpio curl systemctl journalctl dmesg sh; do
+  for command in raspi-config vcgencmd gpioinfo gpiodetect gpiofind pinout gpio curl systemctl journalctl dmesg sh cat find; do
     cp "$TEST_ROOT/mocks/$command" "$directory/$command"
   done
 }
@@ -94,6 +156,49 @@ run_collector_isolated() {
 mkdir -p "$TEST_ROOT/tmp" "$TEST_ROOT/out" "$TEST_ROOT/mocks"
 chmod 700 "$TEST_ROOT/out"
 make_mocks "$TEST_ROOT/mocks" 0
+mkdir -p "$TEST_ROOT/proc-fixture" "$TEST_ROOT/mock-state"
+cat > "$TEST_ROOT/proc-fixture/status" <<'EOF'
+Name:	wsprrypi
+State:	S (sleeping)
+Pid:	4242
+PPid:	1
+Uid:	1000	1000	1000	1000
+Gid:	1000	1000	1000	1000
+VmPeak:	  90000 kB
+VmSize:	  67890 kB
+VmHWM:	   23456 kB
+VmRSS:	   12345 kB
+RssAnon:	10000 kB
+RssFile:	 2345 kB
+RssShmem:	    0 kB
+Threads:	4
+voluntary_ctxt_switches:	99
+nonvoluntary_ctxt_switches:	7
+EOF
+cat > "$TEST_ROOT/proc-fixture/smaps_rollup" <<'EOF'
+00400000-7fffffff ---p 00000000 00:00 0 [rollup]
+Rss:               12345 kB
+Pss:               11223 kB
+EOF
+printf '100 20 10 5 0 3 0\n' > "$TEST_ROOT/proc-fixture/statm"
+printf 'Max open files            1024                 4096                 files\n' > "$TEST_ROOT/proc-fixture/limits"
+printf '0::/system.slice/wsprrypi.service\n' > "$TEST_ROOT/proc-fixture/cgroup"
+
+extract_bundle() {
+  local destination="$1"
+  rm -rf "$destination"
+  mkdir "$destination"
+  tar -xzf "$archive" -C "$destination"
+}
+
+run_process_case() {
+  local scenario="$1" main_pid="$2" active_state="$3" destination="$4"
+  rm -f "$archive" "${archive}.sha256" "$result" "$TEST_ROOT/mock-state/stat-count"
+  export MOCK_PROC_SCENARIO="$scenario" MOCK_MAIN_PID="$main_pid" MOCK_ACTIVE_STATE="$active_state"
+  export MOCK_PROC_PID="$$" MOCK_FIXTURE_DIR="$TEST_ROOT/proc-fixture" MOCK_STATE_DIR="$TEST_ROOT/mock-state"
+  run_collector "$TEST_ROOT/out" "$TEST_ROOT/mocks" "$TEST_ROOT/process-i2c.log" > "$TEST_ROOT/process-${scenario}.stdout"
+  extract_bundle "$destination"
+}
 
 # Default: no active bus scan, stable artifacts, and no work tree remains.
 : > "$TEST_ROOT/default-i2c.log"
@@ -109,6 +214,67 @@ assert_contains "$result" '"i2c_probe_status": "skipped_by_user"'
 assert_not_contains "$TEST_ROOT/default-i2c.log" '-y 1'
 assert_no_workdirs
 [[ "$(stat -c %a "$archive")" == 600 ]] || fail "archive permissions are not restrictive"
+
+# Fixed systemd MainPID discovery and fixed /proc paths produce the requested point-in-time evidence.
+run_process_case success "$$" active "$TEST_ROOT/extracted-success"
+process_dir="$TEST_ROOT/extracted-success/bundle/processes"
+for member in all-processes.txt process-tree.txt systemd-cgroups.txt wsprrypi-summary.txt wsprrypi-status.txt wsprrypi-smaps-rollup.txt wsprrypi-stat.txt wsprrypi-statm.txt wsprrypi-limits.txt wsprrypi-cgroup.txt wsprrypi-cmdline.txt; do
+  assert_file "$process_dir/$member"
+done
+assert_contains "$process_dir/wsprrypi-summary.txt" 'Collection status: collected successfully'
+assert_contains "$process_dir/wsprrypi-summary.txt" 'VmRSS: 12345 kB'
+assert_contains "$process_dir/wsprrypi-summary.txt" 'VmSize: 67890 kB'
+assert_contains "$process_dir/wsprrypi-summary.txt" 'PSS: 11223 kB'
+assert_contains "$process_dir/wsprrypi-summary.txt" 'Threads (status): 4'
+assert_contains "$process_dir/wsprrypi-summary.txt" 'Task directory count: 4'
+assert_contains "$process_dir/wsprrypi-summary.txt" 'Open file descriptor count: 5'
+assert_contains "$process_dir/wsprrypi-status.txt" $'voluntary_ctxt_switches:\t99'
+assert_contains "$process_dir/all-processes.txt" 'php /var/www/worker.php'
+assert_contains "$process_dir/process-tree.txt" 'journalctl'
+assert_contains "$process_dir/systemd-cgroups.txt" 'apache2.service'
+assert_not_contains "$process_dir/all-processes.txt" 'process-secret'
+assert_contains "$process_dir/all-processes.txt" '[REDACTED]'
+assert_not_contains "$process_dir/wsprrypi-cmdline.txt" 'cmdline-secret'
+assert_contains "$process_dir/wsprrypi-cmdline.txt" '[REDACTED]'
+! tar -tzf "$archive" | grep -Eq '/fd(/|$)' || fail 'FD inventory or targets were archived'
+
+# Stopped, zero, malformed, missing, disappearing, reused, and unreadable states remain explicit.
+run_process_case success 0 inactive "$TEST_ROOT/extracted-stopped"
+assert_contains "$TEST_ROOT/extracted-stopped/bundle/processes/wsprrypi-summary.txt" 'Collection status: service not running'
+assert_contains "$TEST_ROOT/extracted-stopped/bundle/processes/wsprrypi-summary.txt" 'PSS: unavailable'
+
+run_process_case success 0 active "$TEST_ROOT/extracted-zero"
+assert_contains "$TEST_ROOT/extracted-zero/bundle/processes/wsprrypi-summary.txt" 'Collection status: MainPID is zero; no active main process'
+
+run_process_case success '' active "$TEST_ROOT/extracted-empty"
+assert_contains "$TEST_ROOT/extracted-empty/bundle/processes/wsprrypi-summary.txt" 'Collection status: invalid or empty MainPID'
+
+run_process_case success malformed active "$TEST_ROOT/extracted-malformed"
+assert_contains "$TEST_ROOT/extracted-malformed/bundle/processes/wsprrypi-summary.txt" 'Collection status: invalid or empty MainPID'
+
+export MOCK_SYSTEMCTL_MAINPID_FAILURE=1
+run_process_case success 0 active "$TEST_ROOT/extracted-mainpid-denied"
+assert_contains "$TEST_ROOT/extracted-mainpid-denied/bundle/processes/wsprrypi-summary.txt" 'Collection status: MainPID unavailable (permission denied)'
+unset MOCK_SYSTEMCTL_MAINPID_FAILURE
+
+run_process_case success 99999999 active "$TEST_ROOT/extracted-missing"
+assert_contains "$TEST_ROOT/extracted-missing/bundle/processes/wsprrypi-summary.txt" 'Collection status: process missing before detailed collection'
+
+run_process_case disappear "$$" active "$TEST_ROOT/extracted-disappear"
+assert_contains "$TEST_ROOT/extracted-disappear/bundle/processes/wsprrypi-summary.txt" 'Collection status: process disappeared during collection'
+
+run_process_case reused "$$" active "$TEST_ROOT/extracted-reused"
+assert_contains "$TEST_ROOT/extracted-reused/bundle/processes/wsprrypi-summary.txt" 'Collection status: process identity changed; PID may have been reused'
+
+run_process_case unreadable "$$" active "$TEST_ROOT/extracted-unreadable"
+unreadable_dir="$TEST_ROOT/extracted-unreadable/bundle/processes"
+assert_contains "$unreadable_dir/wsprrypi-summary.txt" 'PSS: unavailable'
+assert_contains "$unreadable_dir/wsprrypi-summary.txt" 'Task directory count: unavailable (permission denied)'
+assert_contains "$unreadable_dir/wsprrypi-summary.txt" 'Open file descriptor count: unavailable (permission denied)'
+assert_not_contains "$unreadable_dir/wsprrypi-summary.txt" 'PSS: 0'
+assert_contains "$unreadable_dir/wsprrypi-smaps-rollup.txt" 'Collection status: permission denied'
+
+unset MOCK_PROC_SCENARIO MOCK_MAIN_PID MOCK_ACTIVE_STATE MOCK_PROC_PID MOCK_FIXTURE_DIR MOCK_STATE_DIR
 
 # The fixed opt-in probe executes exactly one allowed command and records success.
 rm -f "$archive" "${archive}.sha256" "$result"

--- a/scripts/tests/collect-support-bundle_test.sh
+++ b/scripts/tests/collect-support-bundle_test.sh
@@ -40,6 +40,14 @@ assert_no_workdirs() {
   [[ -z "$leaked" ]] || fail "collector work directory was retained: $leaked"
 }
 
+# Directory prefixes are literal paths, not shell patterns.
+literal_prefix='/tmp/project[*?]\path with spaces'
+literal_file="${literal_prefix}/nested/file.ini"
+literal_relative="${literal_file#"$literal_prefix"/}"
+[[ "$literal_relative" == 'nested/file.ini' ]] || fail "literal path prefix was treated as a pattern"
+assert_contains "$COLLECTOR" "rel=\"\${file#\"\$PROJECT_PATH\"/}\""
+assert_contains "$COLLECTOR" "rel=\"\${file#\"\$LEGACY_LOG_DIR\"/}\""
+
 make_mocks() {
   local directory="$1" probe_exit="$2"
   mkdir -p "$directory"


### PR DESCRIPTION
## Summary

- add point-in-time system process, process-tree, and cgroup snapshots to support bundles
- resolve WsprryPi through systemd `MainPID` and capture RSS, virtual size, PSS, threads/tasks, and FD count
- report stopped, unavailable, permission, disappearance, and PID-reuse states truthfully
- redact common command-line credential forms
- fix literal prefix removal flagged by ShellCheck SC2295
- document the collector behavior in `scripts/README.md`

Addresses #359.

## Validation

- `bash -n scripts/collect-support-bundle.sh`
- `bash -n scripts/tests/collect-support-bundle_test.sh`
- `shellcheck scripts/collect-support-bundle.sh scripts/tests/collect-support-bundle_test.sh`
- `bash scripts/tests/collect-support-bundle_test.sh`
- `git diff --check`

No services, installations, hardware, GPIO, real I2C, tones, transmissions, or RF paths were exercised.