### PR TITLE
Test simulated startup quiesce failure

### DIFF
--- a/.github/workflows/debian-non-hardware.yml
+++ b/.github/workflows/debian-non-hardware.yml
@@ -49,6 +49,9 @@ jobs:
           strace -f -e trace=openat,open \
             -o /tmp/wsprrypi-semantics.strace \
             make semantics-test SUDO=
+          strace -f -e trace=openat,open \
+            -o /tmp/wsprrypi-startup-quiesce-parent.strace \
+            make startup-quiesce-parent-test SUDO=
 
       - name: Run RP1 non-hardware regression
         working-directory: src
@@ -78,6 +81,7 @@ jobs:
       - name: Reject transmitter hardware access
         run: scripts/ci/assert-no-transmitter-hardware.sh \
           /tmp/wsprrypi-semantics.strace \
+          /tmp/wsprrypi-startup-quiesce-parent.strace \
           /tmp/wsprrypi-rp1.strace \
           /tmp/wsprrypi-simulator.strace \
           /tmp/wsprrypi-wspr-simulator.strace

--- a/docs/simulated-backend.md
+++ b/docs/simulated-backend.md
@@ -137,14 +137,30 @@ These fields exist with the same names and defaults in `SimulatedBackendConfig` 
 | --- | --- | --- | --- | --- |
 | `virtual_time` | `bool`, `true` | `false` enables interruptible per-event waits | Ordinary lifecycle events | No |
 | `trace_path` | `std::string`; empty for direct backend config, `/tmp/wsprrypi-simulated-trace.json` for application runtime config | Nonempty path is replaced whenever the trace is rendered | JSON document at the selected path | No |
+| `fail_startup_quiesce` | `bool`, `false` | `quiesceForStartup()` returns `ok == false` | `startup_quiesce_failure`, detail `injected` | No |
 | `fail_configure` | `bool`, `false` | `configure()` returns `ok == false` | `configure_failure`, detail `injected` | No |
 | `fail_event` | `long`, `-1` | Matching zero-based event index returns `faulted == true` | `execution_failure`, detail `injected` | No |
 | `cancel_event` | `long`, `-1` | Matching zero-based event index returns `stopped == true` | `cancelled`, detail `injected` | No |
 | `fail_cleanup` | `bool`, `false` | Armed cleanup returns `ok == false` | `cleanup_failure`, detail `injected` | No |
 
-A negative index disables index-based execution and cancellation injection. Configure failure occurs after the initial `configure` record. `TransmissionController::prepare()` then attempts cleanup; if cleanup also fails, both error messages are preserved. Execution failure and cancellation likewise remain observable if the subsequent cleanup fails, and cleanup failure forces the combined lifecycle result to remain failed rather than reporting false completion or cancellation success.
+A negative index disables index-based execution and cancellation injection. Startup-quiescence failure is injected before configuration or execution state is armed. It returns `Injected simulated startup quiesce failure.`, and every call appends one deterministic `startup_quiesce_failure` record. Repeated calls return the same failure; explicit cleanup remains safe and is distinct from the unarmed `fail_cleanup` execution fault. The application startup gate retains the error and inhibits later preparation, scheduling, and transmission.
+
+Configure failure occurs after the initial `configure` record. `TransmissionController::prepare()` then attempts cleanup; if cleanup also fails, both error messages are preserved. Execution failure and cancellation likewise remain observable if the subsequent cleanup fails, and cleanup failure forces the combined lifecycle result to remain failed rather than reporting false completion or cancellation success.
 
 External cancellation is distinct from `cancel_event`: `stopRequested()`, `stop()`, or an interrupted real-time wait records `cancelled` without the `injected` detail. The focused simulator test covers `fail_event`, `cancel_event`, context stop observation, and `fail_cleanup`. `src/tests/cleanup_lifecycle_test.cpp` covers application-level configure-plus-cleanup failure, execution cleanup failure, cancellation cleanup failure, backend replacement, repeated cleanup, and destructor-safe reporting.
+
+Tests inject startup-quiescence failure through either typed configuration surface before selecting or constructing the backend:
+
+```cpp
+WsprTransmitter::SimulatedRuntimeConfig simulation;
+simulation.fail_startup_quiesce = true;
+transmitter.selectBackend(
+    wsprrypi::BackendKind::SIMULATED,
+    WsprTransmitter::Si5351RuntimeConfig{},
+    simulation);
+```
+
+Direct backend tests use `SimulatedBackendConfig::fail_startup_quiesce` in the same way. This validates software propagation and inhibition only; it does not qualify physical startup quiescence, GPIO, I2C, MMIO, DMA, mailbox, services, scheduling accuracy, or RF behavior.
 
 ## Repeated execution and state reset
 

--- a/src/tests/cleanup_lifecycle_test.cpp
+++ b/src/tests/cleanup_lifecycle_test.cpp
@@ -149,6 +149,27 @@ void test_cancellation_cleanup_failure_prevents_false_cancel_success()
     expect(transmitter.getState() == WsprTransmitter::State::FAILED,
            "cancellation cleanup failure must remain a failed lifecycle");
 }
