### PR TITLE
Enforce conditional transmit GPIO ownership

### DIFF
--- a/release_tools/developer_notes.md
+++ b/release_tools/developer_notes.md
@@ -437,14 +437,16 @@ The installer currently manages these project packages:
 - `chrony`
 - `libgpiod-dev`
 - `libsystemd-dev`
+- `nodejs`
+- `chromium`
 
-The `semantics-test` target also requires Node.js. To install these packages
-without running the full installer:
+The `semantics-test` target requires Node.js, and browser-based UI qualification
+requires Chromium. To install all source-development packages without running
+the full installer, copy and run this complete command:
 
 ```bash
-sudo apt update
-sudo apt install -y \
-    git apache2 php chrony libgpiod-dev libsystemd-dev nodejs
+sudo apt update && sudo apt install -y \
+    git apache2 php chrony libgpiod-dev libsystemd-dev nodejs chromium
 ```
 
 This is a project dependency reference, not a guarantee that every supported

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -395,6 +395,28 @@ static bool validate_pi_io_gpio_assignments(
         reserved_assignments.push_back({candidate.amp_pin, "Amp Control"});
     }
 
+    const bool gpio_rf_output_reserved =
+        candidate.transmit_backend == TransmitBackendKind::GPIO &&
+        is_supported_transmit_gpio(candidate.gpio_tx_pin);
+
+    if (gpio_rf_output_reserved)
+    {
+        for (const ReservedAssignment &reserved : reserved_assignments)
+        {
+            if (reserved.gpio != candidate.gpio_tx_pin)
+            {
+                continue;
+            }
+
+            if (error_message != nullptr)
+            {
+                *error_message = "GPIO" + std::to_string(candidate.gpio_tx_pin) +
+                                 " is reserved by GPIO RF Output.";
+            }
+            return false;
+        }
+    }
+
     for (std::size_t i = 0; i < reserved_assignments.size(); ++i)
     {
         for (std::size_t j = i + 1; j < reserved_assignments.size(); ++j)
@@ -420,6 +442,16 @@ static bool validate_pi_io_gpio_assignments(
         if (!band_config.enabled || band_config.gpio < 0)
         {
             continue;
+        }
+
+        if (gpio_rf_output_reserved && band_config.gpio == candidate.gpio_tx_pin)
+        {
+            if (error_message != nullptr)
+            {
+                *error_message = "GPIO" + std::to_string(band_config.gpio) +
+                                 " is reserved by GPIO RF Output.";
+            }
+            return false;
         }
 
         for (const ReservedAssignment &reserved : reserved_assignments)

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -710,6 +710,154 @@ int main(int argc, char *argv[])
             validate_config_candidate(config, &validation_error),
             "disabled Pi I/O features must not reserve their retained GPIO values");
 
+        enum class OrdinaryGpioRole
+        {
+            Band,
+            Led,
+            Shutdown,
+            Amp
+        };
+        const auto assign_ordinary_gpio = [](ArgParserConfig &candidate,
+                                             OrdinaryGpioRole role,
+                                             int pin,
+                                             bool enabled) {
+            switch (role)
+            {
+                case OrdinaryGpioRole::Band:
+                    candidate.band_gpio[ham_band_index(HamBand::BAND_20M)] =
+                        BandGPIOConfig{.gpio = pin, .enabled = enabled, .active_high = true};
+                    break;
+                case OrdinaryGpioRole::Led:
+                    candidate.use_led = enabled;
+                    candidate.led_pin = pin;
+                    break;
+                case OrdinaryGpioRole::Shutdown:
+                    candidate.use_shutdown = enabled;
+                    candidate.shutdown_pin = pin;
+                    break;
+                case OrdinaryGpioRole::Amp:
+                    candidate.use_amp = enabled;
+                    candidate.amp_pin = pin;
+                    break;
+            }
+        };
+
+        for (const bool transmit : {false, true})
+        {
+            for (const int transmit_pin : {4, 20})
+            {
+                const int available_pin = transmit_pin == 4 ? 20 : 4;
+                for (const OrdinaryGpioRole role : {
+                         OrdinaryGpioRole::Band,
+                         OrdinaryGpioRole::Led,
+                         OrdinaryGpioRole::Shutdown,
+                         OrdinaryGpioRole::Amp})
+                {
+                    prime_valid_runtime_identity_config();
+                    config.transmit = transmit;
+                    config.transmit_backend = TransmitBackendKind::GPIO;
+                    config.gpio_tx_pin = transmit_pin;
+                    resolve_backend_specific_config(config);
+                    assign_ordinary_gpio(config, role, transmit_pin, true);
+                    require(
+                        !validate_config_candidate(config, &validation_error) &&
+                            validation_error ==
+                                "GPIO" + std::to_string(transmit_pin) +
+                                    " is reserved by GPIO RF Output.",
+                        "GPIO RF output must reject every enabled ordinary role on its selected pin regardless of transmit state");
+
+                    prime_valid_runtime_identity_config();
+                    config.transmit = transmit;
+                    config.transmit_backend = TransmitBackendKind::GPIO;
+                    config.gpio_tx_pin = transmit_pin;
+                    resolve_backend_specific_config(config);
+                    assign_ordinary_gpio(config, role, available_pin, true);
+                    require(
+                        validate_config_candidate(config, &validation_error),
+                        "GPIO RF output must leave the other GPCLK0-capable pin available to ordinary roles");
+
+                    prime_valid_runtime_identity_config();
+                    config.transmit = transmit;
+                    config.transmit_backend = TransmitBackendKind::GPIO;
+                    config.gpio_tx_pin = transmit_pin;
+                    resolve_backend_specific_config(config);
+                    assign_ordinary_gpio(config, role, transmit_pin, false);
+                    require(
+                        validate_config_candidate(config, &validation_error),
+                        "disabled ordinary roles may retain the selected GPIO RF output pin");
+                }
+            }
+        }
+
+        for (const int retained_transmit_pin : {4, 20})
+        {
+            for (const int ordinary_pin : {4, 20})
+            {
+                for (const OrdinaryGpioRole role : {
+                         OrdinaryGpioRole::Band,
+                         OrdinaryGpioRole::Led,
+                         OrdinaryGpioRole::Shutdown,
+                         OrdinaryGpioRole::Amp})
+                {
+                    prime_valid_runtime_identity_config();
+                    config.transmit_backend = TransmitBackendKind::SI5351;
+                    config.gpio_tx_pin = retained_transmit_pin;
+                    resolve_backend_specific_config(config);
+                    assign_ordinary_gpio(config, role, ordinary_pin, true);
+                    require(
+                        validate_config_candidate(config, &validation_error),
+                        "Si5351 backend must not reserve a retained GPIO transmit-pin value");
+                }
+            }
+        }
+
+        prime_valid_runtime_identity_config();
+        config.transmit_backend = TransmitBackendKind::GPIO;
+        config.gpio_tx_pin = 20;
+        config.use_led = true;
+        config.led_pin = 20;
+        config_to_json();
+        json_to_config();
+        require(
+            !validate_config_candidate(config, &validation_error) &&
+                validation_error == "GPIO20 is reserved by GPIO RF Output.",
+            "JSON round trips must preserve and reject a retained GPIO RF-output conflict");
+
+        auto transmit_gpio_conflict_ini =
+            make_managed_ini_data("AA0NT", "EM18", "20m", false);
+        transmit_gpio_conflict_ini["GPIO"]["Transmit Pin"] = "20";
+        transmit_gpio_conflict_ini["Operation"]["Use Shutdown"] = "true";
+        transmit_gpio_conflict_ini["Operation"]["Shutdown Button"] = "20";
+        iniFile.setData(transmit_gpio_conflict_ini);
+        PreparedConfigCandidate transmit_gpio_ini_candidate;
+        prepare_ini_config_candidate(
+            "/tmp/transmit_gpio_conflict.ini",
+            transmit_gpio_ini_candidate);
+        require(
+            !transmit_gpio_ini_candidate.valid &&
+                transmit_gpio_ini_candidate.error_reason ==
+                    "GPIO20 is reserved by GPIO RF Output.",
+            "managed INI load and reload candidates must reject GPIO RF-output conflicts when transmit is off");
+
+        prime_valid_runtime_identity_config();
+        config_to_json();
+        const nlohmann::json before_transmit_gpio_patch = jConfig;
+        bool transmit_gpio_patch_rejected = false;
+        try
+        {
+            patch_all_from_web({
+                {"Operation", {{"Use Amp", true}, {"Amp Pin", 4}}}});
+        }
+        catch (const std::exception &e)
+        {
+            transmit_gpio_patch_rejected =
+                std::string(e.what()).find(
+                    "GPIO4 is reserved by GPIO RF Output.") != std::string::npos;
+        }
+        require(
+            transmit_gpio_patch_rejected && jConfig == before_transmit_gpio_patch,
+            "REST/web patches must reject GPIO RF-output conflicts without changing configuration");
+
         config.use_led = true;
         config.led_pin = 6;
         config.use_shutdown = true;

--- a/src/tests/guarded_mode_change_persistence_test.cpp
+++ b/src/tests/guarded_mode_change_persistence_test.cpp
@@ -80,7 +80,20 @@ int main()
         "guarded mode-change stop must not publish an extra persistence generation");
 
     patch_all_from_web({
-        {"Operation", {{"Mode", "QRSS"}, {"Transmit", false}}}
+        {"Operation", {{"Mode", "QRSS"}, {"Transmit", false}}},
+        {"CW",
+         {{"Message", "CQ"},
+          {"Base Frequency", 14096900.0},
+          {"Shift Hz", 5.0},
+          {"Dot Seconds", 3.0},
+          {"Intra Element Gap", 1.0},
+          {"Inter Character Gap", 3.0},
+          {"Inter Word Gap", 7.0},
+          {"DFCW Intra Element Gap", 0.333333},
+          {"DFCW Inter Character Gap", 1.0},
+          {"DFCW Inter Word Gap", 3.0},
+          {"Start Minute", 0},
+          {"Repeat Minutes", 10}}}
     });
 
     const std::string ini_after_guard = read_text_file(config.ini_filename);
