### PR TITLE
Restore inactive mode after Test Tone

### DIFF
--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -156,6 +156,7 @@ static void commit_band_gpio_snapshot_to_request(
 static void commit_execution_request(
     const wsprrypi::TransmissionRequest &controller_request,
     const TransmissionRequest &legacy_request);
+static void clear_committed_execution_request() noexcept;
 static bool refresh_committed_band_gpio_selection() noexcept;
 static void assert_transmit_gpio_outputs(const char *context) noexcept;
 static void deassert_transmit_gpio_outputs(
@@ -275,6 +276,17 @@ std::atomic<bool> shutdown_flag{false};
  * test tone mode so that the original mode can be restored later.
  */
 ModeType lastMode;
+
+enum class TestToneRestorationOwner
+{
+    Unknown,
+    WsprScheduler,
+    DirectToneStartup,
+    ManagedIdleNonWspr,
+};
+
+TestToneRestorationOwner test_tone_restoration_owner =
+    TestToneRestorationOwner::Unknown;
 
 /**
  * @brief Flag indicating if a web-triggered test tone is active.
@@ -1161,6 +1173,22 @@ static void commit_execution_request(
     }
 
     wsprTransmitter.configureExecution(controller_request, current_transmission_request);
+}
+
+/**
+ * @brief Clear scheduler-owned execution snapshots after a completed stop.
+ *
+ * The transmitter owns a separate execution snapshot.  It is cleared by
+ * WsprTransmitter::clearExecutionStateAfterStop(); the scheduler must also
+ * discard its committed request so a completed transient Test Tone cannot be
+ * reported or reused as live work.
+ */
+static void clear_committed_execution_request() noexcept
+{
+    current_transmission_request = TransmissionRequest{};
+    current_controller_request_for_test_storage.reset();
+    committed_execution_route_for_test_storage =
+        CommittedExecutionRouteForTest::NONE;
 }
 
 static bool resolve_qrss_runtime_request(
@@ -3448,10 +3476,35 @@ TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
         explicit_selector_plan = selector_plan.plan;
     }
 
+    // Capture restoration ownership before Test Tone changes config.mode.  A
+    // managed, transmit-disabled non-WSPR mode is idle configuration, not a
+    // transient direct-tone startup request.
+    TestToneRestorationOwner restoration_owner = TestToneRestorationOwner::Unknown;
+    if (config.mode == ModeType::WSPR)
+    {
+        restoration_owner = TestToneRestorationOwner::WsprScheduler;
+    }
+    else
+    {
+        WsprFrequencyEntry startup_entry;
+        double startup_rf_frequency_hz = 0.0;
+        if (try_get_direct_tone_startup_request(startup_entry, startup_rf_frequency_hz))
+        {
+            restoration_owner = TestToneRestorationOwner::DirectToneStartup;
+        }
+        else if (config.use_ini && !runtime_transmit_enabled(config) &&
+                 (config.mode == ModeType::FSKCW || config.mode == ModeType::QRSS ||
+                  config.mode == ModeType::DFCW))
+        {
+            restoration_owner = TestToneRestorationOwner::ManagedIdleNonWspr;
+        }
+    }
+
     web_test_tone.store(true);
 
     // Save previous mode so we can restore it later.
     lastMode = config.mode;
+    test_tone_restoration_owner = restoration_owner;
 
     wsprTransmitter.stopAndJoin();
 
@@ -3544,6 +3597,7 @@ TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
     {
         web_test_tone.store(false);
         config.mode = lastMode;
+        test_tone_restoration_owner = TestToneRestorationOwner::Unknown;
         result.message = "Unable to prepare the requested band selector.";
         return result;
     }
@@ -3609,6 +3663,7 @@ TestToneStopResult end_test_tone()
         "test tone stop",
         true,
         true);
+    clear_committed_execution_request();
     llog.logS(
         DEBUG,
         "Post-test-tone stop transmitter snapshot: ",
@@ -3618,11 +3673,18 @@ TestToneStopResult end_test_tone()
     const bool deferred_reload_pending =
         ini_reload_pending.load(std::memory_order_acquire);
 
+    const TestToneRestorationOwner restoration_owner = test_tone_restoration_owner;
+    test_tone_restoration_owner = TestToneRestorationOwner::Unknown;
     web_test_tone.store(false);
     config.mode = lastMode;
 
-    if (config.mode == ModeType::WSPR)
+    if (restoration_owner == TestToneRestorationOwner::WsprScheduler)
     {
+        if (config.mode != ModeType::WSPR)
+        {
+            result.message = "Inconsistent Test Tone scheduler restoration state.";
+            return result;
+        }
         if (!set_config(true))
         {
             result.message = "Unable to restore scheduler state after test tone stop.";
@@ -3644,6 +3706,27 @@ TestToneStopResult end_test_tone()
             deferred_reload_pending &&
             !ini_reload_pending.load(std::memory_order_acquire);
         result.message = "Test tone stopped and scheduler restored.";
+        return result;
+    }
+
+    if (restoration_owner == TestToneRestorationOwner::ManagedIdleNonWspr)
+    {
+        if (!(config.use_ini && !runtime_transmit_enabled(config) &&
+              (config.mode == ModeType::FSKCW || config.mode == ModeType::QRSS ||
+               config.mode == ModeType::DFCW)))
+        {
+            result.message = "Inconsistent managed Test Tone restoration state.";
+            return result;
+        }
+
+        result.stopped = true;
+        result.message = "Test tone stopped; managed mode restored inactive.";
+        return result;
+    }
+
+    if (restoration_owner != TestToneRestorationOwner::DirectToneStartup)
+    {
+        result.message = "Unknown Test Tone restoration state after safe cleanup.";
         return result;
     }
 

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -6170,7 +6170,9 @@ int main(int argc, char *argv[])
                 "explicit 20m tone must commit canonical dial plus offset once");
         require(!request.selector_gpio_enabled,
                 "different-band first-entry selector must not be inherited");
-        end_test_tone();
+        const TestToneStopResult stopped = end_test_tone();
+        require(stopped.tone_was_active && stopped.stopped,
+                "explicit 20m Test Tone End must succeed");
         set_scheduler_execution_suppressed_for_test(false);
     }
 
@@ -6189,7 +6191,9 @@ int main(int argc, char *argv[])
         require(started.started && nearly_equal(request.dial_frequency_hz, 13551500.0) &&
                     nearly_equal(request.actual_rf_frequency_hz, 13553000.0),
                 "explicit 22m tone must commit canonical dial plus 1500 Hz offset");
-        end_test_tone();
+        const TestToneStopResult stopped = end_test_tone();
+        require(stopped.tone_was_active && stopped.stopped,
+                "explicit 22m Test Tone End must succeed");
         set_scheduler_execution_suppressed_for_test(false);
     }
 
