### PR TITLE
Document hardware-free development path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,30 @@ Never claim that hardware, RF output, GPIO timing, service lifecycle, or install
 
 Before any authorized live transmission, confirm the exact frequency, mode, duration, output path, attached hardware, and stopping procedure.
 
+## Hardware-Free Simulated Backend
+
+WsprryPi provides a canonical hardware-free simulated transmission backend for
+ordinary Debian development, automated tests, and CI. Read
+`docs/simulated-backend.md` before planning or running application-level
+transmission tests that do not require physical hardware.
+
+- Prefer the explicit `--backend simulated` selection when exercising the real
+  application planning, scheduling, cancellation, status, failure, and cleanup
+  paths without GPIO, MMIO, mailbox, DMA, I2C, transmitter device nodes, or RF.
+- Use `.github/workflows/debian-non-hardware.yml` as the checked-in reference
+  for the canonical unprivileged Debian validation suite.
+- Simulation must never be selected automatically because hardware is absent or
+  initialization fails, and it must not weaken safety policy for physical
+  backends.
+- Timing-mode selection, trace-path overrides, and lifecycle fault injection are
+  transient typed C++ test/developer APIs, not production CLI, INI, environment,
+  or UI controls. Additional shell-facing controls require a separately reviewed
+  developer-harness use case.
+- Simulator evidence qualifies software contracts only. It does not qualify
+  Raspberry Pi timing, GPIO, MMIO, DMA, mailbox, I2C electrical behavior,
+  Si5351 output, installation, services, RF output, frequency accuracy, or a
+  physical transmitter chain.
+
 ## Raspberry Pi Kernel Build Worker
 
 Maintainer kernel work can use the Debian ARM64 build worker prepared outside

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - [License](#license)
 - [Origins](#origins)
+- [Development and testing](#development-and-testing)
 - [Installation](#installation)
 
 ## License
@@ -27,6 +28,16 @@ After a conversation with Bruce Raymond of TAPR; I forked @threeme3's repo and p
 In late 2024, George [K9TRV] of TAPR reached out to me about some questions related to using WsprryPi on the Pi 5.  While I have not yet made that jump, the conversation spurred me to discard the original code in favor of a more modern, extensible, and maintainable base.
 
 Version 2.x+ is re-written from scratch, is no longer a derivative work, and is released under the MIT license.
+
+## Development and testing
+
+Developers can exercise WsprryPi's application planning, scheduling,
+cancellation, status, failure, and cleanup paths on an ordinary Debian machine
+without GPIO, MMIO, mailbox, DMA, I2C, transmitter device nodes, or RF hardware.
+See the [hardware-free simulated backend guide](docs/simulated-backend.md) for
+building, explicit selection, deterministic virtual-time traces, bounded
+real-time tests, fault injection, repeated execution, Debian CI, and the limits
+of simulation evidence.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- identify the simulated backend as the canonical hardware-free application-development path in `AGENTS.md`
- direct future agents to the simulator guide and Debian non-hardware workflow
- add a README development link for human discoverability
- preserve the distinction between software-contract evidence and hardware or RF qualification

Related to #400.

## Validation

- `git diff --check origin/devel...HEAD`
- documentation reference validation
- documentation-only diff review