@@ -95,6 +108,11 @@ int main()
         iniFile.getData().at("Operation").at("Mode") == "QRSS" &&
             iniFile.getData().at("Operation").at("Transmit") == "false",
         "guarded mode-change final save must persist the final mode and disabled transmit state");
+
+    config.qrss.message.clear();
+    config.fskcw.message.clear();
+    config.dfcw.message.clear();
+    config_to_json();
 
     bool transmit_enable_rejected = false;
     try

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -119,6 +119,8 @@ int main()
         read_text_file("/home/pi/WsprryPi/src/main.cpp");
     const std::string config_view_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/views/config.php");
+    const std::string gpio_dropdown_source =
+        read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/gpio_dropdown.php");
     const std::string cw_timing_source =
         read_text_file("/home/pi/WsprryPi/WsprryPi-UI/data/cw_timing_state.js");
     const std::string maintenance_script_source =
@@ -140,11 +142,20 @@ int main()
     require(
         ui_source.find("if (!valid && reservedAssignment.field) {") !=
                 std::string::npos &&
-            ui_source.find("setFieldValidationState(reservedAssignment.field, false);") !=
+            ui_source.find("setPinDropdownValidationState(reservedAssignment.field, message);") !=
                 std::string::npos &&
             ui_stylesheet_source.find(".pin-dropdown-btn.is-invalid") !=
                 std::string::npos,
         "Band GPIO conflicts with enabled reserved controls must mark both affected fields invalid");
