### PR TITLE
Serialize Test Tone lifecycle commands

### DIFF
--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -69,6 +69,8 @@ int main()
 {
     const std::string websocket_source =
         read_text_file("/home/pi/WsprryPi/src/web_socket.cpp");
+    const std::string websocket_header_source =
+        read_text_file("/home/pi/WsprryPi/src/web_socket.hpp");
     const std::string web_server_source =
         read_text_file("/home/pi/WsprryPi/src/web_server.cpp");
     const std::string makefile_source =
@@ -84,6 +86,14 @@ int main()
             websocket_source.find("stop_transmission_by_user_request(persist_transmit);") !=
                 std::string::npos,
         "websocket stop command must route through stop_transmission_by_user_request() with persistence control");
+    require(
+        websocket_header_source.find("std::mutex test_tone_command_mutex_;") !=
+                std::string::npos &&
+            websocket_source.find("if (cmd == \"tone_start\" || cmd == \"tone_end\")") !=
+                std::string::npos &&
+            websocket_source.find("std::unique_lock<std::mutex>(test_tone_command_mutex_)") !=
+                std::string::npos,
+        "websocket Test Tone Start and End commands must share one transaction lock through their broadcast reply");
 
     const std::string scheduling_source =
         read_text_file("/home/pi/WsprryPi/src/scheduling.cpp");

--- a/src/tests/websocket_lifecycle_test.cpp
+++ b/src/tests/websocket_lifecycle_test.cpp
@@ -26,9 +26,35 @@ class WebSocketLifecycleTest {
         std::unique_lock<std::mutex> l(s.clients_mutex_);
         return s.client_handlers_cv_.wait_for(l,std::chrono::seconds(2),[&]{return !s.handshaking_sockets_.empty();});
     }
+    static void verify_test_tone_transaction_lock(WebSocketServer &s) {
+        std::mutex state_mutex;
+        std::condition_variable state_cv;
+        bool holder_acquired=false;
+        bool release_holder=false;
+        std::thread holder([&]{
+            std::unique_lock<std::mutex> transaction(s.test_tone_command_mutex_);
+            std::unique_lock<std::mutex> state(state_mutex);
+            holder_acquired=true;
+            state_cv.notify_all();
+            state_cv.wait(state,[&]{return release_holder;});
+        });
+        {
+            std::unique_lock<std::mutex> state(state_mutex);
+            assert(state_cv.wait_for(state,std::chrono::seconds(2),[&]{return holder_acquired;}));
+        }
+        assert(!s.test_tone_command_mutex_.try_lock());
+        {
+            std::lock_guard<std::mutex> state(state_mutex);
+            release_holder=true;
+        }
+        state_cv.notify_all();
+        holder.join();
+        assert(s.test_tone_command_mutex_.try_lock());
+        s.test_tone_command_mutex_.unlock();
+    }
 public:
     static int run() {
-        WebSocketServer s; const unsigned short p=39519; assert(s.start(p,0));
+        WebSocketServer s; verify_test_tone_transaction_lock(s); const unsigned short p=39519; assert(s.start(p,0));
         int raw=socket(AF_INET,SOCK_STREAM,0); assert(raw>=0); sockaddr_in a{}; a.sin_family=AF_INET; a.sin_port=htons(p); inet_pton(AF_INET,"127.0.0.1",&a.sin_addr); assert(connect(raw,reinterpret_cast<sockaddr*>(&a),sizeof(a))==0);
         assert(wait_handshake(s)); std::thread incomplete_stopper([&]{s.stop();}); incomplete_stopper.join(); close(raw);
         assert(s.active_client_handlers_==0 && s.client_sockets_.empty());

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -333,6 +333,7 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
 {
     using json = nlohmann::json;
     json reply;
+    std::unique_lock<std::mutex> test_tone_command_lock;
 
     try
     {
@@ -342,6 +343,15 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
         // Extract "command" (defaults to empty string if missing), lowercase it
         std::string cmd = j.value("command", "");
         std::transform(cmd.begin(), cmd.end(), cmd.begin(), ::tolower);
+
+        if (cmd == "tone_start" || cmd == "tone_end")
+        {
+            // Multiple clients have independent handler threads. Keep each
+            // Test Tone lifecycle operation and its broadcast reply in one
+            // transaction so Start and End cannot race or report out of order.
+            test_tone_command_lock =
+                std::unique_lock<std::mutex>(test_tone_command_mutex_);
+        }
 
         if (cmd == "shutdown")
         {

--- a/src/web_socket.hpp
+++ b/src/web_socket.hpp
@@ -135,6 +135,7 @@ private:
     bool client_registration_closed_{false};
     std::condition_variable client_handlers_cv_;
     std::mutex stop_mutex_;
+    std::mutex test_tone_command_mutex_;
 
     std::condition_variable keep_alive_cv_; ///< Conditional to break from loop
     std::mutex keep_alive_mutex_;           ///< Mutex to control loop break


### PR DESCRIPTION
## Summary

- serialize Test Tone Start and End operations across WebSocket client handler threads
- keep each lifecycle operation locked through its broadcast response so results cannot be reordered
- add focused lifecycle and source-regression coverage
- pin the merged UI correction from WsprryPi/WsprryPi-UI#29

## Root cause

Separate WebSocket client handler threads could enter Test Tone scheduler operations concurrently and broadcast their results out of order.

## Validation

- `make -j3 build/bin/websocket_lifecycle_test build/bin/ui_source_regression_test`
- `./build/bin/websocket_lifecycle_test`
- `./build/bin/ui_source_regression_test`
- UI JavaScript regression suite
- desktop and 390 px browser review
- `git diff --check` in both repositories

Related to #361.