### PR TITLE
Expose calibrated Si5351 2m test-tone planning

### DIFF
--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -4896,6 +4896,7 @@ int main(int argc, char *argv[])
             make_managed_ini_data("AA0NT", "EM18", "20m", false);
         managed_ini["Operation"]["Transmit Backend"] = "si5351";
         managed_ini["Si5351"]["TX Output"] = "CLK2";
+        managed_ini["Calibration"]["PPM"] = "2.409358";
         iniFile.setData(managed_ini);
         require(
             set_config(true),
@@ -4979,6 +4980,94 @@ int main(int argc, char *argv[])
         require(
             wsprTransmitter.getState() == WsprTransmitter::State::DISABLED,
             "test tone stop with transmit disabled must not leave the transmitter busy");
+
+        constexpr std::uint64_t calibrated_2m_hz = 144490498U;
+        const TestToneStartResult calibrated_start = start_test_tone(
+            TestToneRequest{
+                TestToneFrequencySource::CustomRf,
+                "",
+                calibrated_2m_hz});
+        require(
+            calibrated_start.started,
+            "calibrated custom 2 m Test Tone must start through the normal "
+            "disabled-scheduler path");
+        const TransmissionRequest calibrated_tone_request =
+            current_transmission_request_for_test();
+        const auto calibrated_controller_request =
+            current_controller_request_for_test();
+        require(
+            calibrated_tone_request.mode == TransmissionMode::TONE &&
+                nearly_equal(
+                    calibrated_tone_request.actual_rf_frequency_hz,
+                    static_cast<double>(calibrated_2m_hz)) &&
+                nearly_equal(calibrated_tone_request.ppm, 2.409358),
+            "custom 2 m Test Tone must preserve requested RF and committed "
+            "Calibration.PPM in the legacy request");
+        require(
+            calibrated_controller_request.has_value() &&
+                calibrated_controller_request->mode ==
+                    wsprrypi::TransmissionMode::TONE &&
+                calibrated_controller_request->output.backend ==
+                    wsprrypi::BackendKind::SI5351 &&
+                nearly_equal(
+                    calibrated_controller_request->calibration.ppm,
+                    2.409358),
+            "custom 2 m Test Tone must carry committed Calibration.PPM into "
+            "the controller request");
+        const auto *calibrated_payload =
+            calibrated_controller_request.has_value()
+                ? std::get_if<wsprrypi::TonePayload>(
+                      &calibrated_controller_request->payload)
+                : nullptr;
+        require(
+            calibrated_payload != nullptr &&
+                nearly_equal(
+                    calibrated_payload->frequency_hz,
+                    static_cast<double>(calibrated_2m_hz)),
+            "custom 2 m Test Tone must preserve requested RF in the "
+            "controller payload");
+
+        set_raspberry_pi_generation_override_for_test(5);
+        const wsprrypi::ExecutionPlan calibrated_plan =
+            wsprrypi::ExecutionPlanCompiler{}.compile(
+                *calibrated_controller_request);
+        require(
+            calibrated_plan.mode == wsprrypi::TransmissionMode::TONE &&
+                calibrated_plan.backend == wsprrypi::BackendKind::SI5351 &&
+                nearly_equal(calibrated_plan.calibration.ppm, 2.409358) &&
+                calibrated_plan.events.size() == 2 &&
+                nearly_equal(
+                    calibrated_plan.events.front().frequency_hz,
+                    static_cast<double>(calibrated_2m_hz)),
+            "custom 2 m Test Tone must retain requested RF and calibration "
+            "through execution-plan compilation");
+        WsprSi5351Backend calibrated_backend(
+            wsprTransmitter,
+            si5351_config);
+        const wsprrypi::BackendCompileResult calibrated_compile =
+            calibrated_backend.configure(calibrated_plan, inputs);
+        require(
+            calibrated_compile.ok,
+            "calibrated custom 2 m Test Tone must configure through the "
+            "canonical dry-run Si5351 backend");
+        const wsprrypi::ExecutionResult calibrated_execute =
+            calibrated_backend.execute(calibrated_plan);
+        require(
+            calibrated_execute.ok,
+            "calibrated custom 2 m Test Tone must execute through the "
+            "canonical dry-run Si5351 backend");
+        clear_pi_generation_override_for_scope();
+
+        wsprTransmitter.backendSetStateValue(
+            WsprTransmitter::State::TRANSMITTING);
+        const TestToneStopResult calibrated_stop = end_test_tone();
+        require(
+            calibrated_stop.stopped && calibrated_stop.scheduler_restored &&
+                !config.transmit &&
+                wsprTransmitter.getState() ==
+                    WsprTransmitter::State::DISABLED,
+            "calibrated custom 2 m Test Tone stop must restore the disabled "
+            "scheduler and transmitter state");
 
         clear_si5351_detection_override_for_scope();
         set_scheduler_execution_suppressed_for_test(false);


### PR DESCRIPTION
## Summary

- exercise calibrated 144 MHz Si5351 planning through the normal operator Test Tone route
- verify requested RF and committed Calibration.PPM survive legacy request, controller request, payload, execution-plan compilation, backend configuration, and dry-run execution
- verify stopping the test tone restores the disabled scheduler and transmitter state
- advance WSPR-Transmitter to the merged guarded single-tone planning support

## Operator impact

A custom 2-meter Test Tone can now use the same guarded divide-by-6 Si5351 planning strategy as the qualified WSPR tones while preserving the requested RF as the operator-facing target.

This does not persist a calibration value, enable transmission, or alter chrony/NTP behavior.

## Validation

On wspr5:

- semantics-test
- guarded-mode-change-persistence-test
- wspr-tone-regression-test

The focused WSPR-Transmitter planner, transition, and startup-quiesce tests also passed before its corresponding merge.

Related to #383.