+    require(
+        gpio_dropdown_source.find("4 => 'Pin 7'") != std::string::npos &&
+            ui_source.find("function getReservedGpioRfOutputPin()") != std::string::npos &&
+            ui_source.find("is reserved by GPIO RF Output.") != std::string::npos &&
+            ui_source.find("function refreshTransmitGpioOptions()") != std::string::npos &&
+            ui_source.find("function setGpioConflictFieldState(field, message)") != std::string::npos &&
+            config_view_source.find("id=\"tx-pin-error\"") != std::string::npos &&
+            config_view_source.find("band-gpio-gpio-") != std::string::npos,
+        "conditional GPIO RF ownership must expose GPIO4, filter both selection directions, and render accessible inline conflict feedback");
     require(
         cw_message_input.find("type=\"text\"") != std::string::npos &&
             cw_message_input.find("step=") == std::string::npos,


### PR DESCRIPTION
Centralizes GPIO RF-output ownership validation across startup, JSON, managed INI reload, REST/web patches, and repair/restore reload paths. The selected GPIO backend pin is reserved independently of Operation.Transmit; Si5351 reserves neither retained pin. Includes the UI submodule update, complete ownership-matrix regression coverage, the guarded-mode fixture repair, and Chromium as a documented development dependency.\n\nReferences #365.\n\nUI: WsprryPi/WsprryPi-UI#25