### PR TITLE
Expose Si5351 calibration cleanly in Setup

### DIFF
--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -1141,13 +1141,19 @@ int main()
         "update checker must log parsed display branch, raw branch/SHA, branch lookup URL/status/result, selected target branch, fallback state, and target HEAD for debugging");
     require(
         ui_source.find("function isWsprConfigMode()") != std::string::npos &&
-            ui_source.find("const useNtp = isWsprMode && $(\"#use_ntp\").is(\":checked\");") != std::string::npos &&
-            ui_source.find("backend === \"gpio\" && $(\"#use_ntp\").is(\":checked\");") == std::string::npos &&
+            ui_source.find("const si5351Active = selectedTransmitBackend() === \"si5351\";") != std::string::npos &&
+            ui_source.find("const gpioNtpActive = isWsprMode && !si5351Active && $(\"#use_ntp\").is(\":checked\");") != std::string::npos &&
+            ui_source.find("const showNtpControl = isWsprMode && !si5351Active;") != std::string::npos &&
             ui_source.find("$(\"#ntp_calibration_control\")") != std::string::npos &&
-            ui_source.find("$ppm.prop(\"disabled\", !isWsprMode || useNtp);") != std::string::npos &&
+            ui_source.find("$ppm.prop(\"disabled\", !isWsprMode || gpioNtpActive);") != std::string::npos &&
             ui_source.find("$ppmCw.prop(\"disabled\", isWsprMode);") != std::string::npos &&
+            ui_source.find("Applied to the Si5351 reference during synthesis planning.") != std::string::npos &&
+            ui_source.find("$(\"#use_ntp\").prop(\"checked\", false)") == std::string::npos &&
+            ui_source.find("$(\"#ppm\").val(0)") == std::string::npos &&
+            ui_source.find("let use_ntp = parseBool($(\"#use_ntp\").is(\":checked\"));") != std::string::npos &&
+            ui_source.find("let ppm_val = parseFloat(ppmSource) || 0.0;") != std::string::npos &&
             ui_source.find("syncCalibrationControls();") != std::string::npos,
-        "config UI must make calibration controls mode-aware so WSPR follows NTP while CW keeps PPM editable");
+        "config UI must keep Si5351 PPM editable, expose NTP only for GPIO WSPR, and preserve both stored values while switching backends");
 
     require(
         config_view_source.find("id=\"modeChangeGuardModal\"") != std::string::npos &&


### PR DESCRIPTION
## Summary

- advance WsprryPi-UI to the merged backend-aware calibration controls
- update parent UI/source regression expectations
- verify Si5351 manual PPM remains editable while GPIO-only NTP is hidden
- preserve Calibration.PPM and GPIO.Use NTP independently across backend switching

## Operator impact

Si5351 users can enter the existing Frequency calibration (PPM) value directly in Setup without disabling or changing the GPIO NTP preference. GPIO behavior is unchanged.

## Validation

On wspr5:

- real Chromium conditional-transmit GPIO integration test passed, including GPIO to Si5351 to GPIO calibration state and payload checks
- semantics-test passed
- ui_source_regression_test passed
- log timestamp and update-check regressions passed
- JavaScript syntax and diff checks passed

No persisted configuration, service state, or RF state was changed during testing.

Related to #383.