+
+void test_startup_quiesce_failure_propagates_without_arming_cleanup()
+{
+    WsprTransmitter transmitter;
+    WsprTransmitter::SimulatedRuntimeConfig config;
+    config.trace_path = "/tmp/wsprrypi-startup-quiesce-lifecycle-trace.json";
+    config.fail_startup_quiesce = true;
+    config.fail_cleanup = true;
+    transmitter.selectBackend(wsprrypi::BackendKind::SIMULATED, {}, config);
+
+    const auto first = transmitter.quiesceForStartup();
+    const auto second = transmitter.quiesceForStartup();
+    expect(!first.ok && first.error == "Injected simulated startup quiesce failure.",
+           "startup quiesce failure must propagate through WsprTransmitter");
+    expect(!second.ok && second.error == first.error,
+           "repeated startup quiesce failure must remain deterministic");
+
+    transmitter.stopAndJoin();
+    expect(transmitter.lastCleanupResult().ok,
+           "startup quiesce failure must not arm injected execution cleanup failure");
+}
 }
 
 int main()
@@ -159,6 +180,7 @@ try
     test_configuration_and_cleanup_failure_preserve_both_errors();
     test_execution_cleanup_failure_prevents_completion();
     test_cancellation_cleanup_failure_prevents_false_cancel_success();
+    test_startup_quiesce_failure_propagates_without_arming_cleanup();
     std::cout << "cleanup lifecycle tests passed\n";
     return EXIT_SUCCESS;
 }

--- a/src/tests/startup_quiesce_parent_test.cpp
+++ b/src/tests/startup_quiesce_parent_test.cpp
@@ -1,13 +1,138 @@
 #include "config_handler.hpp"
 #include "gpio_output.hpp"
 #include "scheduling.hpp"
-#include <cstdlib>
-#include <iostream>
+#include "WSPR-Transmitter/src/wspr_transmit.hpp"
 
