### PR TITLE
Contain test-tone configuration failures

### DIFF
--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -299,6 +299,7 @@ std::atomic<bool> shutdown_after_current_transmission{false};
 std::atomic<bool> shutdown_after_wspr_plan{false};
 static bool managed_reload_tx_inhibited = false;
 static bool suppress_scheduler_execution_for_test = false;
+static TestToneCommitInvokerForTest test_tone_commit_invoker_for_test{};
 static std::atomic<std::uint64_t> non_wspr_schedule_generation{0};
 
 std::uint64_t non_wspr_schedule_generation_for_test() noexcept
@@ -1106,6 +1107,11 @@ static void commit_execution_request(
         current_controller_request_for_test_storage = controller_request;
         committed_execution_route_for_test_storage =
             CommittedExecutionRouteForTest::CONTROLLER_TONE;
+
+        if (test_tone_commit_invoker_for_test)
+        {
+            test_tone_commit_invoker_for_test();
+        }
 
         if (suppress_scheduler_execution_for_test)
         {
@@ -3407,6 +3413,44 @@ void reboot_system()
  * frequency and does not receive WSPR dial-frequency offset. Tone mode here is
  * runtime-only behavior.
  */
+static void rollback_failed_test_tone_start(ModeType previous_mode) noexcept
+{
+    try
+    {
+        wsprTransmitter.stopAndJoin();
+        wsprTransmitter.clearExecutionStateAfterStop();
+        finalize_transmission_stop_cleanup(
+            &config,
+            false,
+            "test tone start rejection",
+            true,
+            true);
+    }
+    catch (const std::exception &error)
+    {
+        llog.logE(
+            ERROR,
+            "Test tone rejection cleanup failed: " +
+                std::string(error.what()));
+    }
+    catch (...)
+    {
+        llog.logE(ERROR, "Test tone rejection cleanup failed.");
+    }
+
+    (void)reconcile_tx_led_after_transmitter_stop(
+        "test tone start rejection");
+    current_transmission_request = TransmissionRequest{};
+    current_controller_request_for_test_storage.reset();
+    committed_execution_route_for_test_storage =
+        CommittedExecutionRouteForTest::NONE;
+    current_dial_frequency = 0.0;
+    current_frequency_entry = WsprFrequencyEntry{};
+    web_test_tone.store(false);
+    config.mode = previous_mode;
+    test_tone_restoration_owner = TestToneRestorationOwner::Unknown;
+}
+
 TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
 {
     TestToneStartResult result;
@@ -3506,6 +3550,8 @@ TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
     lastMode = config.mode;
     test_tone_restoration_owner = restoration_owner;
 
+    try
+    {
     wsprTransmitter.stopAndJoin();
 
     ArgParserConfig selector_preparation_cfg;
@@ -3623,6 +3669,28 @@ TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
     result.started = true;
     result.message = "Test tone started.";
     return result;
+    }
+    catch (const std::exception &error)
+    {
+        const std::string detail = error.what();
+        llog.logE(
+            ERROR,
+            "Test tone start rejected during configuration: " + detail);
+        rollback_failed_test_tone_start(lastMode);
+        result.message = detail.empty()
+            ? "Unable to configure the requested test tone."
+            : detail;
+        return result;
+    }
+    catch (...)
+    {
+        llog.logE(
+            ERROR,
+            "Test tone start rejected by an unknown configuration error.");
+        rollback_failed_test_tone_start(lastMode);
+        result.message = "Unable to configure the requested test tone.";
+        return result;
+    }
 }
 
 TestToneStartResult start_test_tone(
@@ -5700,6 +5768,17 @@ void reset_current_transmission_request_for_test() noexcept
 void reset_current_controller_request_for_test() noexcept
 {
     current_controller_request_for_test_storage.reset();
+}
+
+void set_test_tone_commit_invoker_for_test(
+    TestToneCommitInvokerForTest invoker)
+{
+    test_tone_commit_invoker_for_test = std::move(invoker);
+}
+
+void reset_test_tone_commit_invoker_for_test() noexcept
+{
+    test_tone_commit_invoker_for_test = {};
 }
 
 void set_startup_quiesce_invoker_for_test(StartupQuiesceInvokerForTest invoker)

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -422,6 +422,9 @@ void set_current_transmission_request_for_test(
 std::optional<wsprrypi::TransmissionRequest> current_controller_request_for_test();
 void reset_current_transmission_request_for_test() noexcept;
 void reset_current_controller_request_for_test() noexcept;
+using TestToneCommitInvokerForTest = std::function<void()>;
+void set_test_tone_commit_invoker_for_test(TestToneCommitInvokerForTest invoker);
+void reset_test_tone_commit_invoker_for_test() noexcept;
 
 using StartupQuiesceInvokerForTest =
     std::function<wsprrypi::StartupQuiesceResult()>;

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -6414,6 +6414,47 @@ int main(int argc, char *argv[])
         set_scheduler_execution_suppressed_for_test(false);
     }
 
+    {
+        init_default_config();
+        reset_current_transmission_request_for_test();
+        reset_current_controller_request_for_test();
+        reset_committed_execution_route_for_test();
+        reset_tx_led_request_counts_for_test();
+        set_scheduler_execution_suppressed_for_test(false);
+        config.mode = ModeType::QRSS;
+        config.transmit = false;
+        config.transmit_backend = TransmitBackendKind::SI5351;
+        config.frequencies = "20m";
+        set_frequencies(config);
+        wsprTransmitter.backendSetStateValue(WsprTransmitter::State::DISABLED);
+        set_test_tone_commit_invoker_for_test([] {
+            throw std::runtime_error(
+                "Si5351 planner produced unusable frequency data for tone 0.");
+        });
+
+        const TestToneStartResult rejected = start_test_tone(
+            TestToneRequest{
+                TestToneFrequencySource::CustomRf,
+                "",
+                144490500U});
+        reset_test_tone_commit_invoker_for_test();
+        const TestToneStopResult inactive_stop = end_test_tone();
+
+        require(
+            !rejected.started &&
+                rejected.message.find("Si5351 planner produced unusable") !=
+                    std::string::npos &&
+                config.mode == ModeType::QRSS &&
+                !inactive_stop.tone_was_active &&
+                current_transmission_request_for_test().actual_rf_frequency_hz == 0.0 &&
+                !current_controller_request_for_test().has_value() &&
+                committed_execution_route_for_test() ==
+                    CommittedExecutionRouteForTest::NONE &&
+                wsprTransmitter.getState() == WsprTransmitter::State::DISABLED &&
+                !tx_led_active_for_test(),
+            "synchronous test tone configuration failure must reject with its diagnostic and restore inactive runtime state");
+    }
+
     // Managed INI CW modes are idle owners, never implicit CLI direct tones.
     const std::array<std::pair<ModeType, TestToneRequest>, 5> managed_idle_cases{{
         {ModeType::FSKCW, {TestToneFrequencySource::WsprBand, "20m", std::nullopt}},

--- a/src/tests/websocket_lifecycle_test.cpp
+++ b/src/tests/websocket_lifecycle_test.cpp
@@ -11,6 +11,16 @@
 #include <unistd.h>
 
 class WebSocketLifecycleTest {
+    static void send_text(int fd, const std::string &text) {
+        assert(text.size() < 126U);
+        std::string frame;
+        frame.push_back(static_cast<char>(0x81));
+        frame.push_back(static_cast<char>(0x80U | text.size()));
+        const unsigned char mask[4]={1,2,3,4};
+        frame.append(reinterpret_cast<const char *>(mask),4);
+        for(std::size_t i=0;i<text.size();++i) frame.push_back(static_cast<char>(text[i]^mask[i%4]));
+        assert(send(fd,frame.data(),frame.size(),0)==static_cast<ssize_t>(frame.size()));
+    }
     static int connect_client(unsigned short port) {
         int fd=socket(AF_INET,SOCK_STREAM,0); assert(fd>=0);
         sockaddr_in a{}; a.sin_family=AF_INET; a.sin_port=htons(port); inet_pton(AF_INET,"127.0.0.1",&a.sin_addr);
@@ -59,6 +69,8 @@ public:
         assert(wait_handshake(s)); std::thread incomplete_stopper([&]{s.stop();}); incomplete_stopper.join(); close(raw);
         assert(s.active_client_handlers_==0 && s.client_sockets_.empty());
         assert(s.start(p,0));
+        int invalid=connect_client(p); send_text(invalid,"{\"command\":42}"); char response[512]{}; auto response_size=recv(invalid,response,sizeof(response),0); assert(response_size>0); assert(std::string(response,response_size).find("command failure")!=std::string::npos); close(invalid); assert(wait_zero(s));
+        int survivor=connect_client(p); close(survivor); assert(wait_zero(s));
         for(int i=0;i<8;++i) { int fd=connect_client(p); const unsigned char close_frame[]={0x88,0x80,0,0,0,0}; send(fd,close_frame,sizeof(close_frame),0); close(fd); assert(wait_zero(s)); }
         for(int i=0;i<8;++i) { int fd=connect_client(p); close(fd); assert(wait_zero(s)); }
         int blocked=connect_client(p); std::thread stopper([&]{s.stop();}); stopper.join(); close(blocked);

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -499,6 +499,23 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
         reply["status"] = "error";
         reply["error"] = "invalid JSON";
     }
+    catch (const std::exception &e)
+    {
+        llog.logE(
+            ERROR,
+            "WebSocket command failed in handleMessage: " +
+                std::string(e.what()));
+        reply["status"] = "error";
+        reply["error"] = "command failure";
+        reply["message"] = "Unable to process the command.";
+    }
+    catch (...)
+    {
+        llog.logE(ERROR, "Unknown WebSocket command failure in handleMessage.");
+        reply["status"] = "error";
+        reply["error"] = "command failure";
+        reply["message"] = "Unable to process the command.";
+    }
 
     // Send the JSON‐formatted reply
     sendJSON(reply);
@@ -930,6 +947,8 @@ void WebSocketServer::clientLoop(int client_fd)
     char buf[1024];
     bool connection_open = true;
 
+    try
+    {
     while (running_ && connection_open)
     {
         ssize_t bytes = recv(client_fd, buf, sizeof(buf), 0);
@@ -986,6 +1005,18 @@ void WebSocketServer::clientLoop(int client_fd)
                           "from fd: ", client_fd);
             }
         }
+    }
+    }
+    catch (const std::exception &error)
+    {
+        llog.logE(
+            ERROR,
+            "WebSocket client handler failed: " +
+                std::string(error.what()));
+    }
+    catch (...)
+    {
+        llog.logE(ERROR, "Unknown WebSocket client handler failure.");
     }
 
     llog.logS(DEBUG, "Client handler thread exiting for fd: ", client_fd);


### PR DESCRIPTION
## Summary

- make test-tone startup transactional when backend configuration fails
- restore transmitter, scheduler mode, selector GPIO, LED, and transient request state after rejection
- return the original backend diagnostic through the WebSocket response
- add command-level and client-thread exception boundaries so an uncaught request error cannot abort the daemon
- add deterministic rollback and WebSocket lifecycle regressions

## Root cause

A rejected Si5351 plan was converted to `std::runtime_error` during synchronous `tone_start` configuration. The exception escaped `handleMessage()` and the detached WebSocket client thread, causing `std::terminate` and `SIGABRT`.

## Validation

On `wspr5.local` (Pi 5, Si5351 CLK0, dummy load):

- runtime semantics, UI/source regression, WebSocket lifecycle, test-tone request, and test-tone response tests passed
- the daemon built successfully
- a 144.490500 MHz request returned `tone_start: rejected` with the specific planner diagnostic
- the service remained active with zero restarts, `Transmit=false`, and Si5351 output-enable register 3 at `0xFF`
- a bounded 14.097100 MHz regression ran for 3.07 seconds; register 3 was `0xFE` while active and returned to `0xFF` after `tone_end`
- a malformed WebSocket command returned a controlled error and a subsequent connection remained healthy

## Scope boundary

This PR addresses the crash-containment portion of #368. It does not change the Si5351 planner, add static or four-tone 2 m synthesis, or qualify 2 m RF output. Those remain separate follow-up work.