### PR TITLE
Integrate recovered Setup autosave fixes

### DIFF
--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -267,15 +267,17 @@ int main()
         "UI save path must use canonical GPIO.Use NTP only");
     require(
         ui_source.find("const CONFIG_AUTOSAVE_DELAY_MS = 800;") != std::string::npos &&
-            ui_source.find("function buildConfigPayload()") != std::string::npos &&
+            ui_source.find("function buildConfigPayload(options = {})") != std::string::npos &&
             ui_source.find("function scheduleAutosave()") != std::string::npos &&
             ui_source.find("function flushAutosave()") != std::string::npos &&
             ui_source.find("payloadJson === lastSavedConfigPayload") != std::string::npos &&
             ui_source.find("payloadJson === lastFailedConfigPayload") != std::string::npos &&
             ui_source.find("Suppressing autosave retry for unchanged rejected payload.") != std::string::npos &&
-            ui_source.find("setConfigSaveStatus(\"saved\", \"Saved\", \"\");") != std::string::npos &&
+            ui_source.find("persistedStationIdentity") != std::string::npos &&
+            ui_source.find("setInvalidIdentitySaveStatus(\"Other changes saved\");") != std::string::npos &&
+            ui_source.find("setInvalidIdentitySaveStatus(\"Identity change not saved\");") != std::string::npos &&
             ui_source.find("configAutosavePendingAfterFlight") != std::string::npos,
-        "configuration autosave must debounce saves, clear stale invalid state for already-saved payloads, suppress unchanged failed payload retries, and suppress duplicate writes");
+        "configuration autosave must debounce saves, preserve persisted station identity for unrelated changes, report unsaved identity drafts accurately, suppress unchanged failed payload retries, and suppress duplicate writes");
     require(
         ui_source.find("function validateCwMessage()") != std::string::npos &&
             ui_source.find("function validateCwDotSeconds()") != std::string::npos &&


### PR DESCRIPTION
## Summary

- advance `WsprryPi-UI` to the merged recovery from UI PR #31
- restore parent regression assertions for partial saves with invalid station identity drafts

## Root cause

The UI fix and its matching parent assertion remained on divergent `fix/2026-08-05-regression-review` branches without pull requests.

## Impact

Unrelated valid Setup changes can be saved while an invalid station-identity draft remains visibly unsaved. The parent source regression now checks that contract.

## Validation

- UI `responsive_shell_logs_test.js` passed
- UI `cw_duration_latch_integration_test.js` passed with installed Chrome through a temporary Chromium-compatible launcher
- parent `ui_source_regression_test` compiled successfully on macOS with Linux-only warning/link flags omitted
- asserted autosave symbols verified in the pinned UI source
- `git diff --check`

The parent regression executable itself was not run on macOS because it intentionally reads source files from `/home/pi/WsprryPi`; Raspberry Pi runtime qualification remains separate.
