### PR TITLE
Integrate responsive WSPR transmission plan layout

### DIFF
--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -1315,6 +1315,12 @@ int main()
             config_view_source.find("class=\"form-select config-planner-field__select\"") == std::string::npos,
         "WSPR transmission settings must keep TX dBm as a fixed-value select and expose planner_preference in the WSPR planning controls");
     require(
+        ui_stylesheet_source.find("@media (max-width: 991.98px) {\n    .config-wspr-top-row,\n    .config-wspr-secondary-row {\n        grid-template-columns: minmax(0, 1fr);") != std::string::npos &&
+            ui_stylesheet_source.find(".config-wspr-top-row .form-label,\n    .config-wspr-secondary-row .form-label {\n        white-space: normal;") != std::string::npos &&
+            ui_stylesheet_source.find(".config-wspr-top-row__field--toggle {\n        min-height: 0;") != std::string::npos &&
+            ui_stylesheet_source.find(".config-wspr-top-row__toggle") == std::string::npos,
+        "WSPR transmission-plan rows must stack in one column with wrap-safe labels at the established narrow breakpoint");
+    require(
         config_view_source.find("id=\"fsk_offset\"") != std::string::npos &&
             config_view_source.find("value=\"5\"") != std::string::npos &&
             config_view_source.find("id=\"dot_length\"") != std::string::npos &&


### PR DESCRIPTION
## Summary

- update `WsprryPi-UI` to the responsive WSPR layout from WsprryPi/WsprryPi-UI#27
- add focused source-regression coverage for the 991.98px single-column breakpoint
- verify wrap-safe labels and the corrected toggle selector

## Impact

The Setup → WSPR transmission-plan panel remains three columns on desktop and becomes a legible single-column form at tablet, portrait, and narrow widths. Configuration behavior and WSPR transmission semantics are unchanged.

## Validation

- `make semantics-test`
- `make build/bin/ui_source_regression_test`
- `./build/bin/ui_source_regression_test`
- `git diff --check` in both repositories
- live visual qualification at 768px, 1024px, 1440px, and effective 200% zoom

Related to #367.