-namespace { void require(bool v, const char *m) { if (!v) { std::cerr << m << '\n'; std::exit(1); } }
-ArgParserConfig cfg_for(EnableOnBootBehavior policy) { init_default_config(); auto cfg = config; cfg.use_ini = true; cfg.transmit = true; cfg.enable_on_boot = policy; cfg.use_led = true; cfg.led_pin = 5; config = cfg; return cfg; }
-void reset() { reset_startup_quiesce_for_test(); GPIOOutput::setTestMode(true); set_scheduler_execution_suppressed_for_test(true); reset_tx_led_request_counts_for_test(); }
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace
+{
+void require(bool value, const char* message)
+{
+    if (!value)
+    {
+        std::cerr << message << '\n';
+        std::exit(1);
+    }
 }
-int main() {
- for (auto policy : {EnableOnBootBehavior::Never, EnableOnBootBehavior::Follow, EnableOnBootBehavior::Always}) { reset(); int calls=0; set_startup_quiesce_invoker_for_test([&calls]{ ++calls; return wsprrypi::StartupQuiesceResult{true,{}}; }); auto cfg=cfg_for(policy); require(run_startup_quiesce_gate_for_test(cfg), "success gate"); require(calls==1, "one quiesce per policy"); require(!startup_quiesce_inhibited_for_test(), "success not inhibited"); require(tx_led_deassert_request_count_for_test()>0, "outputs deasserted"); }
- reset(); int calls=0; set_startup_quiesce_invoker_for_test([&calls]{ ++calls; return wsprrypi::StartupQuiesceResult{false,"fake quiesce failure"}; }); auto cfg=cfg_for(EnableOnBootBehavior::Follow); const bool tx=cfg.transmit; const auto policy=cfg.enable_on_boot; require(!run_startup_quiesce_gate_for_test(cfg), "failure gate"); require(calls==1, "one failed quiesce"); require(startup_quiesce_inhibited_for_test(), "failure inhibited"); require(startup_quiesce_error_for_test()=="fake quiesce failure", "error retained"); require(cfg.transmit==tx && cfg.enable_on_boot==policy, "policy preserved"); require(start_non_wspr_transmission_now_for_test(cfg), "blocked launch returns safely"); require(!current_controller_request_for_test().has_value(), "manual launch must not configure transmitter"); require(startup_quiesce_inhibited_for_test(), "latch retained"); reset_startup_quiesce_for_test(); GPIOOutput::setTestMode(false); set_scheduler_execution_suppressed_for_test(false); std::cout << "startup_quiesce_parent_test passed\n"; }
+
+ArgParserConfig cfg_for(EnableOnBootBehavior policy)
+{
+    init_default_config();
+    auto cfg = config;
+    cfg.use_ini = true;
+    cfg.transmit = true;
+    cfg.enable_on_boot = policy;
+    cfg.use_led = true;
+    cfg.led_pin = 5;
+    config = cfg;
+    return cfg;
+}
+
+void reset()
+{
+    reset_startup_quiesce_for_test();
+    GPIOOutput::setTestMode(true);
+    set_scheduler_execution_suppressed_for_test(true);
+    reset_tx_led_request_counts_for_test();
+}
+
+std::string read_file(const char* path)
+{
+    std::ifstream input(path);
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    return contents.str();
+}
+
+void test_generic_startup_gate()
+{
+    for (auto policy : {EnableOnBootBehavior::Never,
+                        EnableOnBootBehavior::Follow,
+                        EnableOnBootBehavior::Always})
+    {
+        reset();
+        int calls = 0;
+        set_startup_quiesce_invoker_for_test([&calls] {
+            ++calls;
+            return wsprrypi::StartupQuiesceResult{true, {}};
+        });
+        auto cfg = cfg_for(policy);
+        require(run_startup_quiesce_gate_for_test(cfg), "success gate");
+        require(calls == 1, "one quiesce per policy");
+        require(!startup_quiesce_inhibited_for_test(), "success not inhibited");
+        require(tx_led_deassert_request_count_for_test() > 0,
+                "outputs deasserted");
+    }
+
+    reset();
+    int calls = 0;
+    set_startup_quiesce_invoker_for_test([&calls] {
+        ++calls;
+        return wsprrypi::StartupQuiesceResult{false, "fake quiesce failure"};
+    });
+    auto cfg = cfg_for(EnableOnBootBehavior::Follow);
+    const bool transmit = cfg.transmit;
+    const auto policy = cfg.enable_on_boot;
+    require(!run_startup_quiesce_gate_for_test(cfg), "failure gate");
+    require(calls == 1, "one failed quiesce");
+    require(startup_quiesce_inhibited_for_test(), "failure inhibited");
+    require(startup_quiesce_error_for_test() == "fake quiesce failure",
+            "error retained");
+    require(cfg.transmit == transmit && cfg.enable_on_boot == policy,
+            "policy preserved");
+    require(start_non_wspr_transmission_now_for_test(cfg),
+            "blocked launch returns safely");
+    require(!current_controller_request_for_test().has_value(),
+            "manual launch must not configure transmitter");
+    require(startup_quiesce_inhibited_for_test(), "latch retained");
+}
+
+void test_injected_simulator_failure_reaches_application_gate()
+{
+    reset();
+    constexpr const char* trace_path =
+        "/tmp/wsprrypi-startup-quiesce-parent-trace.json";
+    WsprTransmitter transmitter;
+    WsprTransmitter::SimulatedRuntimeConfig simulation;
+    simulation.trace_path = trace_path;
+    simulation.fail_startup_quiesce = true;
+    transmitter.selectBackend(wsprrypi::BackendKind::SIMULATED, {}, simulation);
+    set_startup_quiesce_invoker_for_test([&transmitter] {
+        return transmitter.quiesceForStartup();
+    });
+
+    auto cfg = cfg_for(EnableOnBootBehavior::Follow);
+    require(!run_startup_quiesce_gate_for_test(cfg),
+            "injected simulator failure must fail application gate");
+    require(startup_quiesce_inhibited_for_test(),
+            "injected simulator failure must latch inhibition");
+    require(startup_quiesce_error_for_test() ==
+                "Injected simulated startup quiesce failure.",
+            "injected simulator error must reach application gate");
+    require(start_non_wspr_transmission_now_for_test(cfg),
+            "inhibited application launch must return safely");
+    require(!current_controller_request_for_test().has_value(),
+            "inhibited application launch must not prepare a request");
+
+    const auto trace = read_file(trace_path);
+    require(trace.find("\"kind\":\"startup_quiesce_failure\"") !=
+                std::string::npos,
+            "application path must retain simulator failure trace");
+    require(trace.find("\"detail\":\"injected\"") != std::string::npos,
+            "application path must identify injected failure");
+}
+} // namespace
+
+int main()
+{
+    test_generic_startup_gate();
+    test_injected_simulator_failure_reaches_application_gate();
+    reset_startup_quiesce_for_test();
+    GPIOOutput::setTestMode(false);
+    set_scheduler_execution_suppressed_for_test(false);
+    std::cout << "startup_quiesce_parent_test passed\n";
+}


### PR DESCRIPTION
Related to #400.

Depends on WsprryPi/WSPR-Transmitter#21.

## Summary

- update the recorded transmitter revision for typed startup-quiescence fault injection
- verify the failure propagates through `WsprTransmitter` without arming execution cleanup
- exercise the actual simulator result through the application startup gate
- prove startup inhibition prevents request preparation after failure
- run and hardware-audit the parent startup-gate test in Debian CI
- document injection, trace, repetition, cleanup, and qualification boundaries

## Validation

- clean parent debug build
- parent semantics and cleanup lifecycle tests
- parent startup-quiescence gate test using the actual simulated backend
- simulator, controller, startup-quiescence, and bounded real-time transmitter tests
- RP1 and Si5351 non-hardware regressions
- deterministic QRSS and complete WSPR virtual-time checks
- guarded `strace` audit found no prohibited transmitter hardware access
- `git diff --check` in both repositories

This is software-contract evidence only. It does not qualify physical startup, hardware, services, scheduling accuracy, timing, or RF behavior.