@@ -6212,7 +6216,9 @@ int main(int argc, char *argv[])
                     nearly_equal(request.applied_offset_hz, 2750.0) &&
                     started.audio_offset_hz == 2750U,
                 "one published snapshot must supply explicit RF and committed offset metadata");
-        end_test_tone();
+        const TestToneStopResult stopped = end_test_tone();
+        require(stopped.tone_was_active && stopped.stopped,
+                "snapshot-backed explicit Test Tone End must succeed");
         set_scheduler_execution_suppressed_for_test(false);
     }
 
@@ -6233,7 +6239,9 @@ int main(int argc, char *argv[])
                     nearly_equal(request.dial_frequency_hz, static_cast<double>(custom_rf_hz)) &&
                     started.band == "20m",
                 "explicit custom RF must remain exact and resolve 20m without a WSPR offset");
-        end_test_tone();
+        const TestToneStopResult stopped = end_test_tone();
+        require(stopped.tone_was_active && stopped.stopped,
+                "explicit custom-RF Test Tone End must succeed");
         set_scheduler_execution_suppressed_for_test(false);
     }
 
@@ -6254,7 +6262,9 @@ int main(int argc, char *argv[])
                     !started.selector_gpio_active_high &&
                     request.selector_band == HamBand::BAND_20M,
                 "matching same-band active-low selector metadata must match the committed RF-band request");
-        end_test_tone();
+        const TestToneStopResult stopped = end_test_tone();
+        require(stopped.tone_was_active && stopped.stopped,
+                "selector-backed explicit Test Tone End must succeed");
         set_scheduler_execution_suppressed_for_test(false);
     }
 
@@ -6278,7 +6288,9 @@ int main(int argc, char *argv[])
                     started.selector_gpio_active_high &&
                     request.selector_band == HamBand::BAND_20M,
                 "active-high metadata must come from the committed selected-band fallback, not a different-band selector");
-        end_test_tone();
+        const TestToneStopResult stopped = end_test_tone();
+        require(stopped.tone_was_active && stopped.stopped,
+                "fallback-selector explicit Test Tone End must succeed");
         set_scheduler_execution_suppressed_for_test(false);
     }
 
