### PR TITLE
Archive Issue 390 GPIO prototypes

### DIFF
--- a/docs/research/issue-390-transmitter-qualification.md
+++ b/docs/research/issue-390-transmitter-qualification.md
@@ -172,8 +172,11 @@ retained in
 [`issue-390-transmitter-qualification/`](issue-390-transmitter-qualification/).
 The later clock-profile results are in its
 [`gpio-profile-followup/`](issue-390-transmitter-qualification/gpio-profile-followup/)
-subdirectory. Temporary complex-IQ and decoder WAV captures were removed from
-the test systems after the reviewed summaries and capture hashes were retained.
+subdirectory. That directory also preserves the exact uncommitted diffs from
+the superseded maintained-validation prototype and the rejected fixed-source
+oscillator experiment. Temporary complex-IQ and decoder WAV captures were
+removed from the test systems after the reviewed summaries and capture hashes
+were retained.
 
 Successful WSPR decoding does not establish antenna-ready spectral compliance.
 Filtering, harmonics, spurs, absolute output power, and the assembled station

--- a/docs/research/issue-390-transmitter-qualification/gpio-profile-followup/fixed-oscillator-rejected-prototype.patch
+++ b/docs/research/issue-390-transmitter-qualification/gpio-profile-followup/fixed-oscillator-rejected-prototype.patch
@@ -1,0 +1,164 @@
+diff --git a/src/wspr_transmit_backend_rpi.cpp b/src/wspr_transmit_backend_rpi.cpp
+index 807f496b6841d88d5b23879a7b8a24413e6a1755..c9905f956d9dd1ac51f84b42e16e839a11c7b053 100644
+--- a/src/wspr_transmit_backend_rpi.cpp
++++ b/src/wspr_transmit_backend_rpi.cpp
+@@ -485,6 +485,8 @@ double gpioCorrectedPlldFrequency(double nominal_hz, double source_rate_ppm)
+ WsprRpiBackend::DMAConfig::DMAConfig()
+     : plld_nominal_freq(500000000.0 * (1 - 2.500e-6)),
+       plld_clock_frequency(plld_nominal_freq),
++      gpclk_nominal_freq(plld_nominal_freq),
++      gpclk_clock_frequency(gpclk_nominal_freq),
+       peripheral_base_virtual(nullptr),
+       orig_gp0ctl(0),
+       orig_gp0div(0),
+@@ -2022,16 +2024,19 @@ void WsprRpiBackend::get_plld()
+     }
+ 
+     double base_freq_hz = 500e6;
++    double gpclk_base_freq_hz = 500e6;
+     switch (proc_id)
+     {
+     case BCMChip::BCM_HOST_PROCESSOR_BCM2835:
+     case BCMChip::BCM_HOST_PROCESSOR_BCM2836:
+     case BCMChip::BCM_HOST_PROCESSOR_BCM2837:
+         base_freq_hz = 500e6;
++        gpclk_base_freq_hz = base_freq_hz;
+         break;
+ 
+     case BCMChip::BCM_HOST_PROCESSOR_BCM2711:
+         base_freq_hz = 750e6;
++        gpclk_base_freq_hz = 54e6;
+         break;
+ 
+     default:
+@@ -2042,6 +2047,8 @@ void WsprRpiBackend::get_plld()
+ 
+     dma_config_.plld_nominal_freq = base_freq_hz;
+     dma_config_.plld_clock_frequency = base_freq_hz;
++    dma_config_.gpclk_nominal_freq = gpclk_base_freq_hz;
++    dma_config_.gpclk_clock_frequency = gpclk_base_freq_hz;
+ 
+     if (dma_config_.plld_clock_frequency <= 0)
+     {
+@@ -2054,6 +2061,8 @@ void WsprRpiBackend::get_plld()
+             0.0);
+         dma_config_.plld_nominal_freq = 500e6;
+         dma_config_.plld_clock_frequency = 500e6;
++        dma_config_.gpclk_nominal_freq = 500e6;
++        dma_config_.gpclk_clock_frequency = 500e6;
+     }
+ }
+ 
+@@ -2188,8 +2197,8 @@ void WsprRpiBackend::transmit_on(const WsprTransmissionPlan &plan)
+ 
+     access_bus_address(PADS_GPIO_0_27_BUS) = 0x5a000018 + plan.power_level;
+ 
+-    struct GPCTL setupword = {6, 0, 0, 0, 0, 3, 0x5A};
+-    setupword = {6, 1, 0, 0, 0, 3, 0x5A};
++    struct GPCTL setupword = {1, 0, 0, 0, 0, 3, 0x5A};
++    setupword = {1, 1, 0, 0, 0, 3, 0x5A};
+     int temp;
+     std::memcpy(&temp, &setupword, sizeof(int));
+ 
+@@ -2364,12 +2373,12 @@ void WsprRpiBackend::transmit_symbol(
+     std::int64_t n_f0_transmitted = 0;
+ 
+     const double f0_freq =
+-        dma_config_.plld_clock_frequency /
++        dma_config_.gpclk_clock_frequency /
+         (static_cast<double>(
+              reinterpret_cast<std::uint32_t *>(const_page_.v)[f0_idx] & 0x00FFFFFFu) /
+          std::pow(2.0, 12));
+     const double f1_freq =
+-        dma_config_.plld_clock_frequency /
++        dma_config_.gpclk_clock_frequency /
+         (static_cast<double>(
+              reinterpret_cast<std::uint32_t *>(const_page_.v)[f1_idx] & 0x00FFFFFFu) /
+          std::pow(2.0, 12));
+@@ -2730,12 +2739,17 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+     dma_config_.plld_clock_frequency = gpioCorrectedPlldFrequency(
+         dma_config_.plld_nominal_freq,
+         plan.ppm);
++    dma_config_.gpclk_clock_frequency = gpioCorrectedPlldFrequency(
++        dma_config_.gpclk_nominal_freq,
++        plan.ppm);
+ 
+     if (!std::isfinite(dma_config_.plld_clock_frequency) ||
+-        dma_config_.plld_clock_frequency <= 0.0)
++        dma_config_.plld_clock_frequency <= 0.0 ||
++        !std::isfinite(dma_config_.gpclk_clock_frequency) ||
++        dma_config_.gpclk_clock_frequency <= 0.0)
+     {
+         throw std::runtime_error(
+-            "configureTransmission(): invalid PLLD frequency after PPM correction.");
++            "configureTransmission(): invalid PLLD or GPCLK frequency after PPM correction.");
+     }
+ 
+     uint32_t div_reg = static_cast<uint32_t>(
+@@ -2751,19 +2765,19 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+     pwm_clock_init_ = dma_config_.plld_clock_frequency / double(divisor);
+ 
+     double div_lo = bit_trunc(
+-                        dma_config_.plld_clock_frequency /
++                        dma_config_.gpclk_clock_frequency /
+                             (plan.frequency_hz - 1.5 * plan.tone_spacing_hz),
+                         -12) +
+                     std::pow(2.0, -12);
+     double div_hi = bit_trunc(
+-        dma_config_.plld_clock_frequency /
++        dma_config_.gpclk_clock_frequency /
+             (plan.frequency_hz + 1.5 * plan.tone_spacing_hz),
+         -12);
+ 
+     if (std::floor(div_lo) != std::floor(div_hi))
+     {
+         result.applied_frequency_hz =
+-            dma_config_.plld_clock_frequency / std::floor(div_lo) -
++            dma_config_.gpclk_clock_frequency / std::floor(div_lo) -
+             1.6 * plan.tone_spacing_hz;
+         if (plan.frequency_hz != 0.0)
+         {
+@@ -2788,7 +2802,7 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+     for (int i = 0; i < 8; i++)
+     {
+         double tone_freq = tone0_freq + (i >> 1) * plan.tone_spacing_hz;
+-        double div = bit_trunc(dma_config_.plld_clock_frequency / tone_freq, -12);
++        double div = bit_trunc(dma_config_.gpclk_clock_frequency / tone_freq, -12);
+ 
+         if (i % 2 == 0)
+         {
+@@ -2811,6 +2825,8 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+             << plan.ppm
+             << " plld_hz=" << std::fixed << std::setprecision(3)
+             << dma_config_.plld_clock_frequency
++            << " gpclk_hz=" << std::fixed << std::setprecision(3)
++            << dma_config_.gpclk_clock_frequency
+             << " pwm_clock_hz=" << std::fixed << std::setprecision(3)
+             << pwm_clock_init_
+             << " dither_block_clocks="
+@@ -2823,10 +2839,10 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+             const double requested_hz =
+                 tone0_freq + static_cast<double>(symbol) * plan.tone_spacing_hz;
+             const double lower_hz =
+-                dma_config_.plld_clock_frequency /
++                dma_config_.gpclk_clock_frequency /
+                 (static_cast<double>(tuning_word[lower_index]) / std::pow(2.0, 12));
+             const double upper_hz =
+-                dma_config_.plld_clock_frequency /
++                dma_config_.gpclk_clock_frequency /
+                 (static_cast<double>(tuning_word[upper_index]) / std::pow(2.0, 12));
+             oss
+                 << " tone" << symbol
+diff --git a/src/wspr_transmit_backend_rpi.hpp b/src/wspr_transmit_backend_rpi.hpp
+index 6e3b41c4e69214be2e0e215f7a3f64423db1d04e..1f5bc3f74876f0568912286bd1beb6dc747871af 100644
+--- a/src/wspr_transmit_backend_rpi.hpp
++++ b/src/wspr_transmit_backend_rpi.hpp
+@@ -296,6 +296,8 @@ private:
+     {
+         double plld_nominal_freq;
+         double plld_clock_frequency;
++        double gpclk_nominal_freq;
++        double gpclk_clock_frequency;
+         volatile uint8_t *peripheral_base_virtual;
+         uint32_t orig_gp0ctl;
+         uint32_t orig_gp0div;

--- a/docs/research/issue-390-transmitter-qualification/gpio-profile-followup/maintained-validation-prototype.patch
+++ b/docs/research/issue-390-transmitter-qualification/gpio-profile-followup/maintained-validation-prototype.patch
@@ -1,0 +1,560 @@
+diff --git a/src/startup_quiesce_test.cpp b/src/startup_quiesce_test.cpp
+index ef909317867e8465729cca9cc931b75ce68ee95e..3ec9aee4625e34b8b8600a88d350a8f8ff4d080e 100644
+--- a/src/startup_quiesce_test.cpp
++++ b/src/startup_quiesce_test.cpp
+@@ -16,6 +16,7 @@
+ #include <set>
+ #include <sstream>
+ #include <string>
++#include <tuple>
+ #include <utility>
+ #include <vector>
+ 
+@@ -657,6 +658,115 @@ namespace
+         }
+     }
+ 
++    void test_gpio_rf_clock_planning_and_divider_bounds()
++    {
++        constexpr double spacing_hz = 12000.0 / 8192.0;
++        const auto tone_range = [spacing_hz](double center_hz) {
++            return std::pair<double, double>{
++                center_hz - 1.5 * spacing_hz,
++                center_hz + 1.5 * spacing_hz};
++        };
++
++        const auto pi4_2200m_range = tone_range(137500.0);
++        const auto pi4_2200m = gpioPlanRfClock(
++            GpioProcessorClockProfile::Bcm2711,
++            pi4_2200m_range.first,
++            pi4_2200m_range.second,
++            0.0);
++        expect(pi4_2200m.source == GpioRfClockSource::Oscillator &&
++                   pi4_2200m.nominal_hz == 54e6 &&
++                   pi4_2200m.corrected_hz == 54e6,
++               "Pi 4 2200 m must select the representable 54 MHz oscillator source");
++
++        const auto pi4_630m_range = tone_range(475700.0);
++        const auto pi4_630m = gpioPlanRfClock(
++            GpioProcessorClockProfile::Bcm2711,
++            pi4_630m_range.first,
++            pi4_630m_range.second,
++            0.0);
++        expect(pi4_630m.source == GpioRfClockSource::PllD &&
++                   pi4_630m.nominal_hz == 750e6,
++               "Pi 4 630 m must retain the preferred 750 MHz PLLD source");
++
++        const auto legacy_2200m = gpioPlanRfClock(
++            GpioProcessorClockProfile::Legacy500Mhz,
++            pi4_2200m_range.first,
++            pi4_2200m_range.second,
++            0.0);
++        expect(legacy_2200m.source == GpioRfClockSource::Oscillator &&
++                   legacy_2200m.nominal_hz == 19.2e6,
++               "500 MHz processors must select the 19.2 MHz oscillator on 2200 m");
++
++        const auto legacy_630m = gpioPlanRfClock(
++            GpioProcessorClockProfile::Legacy500Mhz,
++            pi4_630m_range.first,
++            pi4_630m_range.second,
++            0.0);
++        expect(legacy_630m.source == GpioRfClockSource::PllD &&
++                   legacy_630m.nominal_hz == 500e6,
++               "500 MHz processors must retain PLLD on 630 m");
++
++        constexpr double pi4_plld_boundary_hz =
++            750e6 / (static_cast<double>(0x00FFFFFFu) / 4096.0);
++        const auto below_boundary = gpioPlanRfClock(
++            GpioProcessorClockProfile::Bcm2711,
++            pi4_plld_boundary_hz - 100.0,
++            pi4_plld_boundary_hz - 100.0,
++            0.0);
++        const auto above_boundary = gpioPlanRfClock(
++            GpioProcessorClockProfile::Bcm2711,
++            pi4_plld_boundary_hz + 100.0,
++            pi4_plld_boundary_hz + 100.0,
++            0.0);
++        expect(below_boundary.source == GpioRfClockSource::Oscillator &&
++                   above_boundary.source == GpioRfClockSource::PllD,
++               "Pi 4 source selection must switch safely across the PLLD divisor boundary");
++
++        const auto ppm_plan = gpioPlanRfClock(
++            GpioProcessorClockProfile::Bcm2711,
++            pi4_2200m_range.first,
++            pi4_2200m_range.second,
++            100.0);
++        expect(ppm_plan.source == GpioRfClockSource::Oscillator &&
++                   ppm_plan.corrected_hz == 54e6 * 1.0001,
++               "GPIO PPM correction must apply to the selected oscillator source");
++
++        const auto legacy_ppm_plan = gpioPlanRfClock(
++            GpioProcessorClockProfile::Legacy500Mhz,
++            pi4_2200m_range.first,
++            pi4_2200m_range.second,
++            -50.0);
++        expect(legacy_ppm_plan.source == GpioRfClockSource::Oscillator &&
++                   legacy_ppm_plan.corrected_hz == 19.2e6 * 0.99995,
++               "legacy GPIO PPM correction must apply to the 19.2 MHz oscillator");
++
++        const auto lower_word = gpioBuildDividerWord(54e6, 137500.0, false);
++        const auto upper_word = gpioBuildDividerWord(54e6, 137500.0, true);
++        expect(lower_word <= 0x00FFFFFFu && upper_word == lower_word + 1,
++               "representable oscillator tuning words must remain inside the 24-bit field");
++
++        for (const auto& invalid : {
++                 std::tuple<double, double, bool>{750e6, 137500.0, false},
++                 std::tuple<double, double, bool>{500e6, 100000.0, false},
++                 std::tuple<double, double, bool>{500e6, 120000000.0, false}})
++        {
++            bool rejected = false;
++            try
++            {
++                (void)gpioBuildDividerWord(
++                    std::get<0>(invalid),
++                    std::get<1>(invalid),
++                    std::get<2>(invalid));
++            }
++            catch (const std::out_of_range&)
++            {
++                rejected = true;
++            }
++            expect(rejected,
++                   "unrepresentable GPIO divider words must fail closed");
++        }
++    }
++
+     void test_rpi_gpio4_exact_safe_trace()
+     {
+         TestBridge bridge;
+@@ -811,6 +921,7 @@ int main()
+     test_si5351_quiesce_failures_close_handles();
+     test_si5351_dry_run_avoids_i2c();
+     test_gpio_ppm_sign_and_bounds();
++    test_gpio_rf_clock_planning_and_divider_bounds();
+     test_rpi_gpio4_exact_safe_trace();
+     test_rpi_gpio20_exact_safe_trace();
+     test_rpi_repeated_call_safety();
+diff --git a/src/wspr_transmit_backend_rpi.cpp b/src/wspr_transmit_backend_rpi.cpp
+index 807f496b6841d88d5b23879a7b8a24413e6a1755..b1bd9308ee9d2d6d930389625467b8685257f005 100644
+--- a/src/wspr_transmit_backend_rpi.cpp
++++ b/src/wspr_transmit_backend_rpi.cpp
+@@ -482,9 +482,124 @@ double gpioCorrectedPlldFrequency(double nominal_hz, double source_rate_ppm)
+     return nominal_hz * (1.0 + source_rate_ppm * 1.0e-6);
+ }
+ 
++namespace
++{
++    constexpr std::uint32_t kGpclkDividerMask = 0x00FFFFFFu;
++    constexpr double kGpclkDividerScale = 4096.0;
++    constexpr double kGpclkMash3MinimumDivisor = 5.0;
++    constexpr double kGpclkPreferOscillatorMaximumToneHz = 150e3;
++
++    bool gpioClockCanRepresent(
++        double source_hz,
++        double minimum_tone_hz,
++        double maximum_tone_hz)
++    {
++        if (!std::isfinite(source_hz) || source_hz <= 0.0 ||
++            !std::isfinite(minimum_tone_hz) || minimum_tone_hz <= 0.0 ||
++            !std::isfinite(maximum_tone_hz) ||
++            maximum_tone_hz < minimum_tone_hz)
++        {
++            return false;
++        }
++
++        for (const double tone_hz : {minimum_tone_hz, maximum_tone_hz})
++        {
++            const double scaled = source_hz / tone_hz * kGpclkDividerScale;
++            const double lower = std::floor(scaled);
++            const double upper = lower + 1.0;
++            if (!std::isfinite(scaled) ||
++                lower < kGpclkMash3MinimumDivisor * kGpclkDividerScale ||
++                upper > static_cast<double>(kGpclkDividerMask))
++            {
++                return false;
++            }
++        }
++        return true;
++    }
++}
++
++GpioRfClockPlan gpioPlanRfClock(
++    GpioProcessorClockProfile profile,
++    double minimum_tone_hz,
++    double maximum_tone_hz,
++    double source_rate_ppm)
++{
++    const double plld_nominal_hz =
++        profile == GpioProcessorClockProfile::Bcm2711 ? 750e6 : 500e6;
++    const double oscillator_nominal_hz =
++        profile == GpioProcessorClockProfile::Bcm2711 ? 54e6 : 19.2e6;
++    const double corrected_plld_hz =
++        gpioCorrectedPlldFrequency(plld_nominal_hz, source_rate_ppm);
++    const double corrected_oscillator_hz =
++        gpioCorrectedPlldFrequency(
++            oscillator_nominal_hz,
++            source_rate_ppm);
++
++    if (maximum_tone_hz <= kGpclkPreferOscillatorMaximumToneHz &&
++        gpioClockCanRepresent(
++            corrected_oscillator_hz,
++            minimum_tone_hz,
++            maximum_tone_hz))
++    {
++        return {
++            GpioRfClockSource::Oscillator,
++            oscillator_nominal_hz,
++            corrected_oscillator_hz};
++    }
++
++    if (gpioClockCanRepresent(
++            corrected_plld_hz,
++            minimum_tone_hz,
++            maximum_tone_hz))
++    {
++        return {
++            GpioRfClockSource::PllD,
++            plld_nominal_hz,
++            corrected_plld_hz};
++    }
++
++    if (gpioClockCanRepresent(
++            corrected_oscillator_hz,
++            minimum_tone_hz,
++            maximum_tone_hz))
++    {
++        return {
++            GpioRfClockSource::Oscillator,
++            oscillator_nominal_hz,
++            corrected_oscillator_hz};
++    }
++
++    throw std::out_of_range(
++        "GPIO RF frequency cannot be represented by an available GPCLK source.");
++}
++
++std::uint32_t gpioBuildDividerWord(
++    double source_hz,
++    double tone_hz,
++    bool round_up_one_lsb)
++{
++    if (!gpioClockCanRepresent(source_hz, tone_hz, tone_hz))
++    {
++        throw std::out_of_range(
++            "GPIO RF tuning word is outside the GPCLK 12.12 divisor range.");
++    }
++    const double scaled = source_hz / tone_hz * kGpclkDividerScale;
++    const double word = std::floor(scaled) + (round_up_one_lsb ? 1.0 : 0.0);
++    if (word < 0.0 || word > static_cast<double>(kGpclkDividerMask))
++    {
++        throw std::out_of_range(
++            "GPIO RF tuning word exceeds the GPCLK divider field.");
++    }
++    return static_cast<std::uint32_t>(word);
++}
++
+ WsprRpiBackend::DMAConfig::DMAConfig()
+     : plld_nominal_freq(500000000.0 * (1 - 2.500e-6)),
+       plld_clock_frequency(plld_nominal_freq),
++      gpclk_nominal_freq(plld_nominal_freq),
++      gpclk_clock_frequency(gpclk_nominal_freq),
++      processor_profile(GpioProcessorClockProfile::Legacy500Mhz),
++      gpclk_source(GpioRfClockSource::PllD),
+       peripheral_base_virtual(nullptr),
+       orig_gp0ctl(0),
+       orig_gp0div(0),
+@@ -2028,10 +2143,14 @@ void WsprRpiBackend::get_plld()
+     case BCMChip::BCM_HOST_PROCESSOR_BCM2836:
+     case BCMChip::BCM_HOST_PROCESSOR_BCM2837:
+         base_freq_hz = 500e6;
++        dma_config_.processor_profile =
++            GpioProcessorClockProfile::Legacy500Mhz;
+         break;
+ 
+     case BCMChip::BCM_HOST_PROCESSOR_BCM2711:
+         base_freq_hz = 750e6;
++        dma_config_.processor_profile =
++            GpioProcessorClockProfile::Bcm2711;
+         break;
+ 
+     default:
+@@ -2042,6 +2161,9 @@ void WsprRpiBackend::get_plld()
+ 
+     dma_config_.plld_nominal_freq = base_freq_hz;
+     dma_config_.plld_clock_frequency = base_freq_hz;
++    dma_config_.gpclk_nominal_freq = base_freq_hz;
++    dma_config_.gpclk_clock_frequency = base_freq_hz;
++    dma_config_.gpclk_source = GpioRfClockSource::PllD;
+ 
+     if (dma_config_.plld_clock_frequency <= 0)
+     {
+@@ -2054,6 +2176,11 @@ void WsprRpiBackend::get_plld()
+             0.0);
+         dma_config_.plld_nominal_freq = 500e6;
+         dma_config_.plld_clock_frequency = 500e6;
++        dma_config_.gpclk_nominal_freq = 500e6;
++        dma_config_.gpclk_clock_frequency = 500e6;
++        dma_config_.processor_profile =
++            GpioProcessorClockProfile::Legacy500Mhz;
++        dma_config_.gpclk_source = GpioRfClockSource::PllD;
+     }
+ }
+ 
+@@ -2188,12 +2315,46 @@ void WsprRpiBackend::transmit_on(const WsprTransmissionPlan &plan)
+ 
+     access_bus_address(PADS_GPIO_0_27_BUS) = 0x5a000018 + plan.power_level;
+ 
+-    struct GPCTL setupword = {6, 0, 0, 0, 0, 3, 0x5A};
+-    setupword = {6, 1, 0, 0, 0, 3, 0x5A};
++    const auto source = static_cast<std::uint32_t>(dma_config_.gpclk_source);
++    struct GPCTL setupword = {source, 0, 0, 0, 0, 3, 0x5A};
++    setupword = {source, 1, 0, 0, 0, 3, 0x5A};
+     int temp;
+     std::memcpy(&temp, &setupword, sizeof(int));
+ 
+     access_bus_address(CM_GP0CTL_BUS) = temp;
++
++    bool verified = false;
++    std::uint32_t observed_control = 0;
++    std::uint32_t observed_divider = 0;
++    for (int attempt = 0; attempt < 20 && !verified; ++attempt)
++    {
++        observed_control = access_bus_address(CM_GP0CTL_BUS);
++        observed_divider =
++            access_bus_address(CM_GP0DIV_BUS) & kGpclkDividerMask;
++        verified = (observed_control & 0xFu) == source &&
++            (observed_control & (1u << 4)) != 0 &&
++            std::find(
++                active_gpclk_words_.begin(),
++                active_gpclk_words_.end(),
++                observed_divider) != active_gpclk_words_.end();
++        if (!verified)
++        {
++            (void)owner_.backendWaitInterruptableFor(
++                std::chrono::milliseconds(1));
++        }
++    }
++    if (!verified)
++    {
++        gpclk0_disable_wait(access_bus_address(CM_GP0CTL_BUS));
++        std::ostringstream oss;
++        oss << "GPCLK source/divider readback did not match the validated RF plan:"
++            << " control=0x" << std::hex << observed_control
++            << " divider=0x" << observed_divider
++            << " expected_source=0x" << source
++            << " expected_divider=0x" << active_gpclk_words_[0]
++            << std::dec << ".";
++        throw std::runtime_error(oss.str());
++    }
+     owner_.backendSetStateValue(WsprTransmitState::TRANSMITTING);
+ }
+ 
+@@ -2364,12 +2525,12 @@ void WsprRpiBackend::transmit_symbol(
+     std::int64_t n_f0_transmitted = 0;
+ 
+     const double f0_freq =
+-        dma_config_.plld_clock_frequency /
++        dma_config_.gpclk_clock_frequency /
+         (static_cast<double>(
+              reinterpret_cast<std::uint32_t *>(const_page_.v)[f0_idx] & 0x00FFFFFFu) /
+          std::pow(2.0, 12));
+     const double f1_freq =
+-        dma_config_.plld_clock_frequency /
++        dma_config_.gpclk_clock_frequency /
+         (static_cast<double>(
+              reinterpret_cast<std::uint32_t *>(const_page_.v)[f1_idx] & 0x00FFFFFFu) /
+          std::pow(2.0, 12));
+@@ -2731,11 +2892,43 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+         dma_config_.plld_nominal_freq,
+         plan.ppm);
+ 
++    const double minimum_tone_hz =
++        plan.frequency_hz - 1.5 * plan.tone_spacing_hz;
++    const double maximum_tone_hz =
++        plan.frequency_hz + 1.5 * plan.tone_spacing_hz;
++    const GpioRfClockPlan rf_clock = gpioPlanRfClock(
++        dma_config_.processor_profile,
++        minimum_tone_hz,
++        maximum_tone_hz,
++        plan.ppm);
++    dma_config_.gpclk_nominal_freq = rf_clock.nominal_hz;
++    dma_config_.gpclk_clock_frequency = rf_clock.corrected_hz;
++    dma_config_.gpclk_source = rf_clock.source;
++
++    {
++        std::ostringstream oss;
++        oss << "GPIO RF clock source="
++            << (rf_clock.source == GpioRfClockSource::Oscillator
++                    ? "oscillator"
++                    : "PLLD")
++            << " nominal_hz=" << std::fixed << std::setprecision(0)
++            << rf_clock.nominal_hz
++            << " corrected_hz=" << std::fixed << std::setprecision(3)
++            << rf_clock.corrected_hz;
++        owner_.backendFireTransmitCallback(
++            WsprTransmissionCallbackEvent::LOGGING,
++            WsprTransmitLogLevel::DEBUG,
++            oss.str(),
++            0.0);
++    }
++
+     if (!std::isfinite(dma_config_.plld_clock_frequency) ||
+-        dma_config_.plld_clock_frequency <= 0.0)
++        dma_config_.plld_clock_frequency <= 0.0 ||
++        !std::isfinite(dma_config_.gpclk_clock_frequency) ||
++        dma_config_.gpclk_clock_frequency <= 0.0)
+     {
+         throw std::runtime_error(
+-            "configureTransmission(): invalid PLLD frequency after PPM correction.");
++            "configureTransmission(): invalid PLLD or GPCLK frequency after PPM correction.");
+     }
+ 
+     uint32_t div_reg = static_cast<uint32_t>(
+@@ -2751,19 +2944,19 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+     pwm_clock_init_ = dma_config_.plld_clock_frequency / double(divisor);
+ 
+     double div_lo = bit_trunc(
+-                        dma_config_.plld_clock_frequency /
++                        dma_config_.gpclk_clock_frequency /
+                             (plan.frequency_hz - 1.5 * plan.tone_spacing_hz),
+                         -12) +
+                     std::pow(2.0, -12);
+     double div_hi = bit_trunc(
+-        dma_config_.plld_clock_frequency /
++        dma_config_.gpclk_clock_frequency /
+             (plan.frequency_hz + 1.5 * plan.tone_spacing_hz),
+         -12);
+ 
+     if (std::floor(div_lo) != std::floor(div_hi))
+     {
+         result.applied_frequency_hz =
+-            dma_config_.plld_clock_frequency / std::floor(div_lo) -
++            dma_config_.gpclk_clock_frequency / std::floor(div_lo) -
+             1.6 * plan.tone_spacing_hz;
+         if (plan.frequency_hz != 0.0)
+         {
+@@ -2788,14 +2981,11 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+     for (int i = 0; i < 8; i++)
+     {
+         double tone_freq = tone0_freq + (i >> 1) * plan.tone_spacing_hz;
+-        double div = bit_trunc(dma_config_.plld_clock_frequency / tone_freq, -12);
+-
+-        if (i % 2 == 0)
+-        {
+-            div += std::pow(2.0, -12);
+-        }
+-
+-        tuning_word[i] = static_cast<std::uint32_t>(div * std::pow(2.0, 12));
++        tuning_word[i] = gpioBuildDividerWord(
++            dma_config_.gpclk_clock_frequency,
++            tone_freq,
++            i % 2 == 0);
++        active_gpclk_words_[i] = tuning_word[i];
+     }
+ 
+     if (trace_wspr_tones_enabled())
+@@ -2811,6 +3001,10 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+             << plan.ppm
+             << " plld_hz=" << std::fixed << std::setprecision(3)
+             << dma_config_.plld_clock_frequency
++            << " gpclk_source="
++            << static_cast<std::uint32_t>(dma_config_.gpclk_source)
++            << " gpclk_hz=" << std::fixed << std::setprecision(3)
++            << dma_config_.gpclk_clock_frequency
+             << " pwm_clock_hz=" << std::fixed << std::setprecision(3)
+             << pwm_clock_init_
+             << " dither_block_clocks="
+@@ -2823,10 +3017,10 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+             const double requested_hz =
+                 tone0_freq + static_cast<double>(symbol) * plan.tone_spacing_hz;
+             const double lower_hz =
+-                dma_config_.plld_clock_frequency /
++                dma_config_.gpclk_clock_frequency /
+                 (static_cast<double>(tuning_word[lower_index]) / std::pow(2.0, 12));
+             const double upper_hz =
+-                dma_config_.plld_clock_frequency /
++                dma_config_.gpclk_clock_frequency /
+                 (static_cast<double>(tuning_word[upper_index]) / std::pow(2.0, 12));
+             oss
+                 << " tone" << symbol
+@@ -2854,14 +3048,17 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
+ 
+     for (int i = 8; i < 1024; i++)
+     {
+-        double div = 500 + i;
+-        tuning_word[i] = static_cast<std::uint32_t>(div * std::pow(2.0, 12));
++        // DMA control blocks initially reference an otherwise unused table
++        // entry before transmit_symbol() assigns the active tone pair.  Keep
++        // every placeholder on a validated in-plan divider so enabling GPCLK
++        // can never expose an arbitrary stale frequency.
++        tuning_word[i] = tuning_word[0];
+     }
+ 
+     for (int i = 0; i < 1024; i++)
+     {
+         reinterpret_cast<std::uint32_t *>(const_page_.v)[i] =
+-            (0x5Au << 24) + tuning_word[i];
++            (0x5Au << 24) | (tuning_word[i] & kGpclkDividerMask);
+ 
+         if ((i % 2 == 0) && (i < 8))
+         {
+diff --git a/src/wspr_transmit_backend_rpi.hpp b/src/wspr_transmit_backend_rpi.hpp
+index 6e3b41c4e69214be2e0e215f7a3f64423db1d04e..4c759c23197a1bd3fd4e4f02091dc1a85c0f70c7 100644
+--- a/src/wspr_transmit_backend_rpi.hpp
++++ b/src/wspr_transmit_backend_rpi.hpp
+@@ -116,6 +116,36 @@ makeProductionRpiStartupQuiesceAccess();
+  */
+ double gpioCorrectedPlldFrequency(double nominal_hz, double source_rate_ppm);
+ 
++enum class GpioProcessorClockProfile
++{
++    Legacy500Mhz,
++    Bcm2711
++};
++
++enum class GpioRfClockSource : std::uint32_t
++{
++    Oscillator = 1,
++    PllD = 6
++};
++
++struct GpioRfClockPlan
++{
++    GpioRfClockSource source{GpioRfClockSource::PllD};
++    double nominal_hz{0.0};
++    double corrected_hz{0.0};
++};
++
++GpioRfClockPlan gpioPlanRfClock(
++    GpioProcessorClockProfile profile,
++    double minimum_tone_hz,
++    double maximum_tone_hz,
++    double source_rate_ppm);
++
++std::uint32_t gpioBuildDividerWord(
++    double source_hz,
++    double tone_hz,
++    bool round_up_one_lsb);
++
+ /**
+  * @class WsprRpiBackend
+  * @brief Raspberry Pi implementation of the generic transmission backend.
+@@ -296,6 +326,10 @@ private:
+     {
+         double plld_nominal_freq;
+         double plld_clock_frequency;
++        double gpclk_nominal_freq;
++        double gpclk_clock_frequency;
++        GpioProcessorClockProfile processor_profile;
++        GpioRfClockSource gpclk_source;
+         volatile uint8_t *peripheral_base_virtual;
+         uint32_t orig_gp0ctl;
+         uint32_t orig_gp0div;
+@@ -452,6 +486,7 @@ private:
+     bool dma_setup_done_{false};
+     std::uint32_t dma_buf_ptr_{0};
+     double pwm_clock_init_{0};
++    std::array<std::uint32_t, 8> active_gpclk_words_{};
+     int watchdog_cpu_{1};
+     int configured_tx_gpio_{4};
+     std::optional<ExecutionPlanConfig> configured_plan_{};


### PR DESCRIPTION
## Summary

- preserve the exact superseded maintained-validation prototype
- preserve the exact rejected fixed-source oscillator experiment
- document why the temporary worktrees can now be removed safely

Related to #390.

## Validation

- archived patches were generated directly from the two temporary submodule worktrees
- documentation diff passed git diff --check
- no runtime behavior changed