@@ -6296,7 +6308,9 @@ int main(int argc, char *argv[])
         require(started.started && !request.selector_gpio_enabled &&
                     !started.selector_gpio_active_high,
                 "selector-disabled Test Tone metadata must remain neutral");
-        end_test_tone();
+        const TestToneStopResult stopped = end_test_tone();
+        require(stopped.tone_was_active && stopped.stopped,
+                "selector-disabled explicit Test Tone End must succeed");
         set_scheduler_execution_suppressed_for_test(false);
     }
 
@@ -6397,6 +6411,132 @@ int main(int argc, char *argv[])
                 "explicit custom-RF request must reject before planning, selector preparation, Test Tone activation, or request mutation while schedule is enabled");
 
         wsprTransmitter.backendSetStateValue(WsprTransmitter::State::DISABLED);
+        set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    // Managed INI CW modes are idle owners, never implicit CLI direct tones.
+    const std::array<std::pair<ModeType, TestToneRequest>, 5> managed_idle_cases{{
+        {ModeType::FSKCW, {TestToneFrequencySource::WsprBand, "20m", std::nullopt}},
+        {ModeType::FSKCW, {TestToneFrequencySource::CustomRf, "", 14097123U}},
+        {ModeType::QRSS, {TestToneFrequencySource::WsprBand, "20m", std::nullopt}},
+        {ModeType::DFCW, {TestToneFrequencySource::WsprBand, "20m", std::nullopt}},
+        {ModeType::FSKCW, {TestToneFrequencySource::LegacyExactRf, "", 14097123U}},
+    }};
+    for (const auto &[prior_mode, request] : managed_idle_cases)
+    {
+        init_default_config();
+        clear_direct_tone_startup_request();
+        reset_current_transmission_request_for_test();
+        reset_committed_execution_route_for_test();
+        reset_band_gpio_prepare_call_count_for_test();
+        set_scheduler_execution_suppressed_for_test(true);
+        config.use_ini = true;
+        config.transmit = false;
+        config.mode = prior_mode;
+        config.frequencies = "20m";
+        config.wspr.audio_offset_hz = 1500.0;
+        set_frequencies(config);
+        copy_runtime_config(config, config);
+        const WsprTransmitter::State state_before_start =
+            wsprTransmitter.getState();
+        const TestToneStartResult start = start_test_tone(request);
+        const WsprTransmitter::State state_after_suppressed_start =
+            wsprTransmitter.getState();
+        const TransmissionRequest committed = current_transmission_request_for_test();
+        const TestToneStopResult stop = end_test_tone();
+        const TransmissionRequest cleared = current_transmission_request_for_test();
+        const std::size_t prepares = band_gpio_prepare_call_count_for_test();
+        BandGPIOConfig selector_config;
+        std::string selector_band;
+        const bool selector_active = current_band_gpio_selection_for_test(
+            selector_config,
+            selector_band);
+        const ModeType mode_after_first_end = config.mode;
+        const WsprTransmitter::State state_after_first_end =
+            wsprTransmitter.getState();
+        const bool direct_tone_after_first_end =
+            has_direct_tone_startup_request();
+        const TestToneStopResult repeated = end_test_tone();
+        require(start.started && committed.mode == TransmissionMode::TONE,
+                "managed idle non-WSPR Test Tone must start and commit a tone request");
+        require(state_before_start == WsprTransmitter::State::DISABLED &&
+                    state_after_suppressed_start == WsprTransmitter::State::DISABLED,
+                "suppressed managed idle Test Tone setup must leave the transmitter disabled before End cleanup");
+        require(stop.tone_was_active && stop.stopped,
+                "managed idle non-WSPR Test Tone End must report a successful active stop");
+        require(config.mode == prior_mode && !config.transmit,
+                "managed idle non-WSPR Test Tone End must restore the inactive managed mode");
+        require(state_after_first_end == WsprTransmitter::State::DISABLED,
+                "managed idle non-WSPR Test Tone End must leave the transmitter disabled");
+        require(cleared.actual_rf_frequency_hz == 0.0,
+                "managed idle non-WSPR Test Tone End must clear committed execution state");
+        require(!selector_active && prepares <= 1U,
+                "managed idle non-WSPR Test Tone must leave the disabled selector neutral without a restart");
+        require(!direct_tone_after_first_end,
+                "managed idle non-WSPR Test Tone must not create or consume a direct-tone startup request");
+        require(!repeated.tone_was_active && !repeated.stopped &&
+                    config.mode == mode_after_first_end &&
+                    wsprTransmitter.getState() == state_after_first_end &&
+                    current_transmission_request_for_test().actual_rf_frequency_hz == 0.0 &&
+                    band_gpio_prepare_call_count_for_test() == prepares &&
+                    has_direct_tone_startup_request() == direct_tone_after_first_end,
+                "managed idle non-WSPR Test Tone repeated End must remain inert");
+        if (request.source == TestToneFrequencySource::WsprBand)
+            require(nearly_equal(committed.dial_frequency_hz, 14095600.0) &&
+                        nearly_equal(committed.actual_rf_frequency_hz, 14097100.0),
+                    "managed explicit 20m Test Tone must use dial plus 1500 Hz once");
+        if (request.source == TestToneFrequencySource::CustomRf ||
+            request.source == TestToneFrequencySource::LegacyExactRf)
+            require(nearly_equal(committed.actual_rf_frequency_hz, 14097123.0),
+                    "managed exact-RF Test Tone must not apply WSPR offset");
+        clear_direct_tone_startup_request();
+        set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    {
+        init_default_config();
+        clear_direct_tone_startup_request();
+        reset_current_transmission_request_for_test();
+        reset_committed_execution_route_for_test();
+        set_scheduler_execution_suppressed_for_test(true);
+        config.use_ini = false;
+        config.transmit = true;
+        config.mode = ModeType::TONE;
+        require(set_direct_tone_startup_request("730000"),
+                "CLI direct-tone restoration setup must create the production startup request");
+        set_startup_quiesce_invoker_for_test(
+            []()
+            {
+                return wsprrypi::StartupQuiesceResult{
+                    false,
+                    "direct-tone restoration regression inhibition"};
+            });
+        require(!run_startup_quiesce_gate_for_test(config) &&
+                    startup_quiesce_inhibited_for_test(),
+                "CLI direct-tone restoration setup must use the production startup inhibition path");
+        copy_runtime_config(config, config);
+
+        const TestToneStartResult start = start_test_tone(
+            TestToneRequest{TestToneFrequencySource::WsprBand, "20m", std::nullopt});
+        require(start.started,
+                "CLI direct-tone restoration regression must begin the web Test Tone");
+        reset_startup_quiesce_for_test();
+        const TestToneStopResult stop = end_test_tone();
+        const TransmissionRequest restored = current_transmission_request_for_test();
+        WsprFrequencyEntry startup_entry;
+        double startup_rf_hz = 0.0;
+        const bool startup_request_preserved =
+            try_get_direct_tone_startup_request(startup_entry, startup_rf_hz);
+
+        require(start.started && stop.tone_was_active && stop.stopped &&
+                    config.mode == ModeType::TONE &&
+                    startup_request_preserved && nearly_equal(startup_rf_hz, 730000.0) &&
+                    restored.mode == TransmissionMode::TONE &&
+                    nearly_equal(restored.actual_rf_frequency_hz, 730000.0),
+                "a genuine CLI direct-tone startup request must restore through the direct-tone path");
+        clear_direct_tone_startup_request();
+        reset_startup_quiesce_for_test();
+        reset_current_transmission_request_for_test();
         set_scheduler_execution_suppressed_for_test(false);
     }
 


### PR DESCRIPTION
## Summary

- distinguish WSPR scheduler, transient CLI direct-tone, and managed inactive non-WSPR restoration ownership
- clear scheduler-owned committed Test Tone state after transmitter and GPIO cleanup
- restore disabled managed FSKCW, QRSS, and DFCW modes without requiring a CLI direct-tone request
- preserve existing WSPR scheduler and genuine CLI direct-tone restoration
- add deterministic managed-idle, repeated-End, explicit-source, selector, and direct-tone regression coverage

## Validation

- `make -B -j1 build/bin/wspr_band_catalog_test`
- `./build/bin/wspr_band_catalog_test`
- `make -j3 build/bin/dial_frequency_semantics_test`
- `./build/bin/dial_frequency_semantics_test`
- `make -j3 wspr-tone-regression-test`
- `make -j3 test-tone-request-test`
- `make -j3 test-tone-frequency-plan-test`
- `make -j3 test-tone-selector-plan-test`
- `make -j3 test-tone-response-test`
- `make -j3 build/bin/ui_source_regression_test`
- `./build/bin/ui_source_regression_test`
- `git diff --check`

Related to #361.