### PR TITLE
Add mode-aware frequency qualification

### DIFF
--- a/config/wsprrypi.ini
+++ b/config/wsprrypi.ini
@@ -71,6 +71,14 @@ Use Shutdown = False
 Shutdown Button = 19
 
 
+[Experimental]
+; Advanced CLI/INI-only frequency policy. These settings do not grant legal
+; authority to transmit and are not shown in the Web UI.
+Allow Unqualified Frequency = false
+; Frequencies outside recognized amateur bands require both settings to be true.
+Allow Non-Amateur Frequency = false
+
+
 [Calibration]
 ; PPM:
 ; Frequency calibration in parts per million.

--- a/docs/research/issue-401-wspr2-gpio-requalification.md
+++ b/docs/research/issue-401-wspr2-gpio-requalification.md
@@ -1,0 +1,96 @@
+# Issue 401: wspr2 legacy GPIO requalification
+
+Date: 2026-08-14
+
+## Outcome
+
+The current Issue 401 build was exercised on `wspr2`, a Raspberry Pi Zero 2 W
+using the legacy 500 MHz PLLD GPIO backend. The conducted carrier evidence
+passes the coalesced-carrier prerequisite on 2200 m and 12 m for this recorded
+hardware and source combination. Neither band passed the separate WSPR gate,
+which requires three consecutive correct decodes. Mode-specific keyed or
+multitone evidence remains separate from this carrier requalification.
+
+The higher-frequency candidates did not pass the carrier prerequisite. No WSPR
+frames were transmitted for those bands.
+
+| Band | Requested frequency | Carrier result | WSPR result | Issue 401 disposition |
+|---|---:|---|---|---|
+| 2200 m | 137,500 Hz | Pass: -1.526 Hz offset; 99.8855% best-20-Hz share | 1 maximum consecutive correct decode of 3 required | Carrier prerequisite passed; WSPR unqualified |
+| 12 m | 24,926,100 Hz | Pass: -31.090 Hz offset; 99.9944% best-20-Hz share | 1 maximum consecutive correct decode of 3 required | Carrier prerequisite passed; WSPR unqualified |
+| 6 m | 50,294,500 Hz | Fail: -28,177.834 Hz offset; 0.1817% best-20-Hz share | Suppressed | Unqualified |
+| 4 m | 70,092,500 Hz | Fail: +16,523.743 Hz offset; 0.2899% best-20-Hz share | Suppressed | Unqualified |
+| 2 m | 144,490,500 Hz | Fail: +14,951.134 Hz offset; 0.5146% best-20-Hz share | Suppressed | Unqualified |
+| 1.25 m | 222,101,500 Hz | Fail: -830.269 Hz offset; 1.0872% best-20-Hz share | Suppressed | Unqualified |
+| 70 cm | 432,301,500 Hz | Fail: +62,674.904 Hz offset; 3.2870% best-20-Hz share | Suppressed | Unqualified |
+
+Passing carrier evidence establishes a coalesced continuous tone and the
+carrier prerequisite used by CW-family review. It does not independently
+qualify QRSS keying or the wider tone spacing and transitions used by FSKCW and
+DFCW. It is not a WSPR qualification and does not establish calibrated power,
+harmonic suppression, occupied bandwidth, or regulatory compliance.
+
+## WSPR evidence
+
+The 2200 m and 12 m carrier gates passed before their WSPR runs. Each retained
+coherent capture contained exactly 92,500,000 CF32 samples at 250,000 samples
+per second, with zero overflow and zero clipped samples. Each covered three
+planned consecutive UTC slots.
+
+- 2200 m slots: 21:20, 21:22, and 21:24 UTC. Maximum consecutive correct
+  decodes: 1.
+- 12 m slots: 21:44, 21:46, and 21:48 UTC. Maximum consecutive correct
+  decodes: 1.
+
+One correct decode demonstrates that a frame was receivable; it does not meet
+the three-consecutive-decode qualification contract. Both bands therefore
+remain WSPR-unqualified.
+
+## Source and bench binding
+
+- WsprryPi source: `5109d24d39a4f832d31865014e1bfdee21249dd6`
+- WSPR-Transmitter source: `332a318417c9e92f5137f6254647a6e656826e02`
+- Transmitter: `wspr2`, Raspberry Pi Zero 2 W, GPIO4
+- Clock profile: legacy 500 MHz PLLD
+- Receiver: SDRplay RSP1B serial `2404058C60` on `wspr5`
+- Capture format: CF32, 250 ksps, 200 kHz bandwidth, fixed 10 dB gain
+- RF path: direct conducted connection with two inline 10 dB attenuators;
+  relative measurements only
+
+The direct numeric `0.136` command path exposed a separate input-resolution
+defect during testing: one form incorrectly required the non-amateur override,
+and the fully overridden form reached the selector as 0 Hz. The canonical
+`2200m` selector emitted 137.500 kHz and was used for the authoritative run.
+This CLI defect does not invalidate the canonical-selector RF evidence and is
+not corrected by this research record.
+
+## Evidence integrity
+
+The immutable working evidence is retained externally on `wspr5` at:
+
+```text
+/home/pi/issue401-wspr2-gpio-wspr-requalification-20260814
+```
+
+Its `SHA256SUMS` manifest covers 139 retained artifacts and verified without an
+error after finalization. The manifest SHA-256 is:
+
+```text
+1bba1df26d9e1f2a71936c8f511a9674e0e9308eae3622cf085776626456f117
+```
+
+The bundle retains superseded inconclusive analyses and interrupted-run
+artifacts for audit history. The authoritative carrier analyses use the `-v2`
+suffix. The final WSPR decisions are in
+`2200m-v4-decode-summary.json` and `12m-wspr-decode-summary.json`.
+
+## Qualification boundary
+
+This record applies only to the recorded legacy GPIO hardware, source
+revisions, frequencies, receiver, and conducted path. It does not qualify
+BCM2711 GPIO, RP1 GPIO, Si5351, another PLL profile, another receiver path, or
+another WsprryPi revision.
+
+The separately acquired wspr4 bundle failed known-frequency controls and is
+classified as fixture/path-invalid. It is intentionally excluded from this
+wspr2 result and makes no change to existing wspr4 qualification status.

--- a/docs/research/issue-401-wspr2-gpio-requalification.md
+++ b/docs/research/issue-401-wspr2-gpio-requalification.md
@@ -24,6 +24,11 @@ frames were transmitted for those bands.
 | 1.25 m | 222,101,500 Hz | Fail: -830.269 Hz offset; 1.0872% best-20-Hz share | Suppressed | Unqualified |
 | 70 cm | 432,301,500 Hz | Fail: +62,674.904 Hz offset; 3.2870% best-20-Hz share | Suppressed | Unqualified |
 
+The resulting legacy 500 MHz PLLD policy on 2200 m qualifies TONE from the
+passing carrier evidence. QRSS, FSKCW, and DFCW remain untested and fail closed
+without the explicit experimental override. WSPR remains unqualified after the
+completed decode attempts.
+
 Passing carrier evidence establishes a coalesced continuous tone and the
 carrier prerequisite used by CW-family review. It does not independently
 qualify QRSS keying or the wider tone spacing and transitions used by FSKCW and

--- a/docs/research/issue-401-wspr2-gpio-requalification.md
+++ b/docs/research/issue-401-wspr2-gpio-requalification.md
@@ -1,6 +1,6 @@
 # Issue 401: wspr2 legacy GPIO requalification
 
-Date: 2026-08-14
+Date: 2026-08-14; follow-up WSPR run: 2026-08-16 UTC
 
 ## Outcome
 
@@ -46,6 +46,18 @@ One correct decode demonstrates that a frame was receivable; it does not meet
 the three-consecutive-decode qualification contract. Both bands therefore
 remain WSPR-unqualified.
 
+### 2200 m follow-up
+
+A follow-up 2200 m run on 2026-08-16 UTC first repeated the conducted carrier
+control. The control passed at -1.526 Hz offset with 99.9643% of resolved
+transmitter-added power in the best 20 Hz. The subsequent coherent capture
+contained exactly 92,500,000 CF32 samples at 250,000 samples per second, with
+zero overflow and zero clipped samples, and covered the 01:08, 01:10, and
+01:12 UTC slots. All three transmissions completed, but none decoded as the
+expected `AA0NT EM18 20` message. This follow-up result is 0 of 3; combined
+with the earlier evidence, the maximum consecutive correct decode count
+remains 1 of the 3 required. WSPR therefore remains unqualified.
+
 ## Source and bench binding
 
 - WsprryPi source: `5109d24d39a4f832d31865014e1bfdee21249dd6`
@@ -83,6 +95,22 @@ The bundle retains superseded inconclusive analyses and interrupted-run
 artifacts for audit history. The authoritative carrier analyses use the `-v2`
 suffix. The final WSPR decisions are in
 `2200m-v4-decode-summary.json` and `12m-wspr-decode-summary.json`.
+
+The follow-up evidence is retained externally on `wspr5` at:
+
+```text
+/home/pi/issue401-legacy-2200m-completion-20260816T0110Z
+```
+
+Its verified `SHA256SUMS` manifest has SHA-256:
+
+```text
+a339fed370c8bcbdad2067f259e7f636e32cfba3f946b1b5f584f0f4e26daf22
+```
+
+The authoritative follow-up decode decision is
+`wspr/decode-summary-final.json`. The retained IQ capture SHA-256 is
+`2bab8e00f78459ee4619b56d00b903111faa8d72c7f8939d25feeb9d77726f86`.
 
 ## Qualification boundary
 

--- a/docs/research/issue-401-wspr2-gpio-requalification.md
+++ b/docs/research/issue-401-wspr2-gpio-requalification.md
@@ -81,6 +81,20 @@ and the fully overridden form reached the selector as 0 Hz. The canonical
 This CLI defect does not invalidate the canonical-selector RF evidence and is
 not corrected by this research record.
 
+## Si5351 2200 m qualification
+
+On 2026-08-16, the Si5351 backend completed the separate 2200 m qualification
+on a Raspberry Pi 5 using CLK0, minimum 2 mA drive, a 27 MHz external TCXO, and
+an SDRplay RSP1B receiver. Opening and closing 160 m carrier controls passed.
+The 137,500 Hz carrier was measured at +0.381 Hz from the request, and three
+consecutive WSPR frames decoded `AA0NT EM18 20` at the requested frequency.
+QRSS, FSKCW, and DFCW each passed three independently captured `TEST`
+repetitions. FSKCW retained continuous RF with 5.001 Hz tone separation; DFCW
+used distinct dot and dash tones separated by approximately 5.08 Hz. Every
+credited capture completed without receiver overflow, and CLK0 was disabled
+after each run. The retained evidence is stored on the qualification host at
+`/home/pi/issue401-si5351-2200m-current-20260816T125941Z`.
+
 ## Evidence integrity
 
 The immutable working evidence is retained externally on `wspr5` at:

--- a/docs/research/issue-401-wspr2-gpio-requalification.md
+++ b/docs/research/issue-401-wspr2-gpio-requalification.md
@@ -74,12 +74,15 @@ remains 1 of the 3 required. WSPR therefore remains unqualified.
 - RF path: direct conducted connection with two inline 10 dB attenuators;
   relative measurements only
 
-The direct numeric `0.136` command path exposed a separate input-resolution
-defect during testing: one form incorrectly required the non-amateur override,
-and the fully overridden form reached the selector as 0 Hz. The canonical
-`2200m` selector emitted 137.500 kHz and was used for the authoritative run.
-This CLI defect does not invalidate the canonical-selector RF evidence and is
-not corrected by this research record.
+The bare numeric `0.136` command used during testing correctly meant 0.136 Hz,
+not 0.136 MHz, so the non-amateur-frequency rejection was expected. It also
+exposed inconsistent fractional-Hz validation: the direct test-tone path
+accepted 0.136 Hz before integer-only band correlation and diagnostic rendering
+reported it as 0 Hz. The CLI now rejects values that do not resolve to
+whole-number hertz at the input boundary. Use an explicit unit such as
+`0.136MHz`, an integral value such as `136000`, or the canonical `2200m`
+selector. The authoritative run used `2200m` and emitted 137.500 kHz, so this
+input-validation correction does not alter the RF evidence.
 
 ## Si5351 2200 m qualification
 

--- a/docs/research/issue-401-wspr2-gpio-requalification.md
+++ b/docs/research/issue-401-wspr2-gpio-requalification.md
@@ -24,10 +24,8 @@ frames were transmitted for those bands.
 | 1.25 m | 222,101,500 Hz | Fail: -830.269 Hz offset; 1.0872% best-20-Hz share | Suppressed | Unqualified |
 | 70 cm | 432,301,500 Hz | Fail: +62,674.904 Hz offset; 3.2870% best-20-Hz share | Suppressed | Unqualified |
 
-The resulting legacy 500 MHz PLLD policy on 2200 m qualifies TONE from the
-passing carrier evidence. QRSS, FSKCW, and DFCW remain untested and fail closed
-without the explicit experimental override. WSPR remains unqualified after the
-completed decode attempts.
+The resulting legacy 500 MHz PLLD policy on 2200 m qualifies TONE, QRSS,
+FSKCW, and DFCW. WSPR remains unqualified after the completed decode attempts.
 
 Passing carrier evidence establishes a coalesced continuous tone and the
 carrier prerequisite used by CW-family review. It does not independently
@@ -80,9 +78,31 @@ exposed inconsistent fractional-Hz validation: the direct test-tone path
 accepted 0.136 Hz before integer-only band correlation and diagnostic rendering
 reported it as 0 Hz. The CLI now rejects values that do not resolve to
 whole-number hertz at the input boundary. Use an explicit unit such as
-`0.136MHz`, an integral value such as `136000`, or the canonical `2200m`
-selector. The authoritative run used `2200m` and emitted 137.500 kHz, so this
-input-validation correction does not alter the RF evidence.
+`0.136MHz` or an integral value such as `136000`. The `2200m` band alias is the
+136,000 Hz WSPR dial frequency; direct `--test-tone 2200m` therefore emits
+136,000 Hz rather than the 137,500 Hz qualification carrier. Use explicit
+`137500Hz` when that RF carrier is intended. This distinction does not alter
+the input-validation correction or the RF evidence.
+
+## Legacy GPIO keyed-mode completion
+
+On 2026-08-16, the exact candidate at WsprryPi `7fcc749` and
+WSPR-Transmitter `22faff5` completed the remaining legacy 500 MHz PLLD tests on
+`wspr2`. Opening and closing 137,500 Hz carrier controls passed at +0.381 Hz;
+their best-20-Hz resolved-power shares were 78.70% and 79.96%.
+
+QRSS, FSKCW, and DFCW each passed three independently captured `TEST`
+repetitions using one-second dots. QRSS reproduced the complete keyed message
+envelope. FSKCW retained continuous RF with 5.007 Hz tone separation in all
+three repetitions. DFCW used distinct dot and dash tones separated by 4.947,
+5.066, and 5.186 Hz. Every credited keyed capture contained 10,625,000 CF32
+samples with verified GPIO4 cleanup after the application exited.
+
+A new bounded WSPR attempt retained exactly 92,500,000 CF32 samples at 250,000
+samples per second with zero overflow and zero clipping. All three transmissions
+completed in the 15:00, 15:02, and 15:04 UTC slots, but none decoded as
+`AA0NT EM18 20`. WSPR therefore remains unqualified; the maximum consecutive
+correct decode count across the recorded attempts remains one.
 
 ## Si5351 2200 m qualification
 
@@ -133,6 +153,17 @@ a339fed370c8bcbdad2067f259e7f636e32cfba3f946b1b5f584f0f4e26daf22
 The authoritative follow-up decode decision is
 `wspr/decode-summary-final.json`. The retained IQ capture SHA-256 is
 `2bab8e00f78459ee4619b56d00b903111faa8d72c7f8939d25feeb9d77726f86`.
+
+The keyed-mode completion evidence is retained externally on `wspr5` at:
+
+```text
+/home/pi/issue401-wspr2-legacy-2200m-keyed-20260816T1430Z
+```
+
+The authoritative keyed-mode analyses use the `analysis-v2.json` suffix. The
+valid WSPR decision is `wspr-v2/decode-summary.json`; the earlier `wspr`
+directory is retained as an incomplete orchestration attempt and is not
+qualification evidence.
 
 ## Qualification boundary
 

--- a/docs/research/issue-401-wspr4-gpio-requalification.md
+++ b/docs/research/issue-401-wspr4-gpio-requalification.md
@@ -12,7 +12,7 @@ the fresh 20 m control from +152.969 Hz to +13.733 Hz. The closing control was
 | Band | TONE carrier result | QRSS | FSKCW/DFCW | WSPR | Disposition |
 |---|---|---|---|---|---|
 | 12 m | Failed: -17,131.424 Hz; 11.03% best-20-Hz share | Suppressed | Suppressed | Suppressed | Unqualified |
-| 6 m | Passed 3/3: +63.324, +58.556, and +59.509 Hz; minimum 58.32% share | Qualified: 3/3 keyed repetitions | FSKCW qualified: 3/3 shifted-tone repetitions; DFCW unqualified after its closing carrier control failed | Failed: 2 consecutive correct decodes of 3 required | Partial; TONE, QRSS, and FSKCW |
+| 6 m | Passed 3/3: +63.324, +58.556, and +59.509 Hz; minimum 58.32% share | Qualified: 3/3 keyed repetitions | FSKCW and DFCW qualified: 3/3 shifted-tone repetitions each | Failed: 2 consecutive correct decodes of 3 required | Partial; all CW-family modes qualified |
 | 4 m | Failed: +2,146.149 Hz; 0.0515% share | Suppressed | Suppressed | Suppressed | Unqualified |
 | 2 m | Failed: -51,022.148 Hz; 0.0593% share | Suppressed | Suppressed | Suppressed | Unqualified |
 | 1.25 m | Planner rejected before RF | Unavailable | Unavailable | Unavailable | Unavailable |
@@ -24,8 +24,7 @@ the sole questionable band whose carrier prerequisite passed.
 
 A coalesced continuous tone qualifies TONE; it does not by itself qualify a
 keyed or shifted mode. Follow-up acquired-IQ testing independently qualified
-QRSS and FSKCW on 6 m. DFCW remains unqualified because the final control after
-its corrective captures exceeded the ±100 Hz carrier-offset gate.
+QRSS, FSKCW, and DFCW on 6 m.
 
 ## 6 m keyed-mode follow-up
 
@@ -42,7 +41,15 @@ best-20-Hz share. The control bracketing QRSS and FSKCW closed at +95.749 Hz
 and 89.37% share. Corrective DFCW `AA AA` captures showed the expected timing,
 gaps, and 5 Hz separation, but their final control failed at +107.193 Hz. A
 post-cooldown replacement opening control also failed at +109.100 Hz, so no
-further DFCW candidate run was permitted and no DFCW qualification is claimed.
+further DFCW candidate run was permitted in that session.
+
+A separate DFCW retest recalibrated the transient correction from 10.8511 to
+13.0013 PPM after a +108.147 Hz control failure. The replacement opening and
+closing controls both passed at -19.646 Hz, with 83.18% and 84.05% best-20-Hz
+share. Three accepted `AA AA` repetitions passed timing, RF-off gap, transition,
+carrier-offset, clipping, overflow, and spacing gates. Their median local
+dot/dash separations were 5.158, 4.813, and 5.788 Hz. DFCW is therefore
+qualified on the recorded 6 m BCM2711 path.
 
 The keyed follow-up used WsprryPi revision
 `71bef1d4b38d3810cab974bd3ddcd1928dd1a273` and WSPR-Transmitter revision
@@ -104,6 +111,11 @@ failed-attempt records, and the manifest. The verified `SHA256SUMS` file has
 SHA-256 `3cab95700bab6c0d99fa3c61f7333474620c581993952a487a3de1732fa74c72`.
 The audit excludes scheduled-mode idle attempts, overlapping capture failures,
 and DFCW captures that were not bracketed by a passing closing control.
+
+The superseding DFCW evidence is retained at
+`/home/pi/issue401-wspr4-6m-dfcw-retest-20260815`. Its 45-artifact manifest
+verified without error and has SHA-256
+`3fdbf0f1625f1b5e66e65b1db2deff49c5a8fbeabd8baa6dd820223cb48a040c`.
 
 ## Qualification boundary
 

--- a/docs/research/issue-401-wspr4-gpio-requalification.md
+++ b/docs/research/issue-401-wspr4-gpio-requalification.md
@@ -63,6 +63,19 @@ samples per second, with zero overflow and zero clipped samples. Independent
 frame did not decode, leaving a maximum of two consecutive correct decodes and
 failing the three-consecutive-decode gate.
 
+A second three-frame WSPR retest used the uninstalled build at WsprryPi
+revision `b7240c84747ad01d5c15e32ae77c84caf4e3c7d2`, WSPR-Transmitter revision
+`c416e0f4de608164a10d7f0fe2f5adf6f5b911ce`, and a 13.0013 PPM correction.
+Its opening and closing carrier controls passed at -53.024 Hz with 97.90%
+best-20-Hz share and -38.719 Hz with 95.01% share. The first WSPR frame did not
+decode; the second and third decoded `AA0NT EM18 20` at +12 dB and +11 dB.
+The maximum remained two consecutive correct decodes, so 6 m WSPR remains
+unqualified while the backend-band disposition remains Partial.
+
+The repeat capture contained exactly 92,500,000 CF32 samples with zero overflow
+and zero clipping. The transmitter exited normally after the configured three
+iterations, and GPIO4 returned to input.
+
 ## Source and bench binding
 
 - WsprryPi source under test: `854b39d37433c5b98d4ed43784f0b9819cf6143e`
@@ -116,6 +129,14 @@ The superseding DFCW evidence is retained at
 `/home/pi/issue401-wspr4-6m-dfcw-retest-20260815`. Its 45-artifact manifest
 verified without error and has SHA-256
 `3fdbf0f1625f1b5e66e65b1db2deff49c5a8fbeabd8baa6dd820223cb48a040c`.
+
+The second WSPR retest evidence is retained at
+`/home/pi/issue401-wspr4-6m-wspr-retest-20260816T043428Z` on `wspr5`. Its
+48-artifact manifest verified without error and has SHA-256
+`55f100b5be9a53c5becdedf9f9b548cdd06995edcfe51313e2062841cd185b71`.
+The opening and closing carrier gates passed, making the two-decode result
+authoritative rather than path-invalid. The compiled binary was run directly
+from the build tree and was not installed.
 
 ## Qualification boundary
 

--- a/docs/research/issue-401-wspr4-gpio-requalification.md
+++ b/docs/research/issue-401-wspr4-gpio-requalification.md
@@ -12,7 +12,7 @@ the fresh 20 m control from +152.969 Hz to +13.733 Hz. The closing control was
 | Band | TONE carrier result | QRSS | FSKCW/DFCW | WSPR | Disposition |
 |---|---|---|---|---|---|
 | 12 m | Failed: -17,131.424 Hz; 11.03% best-20-Hz share | Suppressed | Suppressed | Suppressed | Unqualified |
-| 6 m | Passed 3/3: +63.324, +58.556, and +59.509 Hz; minimum 58.32% share | Untested | Untested | Failed: 2 consecutive correct decodes of 3 required | Partial; TONE only |
+| 6 m | Passed 3/3: +63.324, +58.556, and +59.509 Hz; minimum 58.32% share | Qualified: 3/3 keyed repetitions | FSKCW qualified: 3/3 shifted-tone repetitions; DFCW unqualified after its closing carrier control failed | Failed: 2 consecutive correct decodes of 3 required | Partial; TONE, QRSS, and FSKCW |
 | 4 m | Failed: +2,146.149 Hz; 0.0515% share | Suppressed | Suppressed | Suppressed | Unqualified |
 | 2 m | Failed: -51,022.148 Hz; 0.0593% share | Suppressed | Suppressed | Suppressed | Unqualified |
 | 1.25 m | Planner rejected before RF | Unavailable | Unavailable | Unavailable | Unavailable |
@@ -22,10 +22,31 @@ Each carrier analysis used the formal ±100 Hz and 50% best-20-Hz share gates.
 Every analyzed pair had zero clipped samples. WSPR was attempted only on 6 m,
 the sole questionable band whose carrier prerequisite passed.
 
-A coalesced continuous tone qualifies TONE. It does not qualify QRSS keying or
-the wider tone spacing and transitions used by FSKCW and DFCW. The maintained
-qualification harness does not yet produce positive live keyed-mode evidence,
-so those three modes remain untested on 6 m.
+A coalesced continuous tone qualifies TONE; it does not by itself qualify a
+keyed or shifted mode. Follow-up acquired-IQ testing independently qualified
+QRSS and FSKCW on 6 m. DFCW remains unqualified because the final control after
+its corrective captures exceeded the ±100 Hz carrier-offset gate.
+
+## 6 m keyed-mode follow-up
+
+Three QRSS `AE T` repetitions reproduced the expected dots, dashes, element
+gaps, character gaps, and word gap with at least 99.94% template agreement.
+Three FSKCW `AE T` repetitions kept RF active and shifted at every expected
+transition. Their median local mark/space separations were 4.574, 5.047, and
+5.007 Hz; all 18 transitions moved in the commanded direction. Every retained
+positive capture contained exactly 7,500,000 CF32 samples with zero clipping
+and zero overflow.
+
+The keyed session opened with a passing 6 m control at +74.768 Hz and 86.32%
+best-20-Hz share. The control bracketing QRSS and FSKCW closed at +95.749 Hz
+and 89.37% share. Corrective DFCW `AA AA` captures showed the expected timing,
+gaps, and 5 Hz separation, but their final control failed at +107.193 Hz. A
+post-cooldown replacement opening control also failed at +109.100 Hz, so no
+further DFCW candidate run was permitted and no DFCW qualification is claimed.
+
+The keyed follow-up used WsprryPi revision
+`71bef1d4b38d3810cab974bd3ddcd1928dd1a273` and WSPR-Transmitter revision
+`b80766cb1841f43bbc3a2bb5220a0f31337c54fd`.
 
 ## WSPR evidence
 
@@ -71,6 +92,18 @@ reclassified as path failures. Planner rejection before RF is recorded as
 Unavailable rather than as a failed transmission, and experimental overrides
 must not bypass it. Each bounded run returned GPIO4 to input; after the session
 the wspr4 service was inactive and no transmitter process remained.
+
+The keyed-mode follow-up evidence is retained at:
+
+```text
+/home/pi/issue401-wspr4-6m-keyed-qualification-20260815
+```
+
+Its 124 artifacts include raw IQ, capture metadata, analyses, plans, logs,
+failed-attempt records, and the manifest. The verified `SHA256SUMS` file has
+SHA-256 `3cab95700bab6c0d99fa3c61f7333474620c581993952a487a3de1732fa74c72`.
+The audit excludes scheduled-mode idle attempts, overlapping capture failures,
+and DFCW captures that were not bracketed by a passing closing control.
 
 ## Qualification boundary
 

--- a/docs/research/issue-401-wspr4-gpio-requalification.md
+++ b/docs/research/issue-401-wspr4-gpio-requalification.md
@@ -1,0 +1,80 @@
+# Issue 401: wspr4 BCM2711 GPIO requalification
+
+Date: 2026-08-15
+
+## Outcome
+
+The current Issue 401 build was exercised on `wspr4`, a Raspberry Pi 4 using
+the BCM2711 750 MHz PLLD GPIO backend. A manual correction of 10.8511 PPM moved
+the fresh 20 m control from +152.969 Hz to +13.733 Hz. The closing control was
++12.779 Hz, confirming that the conducted receive path remained valid.
+
+| Band | TONE carrier result | QRSS | FSKCW/DFCW | WSPR | Disposition |
+|---|---|---|---|---|---|
+| 12 m | Failed: -17,131.424 Hz; 11.03% best-20-Hz share | Suppressed | Suppressed | Suppressed | Unqualified |
+| 6 m | Passed 3/3: +63.324, +58.556, and +59.509 Hz; minimum 58.32% share | Untested | Untested | Failed: 2 consecutive correct decodes of 3 required | Partial; TONE only |
+| 4 m | Failed: +2,146.149 Hz; 0.0515% share | Suppressed | Suppressed | Suppressed | Unqualified |
+| 2 m | Failed: -51,022.148 Hz; 0.0593% share | Suppressed | Suppressed | Suppressed | Unqualified |
+| 1.25 m | Planner rejected before RF | Unavailable | Unavailable | Unavailable | Unavailable |
+| 70 cm | Planner rejected before RF | Unavailable | Unavailable | Unavailable | Unavailable |
+
+Each carrier analysis used the formal ±100 Hz and 50% best-20-Hz share gates.
+Every analyzed pair had zero clipped samples. WSPR was attempted only on 6 m,
+the sole questionable band whose carrier prerequisite passed.
+
+A coalesced continuous tone qualifies TONE. It does not qualify QRSS keying or
+the wider tone spacing and transitions used by FSKCW and DFCW. The maintained
+qualification harness does not yet produce positive live keyed-mode evidence,
+so those three modes remain untested on 6 m.
+
+## WSPR evidence
+
+The retained 6 m capture contains exactly 92,500,000 CF32 samples at 250,000
+samples per second, with zero overflow and zero clipped samples. Independent
+`wsprd` processing correctly decoded the 23:40 and 23:42 UTC frames. The 23:44
+frame did not decode, leaving a maximum of two consecutive correct decodes and
+failing the three-consecutive-decode gate.
+
+## Source and bench binding
+
+- WsprryPi source under test: `854b39d37433c5b98d4ed43784f0b9819cf6143e`
+- WSPR-Transmitter source under test: `332a318417c9e92f5137f6254647a6e656826e02`
+- Transmitter: `wspr4`, Raspberry Pi 4, GPIO4, 750 MHz PLLD
+- Receiver: SDRplay RSP1B serial `2404058C60` on `wspr5`
+- Capture: CF32, 250 ksps, 200 kHz bandwidth, fixed 10 dB gain
+- RF path: conducted connection with two inline 10 dB attenuators
+- Correction: `--gpio-manual-ppm 10.8511`
+
+These are relative captured-span measurements. They do not establish absolute
+power, harmonic suppression, occupied bandwidth, or regulatory compliance.
+
+## Evidence integrity and adversarial review
+
+The immutable working evidence is retained on `wspr5` at:
+
+```text
+/home/pi/issue401-wspr4-gpio-qualification-20260815
+```
+
+Its 111-entry `SHA256SUMS` manifest verified without error. The manifest
+SHA-256 is:
+
+```text
+c71cc19d8dee1bea870f602768351168ec8a448a6572f34b6a6bbfb22931f5dd
+```
+
+The earlier directory
+`/home/pi/issue401-wspr4-gpio-wspr-requalification-20260814` remains
+path-invalid and contributes no qualification claim. The fresh session is
+bracketed by passing 20 m controls, so its candidate failures are not
+reclassified as path failures. Planner rejection before RF is recorded as
+Unavailable rather than as a failed transmission, and experimental overrides
+must not bypass it. Each bounded run returned GPIO4 to input; after the session
+the wspr4 service was inactive and no transmitter process remained.
+
+## Qualification boundary
+
+This record applies only to the recorded BCM2711 GPIO hardware, source
+revisions, correction, frequencies, receiver, and conducted path. It does not
+qualify the legacy 500 MHz PLLD profile, RP1 GPIO, Si5351, another receiver
+path, or another WsprryPi revision.

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1391,6 +1391,12 @@ void print_usage(const std::string &message, int exit_code)
               << "  -D, --date-time-log                Prefix stream log output with date/time stamps.\n"
               << "  --debug-logging, --no-debug-logging\n"
               << "                                     Enable or disable DEBUG-level application logging.\n\n"
+              << "Experimental Frequency Policy (CLI/INI only):\n"
+              << "  --allow-unqualified-frequency, --no-allow-unqualified-frequency\n"
+              << "                                     Allow or deny unqualified backend/mode combinations.\n"
+              << "  --allow-non-amateur-frequency, --no-allow-non-amateur-frequency\n"
+              << "                                     Allow or deny frequencies outside recognized amateur bands.\n"
+              << "                                     Outside-band transmission requires both allow flags.\n\n"
               << "WSPR Identity And Frequency:\n"
               << "  Positional CALLSIGN GRID POWER FREQ [FREQ...]\n"
               << "                                     Transmit WSPR directly from CLI. POWER is rounded to a standard WSPR dBm value.\n"
@@ -3032,6 +3038,10 @@ bool parse_command_line(int argc, char *argv[])
         {"date-time-log", no_argument, nullptr, 'D'},   // Global: config.date_time_log
         {"debug-logging", no_argument, nullptr, 1018},  // Global: config.debug_logging
         {"no-debug-logging", no_argument, nullptr, 1019},
+        {"allow-unqualified-frequency", no_argument, nullptr, 1056},
+        {"no-allow-unqualified-frequency", no_argument, nullptr, 1057},
+        {"allow-non-amateur-frequency", no_argument, nullptr, 1058},
+        {"no-allow-non-amateur-frequency", no_argument, nullptr, 1059},
         {"no-web", no_argument, nullptr, 1020},
         {"no-offset", no_argument, nullptr, 1021},
         {"no-system-clock-frequency-estimate", no_argument, nullptr, 1022},
@@ -3168,6 +3178,26 @@ bool parse_command_line(int argc, char *argv[])
         case 1019:
         {
             config.debug_logging = false;
+            break;
+        }
+        case 1056:
+        {
+            config.allow_unqualified_frequency = true;
+            break;
+        }
+        case 1057:
+        {
+            config.allow_unqualified_frequency = false;
+            break;
+        }
+        case 1058:
+        {
+            config.allow_non_amateur_frequency = true;
+            break;
+        }
+        case 1059:
+        {
+            config.allow_non_amateur_frequency = false;
             break;
         }
         case 1020:

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -1531,6 +1531,7 @@ void print_usage(const std::string &message, int exit_code)
               << "  Band GPIO                          Configure per-band selector GPIOs in INI or with FREQ @GPIO suffixes.\n\n"
               << "Test Tone:\n"
               << "  -t, --test-tone <rf_frequency>     Start a transient direct RF test tone using whole-number Hz or a unit-qualified value.\n"
+              << "                                     Band aliases resolve to their WSPR dial frequency; use an explicit value for another RF carrier.\n"
               << "                                     Invalid with --ini-file.\n\n";
 
     // Handle exit behavior

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -760,6 +760,53 @@ static double parse_frequency_hz_option(
     return rounded;
 }
 
+static bool validate_cli_frequency_hz(
+    double frequency_hz,
+    bool allow_zero,
+    const std::string &raw_token,
+    const std::string &context,
+    std::string *error_message)
+{
+    const bool valid_sign = allow_zero ? frequency_hz >= 0.0 : frequency_hz > 0.0;
+    if (!std::isfinite(frequency_hz) || !valid_sign)
+    {
+        if (error_message != nullptr)
+        {
+            *error_message =
+                "Invalid " + context + " frequency '" + raw_token +
+                "': expected " + (allow_zero ? "zero or " : "") +
+                "a positive whole-number frequency in Hz.";
+        }
+        return false;
+    }
+
+    if (std::trunc(frequency_hz) != frequency_hz)
+    {
+        if (error_message != nullptr)
+        {
+            *error_message =
+                "Invalid " + context + " frequency '" + raw_token +
+                "': the value must resolve to a whole-number frequency in Hz. "
+                "Use an Hz, kHz, MHz, or GHz suffix for decimal unit values.";
+        }
+        return false;
+    }
+
+    const double signed_hz_exclusive_upper_bound = std::ldexp(1.0, 63);
+    if (frequency_hz >= signed_hz_exclusive_upper_bound)
+    {
+        if (error_message != nullptr)
+        {
+            *error_message =
+                "Invalid " + context + " frequency '" + raw_token +
+                "': the value is outside the supported RF range.";
+        }
+        return false;
+    }
+
+    return true;
+}
+
 static ModeType parse_mode_option(const char *raw_value)
 {
     std::string value = trim_copy_string(raw_value == nullptr ? "" : raw_value);
@@ -1015,12 +1062,13 @@ bool set_direct_tone_startup_request(
     {
         const double actual_rf_frequency_hz =
             lookup.parse_string_to_frequency(entry.token, false);
-        if (actual_rf_frequency_hz <= 0.0)
+        if (!validate_cli_frequency_hz(
+                actual_rf_frequency_hz,
+                false,
+                entry.token,
+                "direct RF test tone",
+                error_message))
         {
-            if (error_message != nullptr)
-            {
-                *error_message = "Invalid direct RF test tone frequency (<=0).";
-            }
             return false;
         }
 
@@ -1400,7 +1448,7 @@ void print_usage(const std::string &message, int exit_code)
               << "WSPR Identity And Frequency:\n"
               << "  Positional CALLSIGN GRID POWER FREQ [FREQ...]\n"
               << "                                     Transmit WSPR directly from CLI. POWER is rounded to a standard WSPR dBm value.\n"
-              << "  FREQ                               Band aliases such as 20m, numeric dial frequencies, or 0 to skip a slot.\n"
+              << "  FREQ                               Band aliases such as 20m; whole-number-Hz or unit-qualified dial frequencies; or 0 to skip.\n"
               << "                                     Append @GPIO, @GPIOH, or @GPIOL for one-slot selector GPIO overrides.\n"
               << "  --planner-preference <auto|prefer_paired|require_paired>\n"
               << "                                     Select single-frame or paired WSPR planning policy.\n"
@@ -1482,7 +1530,8 @@ void print_usage(const std::string &message, int exit_code)
               << "      --use-shutdown, --no-shutdown  Enable or disable shutdown button monitoring.\n"
               << "  Band GPIO                          Configure per-band selector GPIOs in INI or with FREQ @GPIO suffixes.\n\n"
               << "Test Tone:\n"
-              << "  -t, --test-tone <rf_frequency>     Start a transient direct RF test tone. Invalid with --ini-file.\n\n";
+              << "  -t, --test-tone <rf_frequency>     Start a transient direct RF test tone using whole-number Hz or a unit-qualified value.\n"
+              << "                                     Invalid with --ini-file.\n\n";
 
     // Handle exit behavior
     switch (exit_code)
@@ -2738,6 +2787,17 @@ bool set_frequencies(ArgParserConfig &target)
         try
         {
             const double freq = lookup.parse_string_to_frequency(entry.token, false);
+            std::string frequency_error;
+            if (!validate_cli_frequency_hz(
+                    freq,
+                    true,
+                    entry.token,
+                    "WSPR dial",
+                    &frequency_error))
+            {
+                llog.logE(WARN, frequency_error);
+                continue;
+            }
             entry.dial_frequency_hz = freq;
             entry.allow_band_gpio_fallback =
                 entry.selector_gpio == kSelectorGpioUnset;

--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -70,6 +70,8 @@ namespace
     {
         TestTonePlanningConfigSnapshot snapshot;
         snapshot.transmit_backend = source.transmit_backend;
+        snapshot.allow_unqualified_frequency = source.allow_unqualified_frequency;
+        snapshot.allow_non_amateur_frequency = source.allow_non_amateur_frequency;
         snapshot.wspr_audio_offset_hz = source.wspr.audio_offset_hz;
         snapshot.wspr_frequency_entries = source.wspr_frequency_entries;
         snapshot.band_gpio = source.band_gpio;
@@ -1460,6 +1462,9 @@ namespace
             {"Socket Port", 31416},
             {"Use Shutdown", false},
             {"Shutdown Button", 19}};
+        target["Experimental"] = {
+            {"Allow Unqualified Frequency", false},
+            {"Allow Non-Amateur Frequency", false}};
 
         target["GPIO"] = {
             {"Transmit Pin", kDefaultTransmitGpio},
@@ -1752,6 +1757,12 @@ namespace
         target.use_shutdown = source.at("Operation").at("Use Shutdown").get<bool>();
         target.shutdown_pin = source.at("Operation").at("Shutdown Button").get<int>();
         target.use_journald = false;
+        const auto experimental =
+            source.value("Experimental", nlohmann::json::object());
+        target.allow_unqualified_frequency =
+            experimental.value("Allow Unqualified Frequency", false);
+        target.allow_non_amateur_frequency =
+            experimental.value("Allow Non-Amateur Frequency", false);
 
         // Missing Band GPIO data is allowed; explicit disabled defaults stay in place.
         const auto band_gpio_section_it = source.find("Band GPIO");
@@ -1818,6 +1829,10 @@ namespace
         target["Operation"]["Socket Port"] = source.socket_port;
         target["Operation"]["Use Shutdown"] = source.use_shutdown;
         target["Operation"]["Shutdown Button"] = source.shutdown_pin;
+        target["Experimental"]["Allow Unqualified Frequency"] =
+            source.allow_unqualified_frequency;
+        target["Experimental"]["Allow Non-Amateur Frequency"] =
+            source.allow_non_amateur_frequency;
 
         target["GPIO"]["Transmit Pin"] =
             normalize_gpio_transmit_pin(source.gpio_tx_pin);
@@ -1939,6 +1954,8 @@ namespace
         target.use_journald = source.use_journald;
         target.date_time_log = source.date_time_log;
         target.debug_logging = source.debug_logging;
+        target.allow_unqualified_frequency = source.allow_unqualified_frequency;
+        target.allow_non_amateur_frequency = source.allow_non_amateur_frequency;
         target.wspr_planner_preference = source.wspr_planner_preference;
         target.loop_tx = source.loop_tx;
         target.tx_iterations.store(source.tx_iterations.load());
@@ -2083,7 +2100,8 @@ namespace
                 section != "Calibration" &&
                 section != "Si5351" &&
                 section != "WSPR" &&
-                section != "CW")
+                section != "CW" &&
+                section != "Experimental")
             {
                 continue;
             }
@@ -2287,6 +2305,7 @@ build_persistent_ini_data(const nlohmann::json &source)
             section_name != "Si5351" &&
             section_name != "WSPR" &&
             section_name != "CW" &&
+            section_name != "Experimental" &&
             section_name != "Band GPIO")
         {
             continue;
@@ -2379,7 +2398,10 @@ build_persistent_ini_data(const nlohmann::json &source)
                   key == "Fade Slice Ms" ||
                   key == "Start Minute" ||
                   key == "Start Second" ||
-                  key == "Repeat Minutes"));
+                  key == "Repeat Minutes")) ||
+                (section_name == "Experimental" &&
+                 (key == "Allow Unqualified Frequency" ||
+                  key == "Allow Non-Amateur Frequency"));
 
             if (!persist_key)
             {

--- a/src/config_handler.hpp
+++ b/src/config_handler.hpp
@@ -306,6 +306,8 @@ struct ArgParserConfig
     bool use_journald;              ///< Route logs to journald instead of streams.
     bool date_time_log;             ///< Prefix logs with timestamp.
     bool debug_logging;             ///< Enable DEBUG-level application logging.
+    bool allow_unqualified_frequency; ///< Permit unqualified backend/mode combinations.
+    bool allow_non_amateur_frequency; ///< Permit frequencies outside recognized amateur allocations when combined with the unqualified override.
     WsprPlannerPreference wspr_planner_preference; ///< Preferred planner behavior for Type 2/3 pairing.
     bool loop_tx;                   ///< Repeat transmission cycle.
     std::atomic<int> tx_iterations; ///< Number of transmission iterations (0 = infinite).
@@ -383,6 +385,8 @@ struct ArgParserConfig
           use_journald(false),
           date_time_log(false),
           debug_logging(false),
+          allow_unqualified_frequency(false),
+          allow_non_amateur_frequency(false),
           wspr_planner_preference(WsprPlannerPreference::Auto),
           loop_tx(false),
           tx_iterations(0),
@@ -468,6 +472,8 @@ struct ArgParserConfig
         use_journald = other.use_journald;
         date_time_log = other.date_time_log;
         debug_logging = other.debug_logging;
+        allow_unqualified_frequency = other.allow_unqualified_frequency;
+        allow_non_amateur_frequency = other.allow_non_amateur_frequency;
         wspr_planner_preference = other.wspr_planner_preference;
         loop_tx = other.loop_tx;
         tx_iterations.store(other.tx_iterations.load());
@@ -519,6 +525,8 @@ extern ArgParserConfig config;
 struct TestTonePlanningConfigSnapshot
 {
     TransmitBackendKind transmit_backend = TransmitBackendKind::GPIO;
+    bool allow_unqualified_frequency = false;
+    bool allow_non_amateur_frequency = false;
     double wspr_audio_offset_hz = WSPR_AUDIO_OFFSET_HZ;
     std::vector<WsprFrequencyEntry> wspr_frequency_entries{};
     std::array<BandGPIOConfig, HAM_BAND_COUNT> band_gpio{};

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -1111,6 +1111,28 @@ static wsprrypi::BackendKind to_controller_backend(
 static wsprrypi::ClockSource to_controller_clock_source(
     const ArgParserConfig &cfg) noexcept;
 
+static wsprrypi::TransmissionRequest build_controller_request_from_legacy(
+    const TransmissionRequest &legacy_request,
+    wsprrypi::TransmissionMode mode)
+{
+    wsprrypi::TransmissionRequest controller_request;
+    controller_request.mode = mode;
+    controller_request.output.backend =
+        to_controller_backend(config.transmit_backend);
+    controller_request.output.output = to_controller_clock_source(config);
+    controller_request.output.gpio = legacy_request.tx_gpio;
+    controller_request.calibration.ppm = legacy_request.ppm;
+    controller_request.policy.allow_unqualified_frequency =
+        legacy_request.allow_unqualified_frequency;
+    controller_request.policy.allow_non_amateur_frequency =
+        legacy_request.allow_non_amateur_frequency;
+    controller_request.policy.hardware_profile = legacy_request.hardware_profile;
+    controller_request.id.value = 1;
+    controller_request.metadata.label = legacy_request.frequency_entry_label;
+    controller_request.metadata.origin = "scheduler";
+    return controller_request;
+}
+
 /**
  * @brief Commit the single execution request consumed by the transmitter.
  *
@@ -1128,29 +1150,13 @@ static void commit_execution_request(
     committed_execution_route_for_test_storage =
         CommittedExecutionRouteForTest::NONE;
 
-    auto build_controller_request =
-        [&](wsprrypi::TransmissionMode mode) -> wsprrypi::TransmissionRequest
-    {
-        wsprrypi::TransmissionRequest controller_request;
-        controller_request.mode = mode;
-        controller_request.output.backend =
-            to_controller_backend(config.transmit_backend);
-        controller_request.output.output =
-            to_controller_clock_source(config);
-        controller_request.output.gpio = current_transmission_request.tx_gpio;
-        controller_request.calibration.ppm = current_transmission_request.ppm;
-        controller_request.id.value = 1;
-        controller_request.metadata.label =
-            current_transmission_request.frequency_entry_label;
-        controller_request.metadata.origin = "scheduler";
-        return controller_request;
-    };
-
     if (current_transmission_request.isTone() &&
         config.transmit_backend == TransmitBackendKind::SI5351)
     {
         wsprrypi::TransmissionRequest controller_request =
-            build_controller_request(wsprrypi::TransmissionMode::TONE);
+            build_controller_request_from_legacy(
+                current_transmission_request,
+                wsprrypi::TransmissionMode::TONE);
         wsprrypi::TonePayload payload;
         payload.frequency_hz =
             current_transmission_request.actual_rf_frequency_hz;
@@ -1193,10 +1199,13 @@ static void commit_execution_request(
     {
         return;
     }
+
     if (!current_transmission_request.isSkipWindow())
     {
         wsprrypi::TransmissionRequest controller_request =
-            build_controller_request(wsprrypi::TransmissionMode::WSPR);
+            build_controller_request_from_legacy(
+                current_transmission_request,
+                wsprrypi::TransmissionMode::WSPR);
 
         wsprrypi::WsprPayload payload;
         payload.prepared = current_transmission_request.payload;
@@ -5969,6 +5978,13 @@ void set_current_transmission_request_for_test(
 std::optional<wsprrypi::TransmissionRequest> current_controller_request_for_test()
 {
     return current_controller_request_for_test_storage;
+}
+
+wsprrypi::TransmissionRequest controller_request_from_legacy_for_test(
+    const TransmissionRequest &request,
+    wsprrypi::TransmissionMode mode)
+{
+    return build_controller_request_from_legacy(request, mode);
 }
 
 std::vector<BandGPIOConfig> selector_shutdown_cleanup_targets_for_test()

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -3858,6 +3858,7 @@ TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
             ? static_cast<double>(*explicit_frequency_plan->audio_offset_hz)
             : 0.0;
     }
+    selector_preparation_cfg.mode = ModeType::TONE;
     BandGPIOResolution selector_resolution;
     const BandGPIOPrepareStatus selector_status =
         prepare_band_gpio_for_frequency_or_log(

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -106,6 +106,7 @@ struct BandGPIOResolution
     bool selector_enabled = false;
     bool from_band_config = false;
     const char *selector_source = "none";
+    bool band_known = true;
 };
 
 struct SelectorGPIOReservation
@@ -1217,6 +1218,34 @@ static void commit_execution_request(
     wsprTransmitter.configureExecution(current_transmission_request);
 }
 
+static wsprrypi::TransmissionMode to_controller_mode(ModeType mode) noexcept
+{
+    switch (mode)
+    {
+    case ModeType::TONE: return wsprrypi::TransmissionMode::TONE;
+    case ModeType::QRSS: return wsprrypi::TransmissionMode::QRSS;
+    case ModeType::FSKCW: return wsprrypi::TransmissionMode::FSKCW;
+    case ModeType::DFCW: return wsprrypi::TransmissionMode::DFCW;
+    case ModeType::WSPR: return wsprrypi::TransmissionMode::WSPR;
+    }
+    return wsprrypi::TransmissionMode::WSPR;
+}
+
+static wsprrypi::HardwareProfile to_controller_profile(
+    TransmitBackendKind backend) noexcept
+{
+    if (backend == TransmitBackendKind::SI5351)
+        return wsprrypi::HardwareProfile::SI5351;
+    if (backend == TransmitBackendKind::SIMULATED)
+        return wsprrypi::HardwareProfile::UNSPECIFIED;
+    const int generation = get_raspberry_pi_generation();
+    if (generation == 5)
+        return wsprrypi::HardwareProfile::RP1_GPCLK;
+    if (generation == 4)
+        return wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD;
+    return wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD;
+}
+
 static void commit_execution_request(
     const wsprrypi::TransmissionRequest &controller_request,
     const TransmissionRequest &legacy_request)
@@ -1901,7 +1930,11 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
 
     const auto gpio_policy = wsprrypi::evaluate_gpio_band_policy(
         to_controller_backend(cfg.transmit_backend),
-        source_frequency_hz);
+        source_frequency_hz,
+        to_controller_mode(cfg.mode),
+        cfg.allow_unqualified_frequency,
+        cfg.allow_non_amateur_frequency,
+        to_controller_profile(cfg.transmit_backend));
     if (!gpio_policy.allowed)
     {
         llog.logS(WARN, gpio_policy.error);
@@ -1914,6 +1947,23 @@ static BandGPIOPrepareStatus prepare_band_gpio_for_frequency_or_log(
     const auto band = lookup.lookup_ham_band(source_frequency_hz);
     if (!band.has_value())
     {
+        if (entry.selector_gpio != kSelectorGpioUnset)
+        {
+            BandGPIOResolution explicit_resolution;
+            explicit_resolution.config.gpio = entry.selector_gpio;
+            explicit_resolution.config.enabled = true;
+            explicit_resolution.config.active_high = entry.selector_gpio_active_high;
+            explicit_resolution.selector_enabled = true;
+            explicit_resolution.selector_source = "explicit frequency entry";
+            explicit_resolution.band_known = false;
+            if (resolution_out != nullptr)
+                *resolution_out = explicit_resolution;
+            llog.logS(
+                DEBUG, "[BandGPIO]", "Frequency entry ", entry.token,
+                " uses explicit GPIO ", entry.selector_gpio,
+                " without inferring an amateur band.");
+            return apply_band_gpio_resolution(explicit_resolution);
+        }
         llog.logS(
             WARN,
             "Unable to map source frequency ",
@@ -2063,6 +2113,9 @@ static TransmissionRequest make_tone_request(
     request.power_level = cfg.power_level;
     request.tx_gpio = cfg.tx_pin;
     request.frequency_entry_label = entry.token;
+    request.allow_unqualified_frequency = cfg.allow_unqualified_frequency;
+    request.allow_non_amateur_frequency = cfg.allow_non_amateur_frequency;
+    request.hardware_profile = to_controller_profile(cfg.transmit_backend);
     return request;
 }
 
@@ -2081,7 +2134,11 @@ static bool start_direct_tone_execution(
 {
     const auto gpio_policy = wsprrypi::evaluate_gpio_band_policy(
         to_controller_backend(cfg.transmit_backend),
-        actual_rf_frequency_hz);
+        actual_rf_frequency_hz,
+        wsprrypi::TransmissionMode::TONE,
+        cfg.allow_unqualified_frequency,
+        cfg.allow_non_amateur_frequency,
+        to_controller_profile(cfg.transmit_backend));
     if (!gpio_policy.allowed)
     {
         if (error_message != nullptr)
@@ -2236,6 +2293,9 @@ static wsprrypi::TransmissionRequest make_qrss_controller_request(
     request.output.output = to_controller_clock_source(cfg);
     request.output.gpio = cfg.tx_pin;
     request.calibration.ppm = committed_ppm;
+    request.policy.allow_unqualified_frequency = cfg.allow_unqualified_frequency;
+    request.policy.allow_non_amateur_frequency = cfg.allow_non_amateur_frequency;
+    request.policy.hardware_profile = to_controller_profile(cfg.transmit_backend);
     request.metadata.label = "qrss-cli-test";
     request.metadata.origin = "cli";
     request.metadata.note = "temporary qrss test path";
@@ -2275,6 +2335,9 @@ static wsprrypi::TransmissionRequest make_fskcw_controller_request(
     request.output.output = to_controller_clock_source(cfg);
     request.output.gpio = cfg.tx_pin;
     request.calibration.ppm = committed_ppm;
+    request.policy.allow_unqualified_frequency = cfg.allow_unqualified_frequency;
+    request.policy.allow_non_amateur_frequency = cfg.allow_non_amateur_frequency;
+    request.policy.hardware_profile = to_controller_profile(cfg.transmit_backend);
     request.metadata.label = "fskcw-cli-test";
     request.metadata.origin = "cli";
     request.metadata.note = "temporary fskcw test path";
@@ -2317,6 +2380,9 @@ static wsprrypi::TransmissionRequest make_dfcw_controller_request(
     request.output.output = to_controller_clock_source(cfg);
     request.output.gpio = cfg.tx_pin;
     request.calibration.ppm = committed_ppm;
+    request.policy.allow_unqualified_frequency = cfg.allow_unqualified_frequency;
+    request.policy.allow_non_amateur_frequency = cfg.allow_non_amateur_frequency;
+    request.policy.hardware_profile = to_controller_profile(cfg.transmit_backend);
     request.metadata.label = "dfcw-cli-test";
     request.metadata.origin = "cli";
     request.metadata.note = "temporary dfcw test path";
@@ -2760,6 +2826,9 @@ static TransmissionRequest make_wspr_request(
     request.use_offset = cfg.use_offset;
     request.applied_offset_hz = applied_offset_hz;
     request.frequency_entry_label = entry.token;
+    request.allow_unqualified_frequency = cfg.allow_unqualified_frequency;
+    request.allow_non_amateur_frequency = cfg.allow_non_amateur_frequency;
+    request.hardware_profile = to_controller_profile(cfg.transmit_backend);
     return request;
 }
 
@@ -3651,7 +3720,11 @@ TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
 
         const auto gpio_policy = wsprrypi::evaluate_gpio_band_policy(
             to_controller_backend(planning_snapshot.transmit_backend),
-            static_cast<double>(frequency_plan.plan->actual_rf_frequency_hz));
+            static_cast<double>(frequency_plan.plan->actual_rf_frequency_hz),
+            wsprrypi::TransmissionMode::TONE,
+            planning_snapshot.allow_unqualified_frequency,
+            planning_snapshot.allow_non_amateur_frequency,
+            to_controller_profile(planning_snapshot.transmit_backend));
         if (!gpio_policy.allowed)
         {
             result.message = gpio_policy.error;
@@ -3795,7 +3868,11 @@ TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
         test_tone_restoration_owner = TestToneRestorationOwner::Unknown;
         const auto gpio_policy = wsprrypi::evaluate_gpio_band_policy(
             to_controller_backend(selector_preparation_cfg.transmit_backend),
-            actual_rf_freq);
+            actual_rf_freq,
+            wsprrypi::TransmissionMode::TONE,
+            selector_preparation_cfg.allow_unqualified_frequency,
+            selector_preparation_cfg.allow_non_amateur_frequency,
+            to_controller_profile(selector_preparation_cfg.transmit_backend));
         result.message = gpio_policy.allowed
             ? "Unable to prepare the requested band selector."
             : gpio_policy.error;

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -432,6 +432,9 @@ TransmissionRequest current_transmission_request_for_test();
 void set_current_transmission_request_for_test(
     const TransmissionRequest &request) noexcept;
 std::optional<wsprrypi::TransmissionRequest> current_controller_request_for_test();
+wsprrypi::TransmissionRequest controller_request_from_legacy_for_test(
+    const TransmissionRequest &request,
+    wsprrypi::TransmissionMode mode);
 void reset_current_transmission_request_for_test() noexcept;
 void set_current_frequency_estimate_for_test(
     const SystemClockFrequencyEstimate &estimate);

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1882,6 +1882,12 @@ int main(int argc, char *argv[])
             jConfig["Meta"].contains("debug_logging") &&
                 !jConfig["Meta"]["debug_logging"].get<bool>(),
             "default JSON config must serialize debug_logging as false");
+        require(
+            !config.allow_unqualified_frequency &&
+                !config.allow_non_amateur_frequency &&
+                !jConfig["Experimental"]["Allow Unqualified Frequency"].get<bool>() &&
+                !jConfig["Experimental"]["Allow Non-Amateur Frequency"].get<bool>(),
+            "experimental frequency policy must default deny");
     }
 
     {
@@ -2214,6 +2220,23 @@ int main(int argc, char *argv[])
             "--no-debug-logging must update serialized config state");
     }
 
+
+    {
+        reset_getopt_state();
+        std::vector<std::string> args = {
+            "wsprrypi", "--allow-unqualified-frequency",
+            "--allow-non-amateur-frequency",
+            "--no-allow-non-amateur-frequency",
+            "AA0NT", "EM18", "20", "20m"};
+        std::vector<char *> argv = argv_for(args);
+        require(
+            parse_command_line(static_cast<int>(argv.size()), argv.data()),
+            "experimental frequency CLI flags must parse");
+        require(
+            config.allow_unqualified_frequency &&
+                !config.allow_non_amateur_frequency,
+            "experimental frequency CLI flags must use last-option precedence");
+    }
 
     {
         clear_direct_tone_startup_request();
@@ -4034,6 +4057,37 @@ int main(int argc, char *argv[])
             !public_config.contains("Meta"),
             "public config JSON must not expose Meta logging controls to the UI");
 
+        init_default_config();
+    }
+
+    {
+        init_config_json();
+        iniFile.setData({
+            {"Operation", {{"Mode", "WSPR"}}},
+            {"Experimental", {
+                {"Allow Unqualified Frequency", "true"},
+                {"Allow Non-Amateur Frequency", "true"}}}});
+        ini_to_json("/tmp/experimental_frequency.ini");
+        json_to_config();
+        require(
+            config.allow_unqualified_frequency &&
+                config.allow_non_amateur_frequency,
+            "experimental frequency INI controls must load as booleans");
+        config_to_json();
+        const nlohmann::json public_config = get_public_config_json();
+        require(
+            !public_config.contains("Experimental"),
+            "experimental frequency controls must remain hidden from UI JSON");
+        config.use_ini = true;
+        config.ini_filename = "/tmp/experimental_frequency.ini";
+        write_text_file(config.ini_filename, "[Operation]\nMode=WSPR\n");
+        iniFile.set_filename(config.ini_filename);
+        json_to_ini();
+        const auto persisted = iniFile.getData();
+        require(
+            persisted.at("Experimental").at("Allow Unqualified Frequency") == "true" &&
+                persisted.at("Experimental").at("Allow Non-Amateur Frequency") == "true",
+            "experimental frequency controls must persist in the INI section");
         init_default_config();
     }
 
@@ -6678,7 +6732,7 @@ int main(int argc, char *argv[])
                 !seventy_centimeter_rejected.started &&
                 !custom_rejected.started && !custom_125m_rejected.started &&
                 !custom_70cm_rejected.started &&
-                band_rejected.message.find("Direct GPIO transmission is blocked") !=
+                band_rejected.message.find("12 m") !=
                     std::string::npos &&
                 six_meter_rejected.message.find("6 m") != std::string::npos &&
                 four_meter_rejected.message.find("4 m") != std::string::npos &&
@@ -6687,11 +6741,11 @@ int main(int argc, char *argv[])
                     std::string::npos &&
                 seventy_centimeter_rejected.message.find("70 cm") !=
                     std::string::npos &&
-                custom_rejected.message.find("Direct GPIO transmission is blocked") !=
+                custom_rejected.message.find("6 m") !=
                     std::string::npos &&
                 custom_125m_rejected.message.find("1.25 m") != std::string::npos &&
                 custom_70cm_rejected.message.find("70 cm") != std::string::npos &&
-                band_rejected.message.find("separately qualified") !=
+                band_rejected.message.find("experimental risk") !=
                     std::string::npos &&
                 config.mode == ModeType::QRSS &&
                 nearly_equal(
@@ -6782,7 +6836,7 @@ int main(int argc, char *argv[])
         require(
             !unknown_band_started && !lookup_error.empty() &&
                 start_async_calls == 0 &&
-                band_gpio_prepare_call_count_for_test() == 1U &&
+                band_gpio_prepare_call_count_for_test() == 0U &&
                 current_transmission_request_for_test().actual_rf_frequency_hz == 0.0 &&
                 !current_controller_request_for_test().has_value() &&
                 committed_execution_route_for_test() ==
@@ -6790,8 +6844,46 @@ int main(int argc, char *argv[])
                 !current_band_gpio_selection_for_test(
                     inactive_selector_config,
                     inactive_selector_band),
-            "failed direct CLI band lookup and selector preparation must leave RF and selector state inactive without committing or reaching startAsync");
+            "outside-band direct CLI policy rejection must precede selector preparation, request commit, and startAsync");
 
+        reset_direct_tone_start_invoker_for_test();
+        set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    {
+        init_default_config();
+        config.transmit_backend = TransmitBackendKind::GPIO;
+        config.allow_unqualified_frequency = true;
+        config.allow_non_amateur_frequency = true;
+        set_scheduler_execution_suppressed_for_test(true);
+        reset_current_transmission_request_for_test();
+        reset_current_controller_request_for_test();
+        reset_committed_execution_route_for_test();
+        reset_band_gpio_prepare_call_count_for_test();
+        int start_async_calls = 0;
+        set_direct_tone_start_invoker_for_test(
+            [&start_async_calls] { ++start_async_calls; });
+
+        WsprFrequencyEntry experimental_entry;
+        experimental_entry.token = "150000000@17H";
+        experimental_entry.dial_frequency_hz = 150000000.0;
+        experimental_entry.selector_gpio = 17;
+        experimental_entry.selector_gpio_active_high = true;
+        std::string error;
+        const bool started = start_direct_tone_execution_for_test(
+            config, experimental_entry,
+            experimental_entry.dial_frequency_hz, &error);
+        const TransmissionRequest committed =
+            current_transmission_request_for_test();
+        require(
+            started && error.empty() && start_async_calls == 1 &&
+                band_gpio_prepare_call_count_for_test() == 1U &&
+                committed.selector_gpio_enabled &&
+                committed.selector_gpio_config.gpio == 17 &&
+                committed.selector_gpio_config.active_high,
+            "dual outside-band override must retain an explicit CLI selector without band inference");
+
+        stop_active_transmission_selectors_for_test();
         reset_direct_tone_start_invoker_for_test();
         set_scheduler_execution_suppressed_for_test(false);
     }

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1819,6 +1819,38 @@ int main(int argc, char *argv[])
         init_config_json();
         json_to_config();
         config.transmit = true;
+        config.frequencies = "0.136,0.136Hz,14.0971001MHz@22,9223372036854775808";
+
+        require(
+            !set_frequencies(config) &&
+                config.wspr_frequency_entries.empty() &&
+                config.wspr_dial_freq_set.empty(),
+            "WSPR frequency lists must reject values that do not resolve to whole-number Hz before scheduling or selector preparation");
+    }
+
+    {
+        init_config_json();
+        json_to_config();
+        config.transmit = true;
+        config.frequencies = "0,0.136MHz,136kHz,136000,2200m,0.136MHz@22";
+
+        require(
+            set_frequencies(config) &&
+                config.wspr_frequency_entries.size() == 6U &&
+                nearly_equal(config.wspr_frequency_entries[0].dial_frequency_hz, 0.0) &&
+                nearly_equal(config.wspr_frequency_entries[1].dial_frequency_hz, 136000.0) &&
+                nearly_equal(config.wspr_frequency_entries[2].dial_frequency_hz, 136000.0) &&
+                nearly_equal(config.wspr_frequency_entries[3].dial_frequency_hz, 136000.0) &&
+                nearly_equal(config.wspr_frequency_entries[4].dial_frequency_hz, 136000.0) &&
+                nearly_equal(config.wspr_frequency_entries[5].dial_frequency_hz, 136000.0) &&
+                config.wspr_frequency_entries[5].selector_gpio == 22,
+            "WSPR frequency lists must retain zero skip, integral unit conversion, aliases, raw Hz, and selector suffixes");
+    }
+
+    {
+        init_config_json();
+        json_to_config();
+        config.transmit = true;
         config.frequencies = "80m@";
 
         require(
@@ -7405,6 +7437,49 @@ int main(int argc, char *argv[])
         reset_startup_quiesce_for_test();
         reset_current_transmission_request_for_test();
         set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    {
+        clear_direct_tone_startup_request();
+        for (const std::string token : {"0.136", "0.136Hz", "14.0971001MHz@22"})
+        {
+            std::string error;
+            require(
+                !set_direct_tone_startup_request(token, &error) &&
+                    error.find("whole-number frequency in Hz") != std::string::npos &&
+                    !has_direct_tone_startup_request(),
+                "direct CLI test tone must reject fractional-Hz values before creating startup state");
+        }
+
+        {
+            std::string error;
+            require(
+                !set_direct_tone_startup_request("9223372036854775808", &error) &&
+                    error.find("outside the supported RF range") != std::string::npos &&
+                    !has_direct_tone_startup_request(),
+                "direct CLI test tone must reject values outside the signed integral-Hz correlation range");
+        }
+
+        for (const std::string token : {"0.136MHz", "136kHz", "136000", "2200m", "0.136MHz@22"})
+        {
+            std::string error;
+            require(
+                set_direct_tone_startup_request(token, &error),
+                "direct CLI test tone must accept inputs that resolve to integral Hz");
+            WsprFrequencyEntry entry;
+            double actual_rf_hz = 0.0;
+            require(
+                try_get_direct_tone_startup_request(entry, actual_rf_hz) &&
+                    nearly_equal(actual_rf_hz, 136000.0),
+                "accepted direct CLI test-tone forms must retain 136000 Hz exactly");
+            if (token == "0.136MHz@22")
+            {
+                require(
+                    entry.selector_gpio == 22,
+                    "integral unit-qualified direct test-tone input must retain its selector suffix");
+            }
+            clear_direct_tone_startup_request();
+        }
     }
 
     {

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -2,6 +2,7 @@
 #include "config_handler.hpp"
 #include "execution_plan_compiler.hpp"
 #include "frequency_semantics.hpp"
+#include "gpio_band_policy.hpp"
 #include "gpio_output.hpp"
 #include "scheduling.hpp"
 #include "system_clock_frequency_estimate.hpp"
@@ -746,6 +747,11 @@ int main(int argc, char *argv[])
                 stock_ini.find("2m =\n2m Active High = false") != std::string::npos &&
                 stock_ini.find("Active High = true") == std::string::npos,
             "stock INI must declare explicit disabled Band GPIO defaults for every band");
+        require(
+            stock_ini.find("[Experimental]") != std::string::npos &&
+                stock_ini.find("Allow Unqualified Frequency = false") != std::string::npos &&
+                stock_ini.find("Allow Non-Amateur Frequency = false") != std::string::npos,
+            "stock INI must expose both experimental frequency controls as default deny");
     }
 
     {
@@ -1067,6 +1073,72 @@ int main(int argc, char *argv[])
             current_transmission_request_for_test().mode == TransmissionMode::WSPR,
             "scheduler must commit a normal WSPR request for GPIO on Raspberry Pi 4");
 
+        finish_runtime_planning_state_for_identity_test();
+        clear_pi_generation_override_for_scope();
+    }
+
+    {
+        set_raspberry_pi_generation_override_for_test(4);
+        prime_valid_runtime_identity_config();
+        config.frequencies = "2200m";
+        config.allow_unqualified_frequency = false;
+        config.allow_non_amateur_frequency = false;
+        sync_wspr_fields_for_test();
+        require(
+            set_frequencies(config),
+            "BCM2711 2200 m WSPR regression must resolve its dial frequency");
+        reset_runtime_planning_state_for_identity_test();
+        require(
+            set_config(true),
+            "BCM2711 2200 m WSPR regression must plan a scheduler request");
+        const auto bcm2711_legacy_request = current_transmission_request_for_test();
+        auto bcm2711_request = controller_request_from_legacy_for_test(
+            bcm2711_legacy_request,
+            wsprrypi::TransmissionMode::WSPR);
+        wsprrypi::WsprPayload bcm2711_payload;
+        bcm2711_payload.prepared = bcm2711_legacy_request.payload;
+        bcm2711_payload.base_frequency_hz =
+            bcm2711_legacy_request.actual_rf_frequency_hz;
+        bcm2711_request.payload = bcm2711_payload;
+        require(
+            !bcm2711_request.policy.allow_unqualified_frequency &&
+                !bcm2711_request.policy.allow_non_amateur_frequency &&
+                bcm2711_request.policy.hardware_profile ==
+                    wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD &&
+                wsprrypi::evaluate_gpio_band_policy(
+                    wsprrypi::ExecutionPlanCompiler{}.compile(bcm2711_request)).allowed,
+            "direct WSPR controller requests must preserve the qualified BCM2711 2200 m profile");
+        finish_runtime_planning_state_for_identity_test();
+
+        set_raspberry_pi_generation_override_for_test(3);
+        prime_valid_runtime_identity_config();
+        config.frequencies = "2200m";
+        config.allow_unqualified_frequency = true;
+        config.allow_non_amateur_frequency = false;
+        sync_wspr_fields_for_test();
+        require(
+            set_frequencies(config),
+            "legacy 2200 m WSPR override regression must resolve its dial frequency");
+        reset_runtime_planning_state_for_identity_test();
+        require(
+            set_config(true),
+            "legacy 2200 m WSPR override regression must plan a scheduler request");
+        const auto legacy_request = current_transmission_request_for_test();
+        auto legacy_override_request = controller_request_from_legacy_for_test(
+            legacy_request,
+            wsprrypi::TransmissionMode::WSPR);
+        wsprrypi::WsprPayload legacy_payload;
+        legacy_payload.prepared = legacy_request.payload;
+        legacy_payload.base_frequency_hz = legacy_request.actual_rf_frequency_hz;
+        legacy_override_request.payload = legacy_payload;
+        require(
+            legacy_override_request.policy.allow_unqualified_frequency &&
+                !legacy_override_request.policy.allow_non_amateur_frequency &&
+                legacy_override_request.policy.hardware_profile ==
+                    wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD &&
+                wsprrypi::evaluate_gpio_band_policy(
+                    wsprrypi::ExecutionPlanCompiler{}.compile(legacy_override_request)).allowed,
+            "direct WSPR controller requests must preserve the legacy unqualified-frequency override");
         finish_runtime_planning_state_for_identity_test();
         clear_pi_generation_override_for_scope();
     }

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -6780,8 +6780,6 @@ int main(int argc, char *argv[])
 
         const TestToneStartResult band_rejected = start_test_tone(
             TestToneRequest{TestToneFrequencySource::WsprBand, "12m", std::nullopt});
-        const TestToneStartResult six_meter_rejected = start_test_tone(
-            TestToneRequest{TestToneFrequencySource::WsprBand, "6m", std::nullopt});
         const TestToneStartResult four_meter_rejected = start_test_tone(
             TestToneRequest{TestToneFrequencySource::WsprBand, "4m", std::nullopt});
         const TestToneStartResult two_meter_rejected = start_test_tone(
@@ -6790,30 +6788,25 @@ int main(int argc, char *argv[])
             TestToneRequest{TestToneFrequencySource::WsprBand, "1.25m", std::nullopt});
         const TestToneStartResult seventy_centimeter_rejected = start_test_tone(
             TestToneRequest{TestToneFrequencySource::WsprBand, "70cm", std::nullopt});
-        const TestToneStartResult custom_rejected = start_test_tone(
-            TestToneRequest{TestToneFrequencySource::CustomRf, "", 51000000U});
         const TestToneStartResult custom_125m_rejected = start_test_tone(
             TestToneRequest{TestToneFrequencySource::CustomRf, "", 223500000U});
         const TestToneStartResult custom_70cm_rejected = start_test_tone(
             TestToneRequest{TestToneFrequencySource::CustomRf, "", 435000000U});
 
         require(
-            !band_rejected.started && !six_meter_rejected.started &&
-                !four_meter_rejected.started && !two_meter_rejected.started &&
+            !band_rejected.started && !four_meter_rejected.started &&
+                !two_meter_rejected.started &&
                 !one_twenty_five_meter_rejected.started &&
                 !seventy_centimeter_rejected.started &&
-                !custom_rejected.started && !custom_125m_rejected.started &&
+                !custom_125m_rejected.started &&
                 !custom_70cm_rejected.started &&
                 band_rejected.message.find("12 m") !=
                     std::string::npos &&
-                six_meter_rejected.message.find("6 m") != std::string::npos &&
                 four_meter_rejected.message.find("4 m") != std::string::npos &&
                 two_meter_rejected.message.find("2 m") != std::string::npos &&
                 one_twenty_five_meter_rejected.message.find("1.25 m") !=
                     std::string::npos &&
                 seventy_centimeter_rejected.message.find("70 cm") !=
-                    std::string::npos &&
-                custom_rejected.message.find("6 m") !=
                     std::string::npos &&
                 custom_125m_rejected.message.find("1.25 m") != std::string::npos &&
                 custom_70cm_rejected.message.find("70 cm") != std::string::npos &&
@@ -6826,6 +6819,33 @@ int main(int argc, char *argv[])
                 band_gpio_prepare_call_count_for_test() == 0U,
             "named and custom disqualified GPIO Test Tones must reject before runtime or selector mutation");
         set_scheduler_execution_suppressed_for_test(false);
+    }
+
+    {
+        init_default_config();
+        reset_managed_reload_runtime_for_test();
+        reset_current_transmission_request_for_test();
+        set_scheduler_execution_suppressed_for_test(true);
+        config.transmit = false;
+        config.transmit_backend = TransmitBackendKind::GPIO;
+        config.mode = ModeType::QRSS;
+        copy_runtime_config(config, config);
+        set_raspberry_pi_generation_override_for_test(4);
+
+        const TestToneStartResult six_meter_started = start_test_tone(
+            TestToneRequest{TestToneFrequencySource::WsprBand, "6m", std::nullopt});
+        const TestToneStopResult six_meter_stopped = end_test_tone();
+        const TestToneStartResult custom_six_meter_started = start_test_tone(
+            TestToneRequest{TestToneFrequencySource::CustomRf, "", 51000000U});
+        const TestToneStopResult custom_six_meter_stopped = end_test_tone();
+        require(
+            six_meter_started.started && six_meter_stopped.tone_was_active &&
+                six_meter_stopped.stopped && custom_six_meter_started.started &&
+                custom_six_meter_stopped.tone_was_active &&
+                custom_six_meter_stopped.stopped,
+            "named and custom BCM2711 6 m TONE must start and stop after qualification");
+        set_scheduler_execution_suppressed_for_test(false);
+        clear_pi_generation_override_for_scope();
     }
 
     {

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -303,15 +303,19 @@ int main()
         137500.0, true, "BCM2711 2200 m profile", false, false,
         wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
 
-    require_controller_policy(
-        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
-        wsprrypi::TransmissionMode::TONE,
-        50294500.0, true, "BCM2711 6 m tone profile", false, false,
-        wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+    for (const auto mode : {
+             wsprrypi::TransmissionMode::TONE,
+             wsprrypi::TransmissionMode::QRSS,
+             wsprrypi::TransmissionMode::FSKCW})
+    {
+        require_controller_policy(
+            wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+            mode,
+            50294500.0, true, "BCM2711 6 m qualified CW profile", false, false,
+            wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+    }
     for (const auto mode : {
              wsprrypi::TransmissionMode::WSPR,
-             wsprrypi::TransmissionMode::QRSS,
-             wsprrypi::TransmissionMode::FSKCW,
              wsprrypi::TransmissionMode::DFCW})
     {
         require_controller_policy(

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -285,11 +285,7 @@ int main()
         require_controller_policy(
             wsprrypi::BackendKind::SI5351,
             mode,
-            137500.0, false, "untested Si5351 2200 m mode");
-        require_controller_policy(
-            wsprrypi::BackendKind::SI5351,
-            mode,
-            137500.0, true, "experimental Si5351 2200 m mode", true, false);
+            137500.0, true, "qualified Si5351 2200 m mode");
     }
     require_controller_policy(
         wsprrypi::BackendKind::RPI_CLOCK_GPIO,

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -170,11 +170,18 @@ void require_controller_policy(
     request.policy.allow_unqualified_frequency = allow_unqualified;
     request.policy.allow_non_amateur_frequency = allow_non_amateur;
     request.policy.hardware_profile = profile;
+    const auto direct_policy = wsprrypi::evaluate_frequency_policy(
+        backend_kind, mode, frequency_hz, allow_unqualified,
+        allow_non_amateur, profile);
     const auto result = controller.prepare(request);
 
     require(
         result.ok == expected_allowed,
-        context + " policy result must match expectation");
+        context + " policy result must match expectation at " +
+            std::to_string(frequency_hz) + " Hz in mode " +
+            std::to_string(static_cast<int>(mode)) + "; direct policy was " +
+            wsprrypi::qualification_state_name(direct_policy.qualification) +
+            " and controller error was '" + result.error + "'");
     require(
         backend.configure_calls == (expected_allowed ? 1 : 0),
         context + " must reject before backend configuration");
@@ -295,6 +302,32 @@ int main()
         wsprrypi::TransmissionMode::WSPR,
         137500.0, true, "BCM2711 2200 m profile", false, false,
         wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+
+    require_controller_policy(
+        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+        wsprrypi::TransmissionMode::TONE,
+        50294500.0, true, "BCM2711 6 m tone profile", false, false,
+        wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+    for (const auto mode : {
+             wsprrypi::TransmissionMode::WSPR,
+             wsprrypi::TransmissionMode::QRSS,
+             wsprrypi::TransmissionMode::FSKCW,
+             wsprrypi::TransmissionMode::DFCW})
+    {
+        require_controller_policy(
+            wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+            mode,
+            50294500.0, false, "BCM2711 6 m non-tone profile", false, false,
+            wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+    }
+    for (const double unavailable_frequency : {222101500.0, 432301500.0})
+    {
+        require_controller_policy(
+            wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+            wsprrypi::TransmissionMode::TONE,
+            unavailable_frequency, false, "BCM2711 unavailable profile", true, true,
+            wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+    }
 
     for (const auto mode : exercised_modes)
     {

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -278,6 +278,18 @@ int main()
         wsprrypi::TransmissionMode::WSPR,
         137500.0, false, "legacy 2200 m profile", false, false,
         wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+    for (const auto mode : {
+             wsprrypi::TransmissionMode::TONE,
+             wsprrypi::TransmissionMode::QRSS,
+             wsprrypi::TransmissionMode::FSKCW,
+             wsprrypi::TransmissionMode::DFCW})
+    {
+        require_controller_policy(
+            wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+            mode,
+            137500.0, true, "legacy 2200 m CW profile", false, false,
+            wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+    }
     require_controller_policy(
         wsprrypi::BackendKind::RPI_CLOCK_GPIO,
         wsprrypi::TransmissionMode::WSPR,

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -296,16 +296,35 @@ int main()
         wsprrypi::TransmissionMode::WSPR,
         137500.0, false, "legacy 2200 m profile", false, false,
         wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
-    for (const auto mode : {
-             wsprrypi::TransmissionMode::TONE,
+    require_controller_policy(
+        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+        wsprrypi::TransmissionMode::TONE,
+        137500.0, true, "legacy 2200 m TONE profile", false, false,
+        wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+    for (const auto untested_mode : {
              wsprrypi::TransmissionMode::QRSS,
              wsprrypi::TransmissionMode::FSKCW,
              wsprrypi::TransmissionMode::DFCW})
     {
+        const auto decision = wsprrypi::evaluate_frequency_policy(
+            wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+            untested_mode,
+            137500.0,
+            false,
+            false,
+            wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+        require(
+            decision.qualification == wsprrypi::QualificationState::UNTESTED,
+            "legacy 2200 m untested CW mode must retain untested state");
         require_controller_policy(
             wsprrypi::BackendKind::RPI_CLOCK_GPIO,
-            mode,
-            137500.0, true, "legacy 2200 m CW profile", false, false,
+            untested_mode,
+            137500.0, false, "legacy 2200 m untested CW profile", false, false,
+            wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+        require_controller_policy(
+            wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+            untested_mode,
+            137500.0, true, "legacy 2200 m overridden CW profile", true, false,
             wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
     }
     require_controller_policy(

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -280,6 +280,17 @@ int main()
         wsprrypi::BackendKind::SI5351,
         wsprrypi::TransmissionMode::TONE,
         223500000.0, false, "unavailable cannot be overridden", true, true);
+    for (const auto mode : exercised_modes)
+    {
+        require_controller_policy(
+            wsprrypi::BackendKind::SI5351,
+            mode,
+            137500.0, false, "untested Si5351 2200 m mode");
+        require_controller_policy(
+            wsprrypi::BackendKind::SI5351,
+            mode,
+            137500.0, true, "experimental Si5351 2200 m mode", true, false);
+    }
     require_controller_policy(
         wsprrypi::BackendKind::RPI_CLOCK_GPIO,
         wsprrypi::TransmissionMode::WSPR,

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -306,7 +306,8 @@ int main()
     for (const auto mode : {
              wsprrypi::TransmissionMode::TONE,
              wsprrypi::TransmissionMode::QRSS,
-             wsprrypi::TransmissionMode::FSKCW})
+             wsprrypi::TransmissionMode::FSKCW,
+             wsprrypi::TransmissionMode::DFCW})
     {
         require_controller_policy(
             wsprrypi::BackendKind::RPI_CLOCK_GPIO,
@@ -314,16 +315,11 @@ int main()
             50294500.0, true, "BCM2711 6 m qualified CW profile", false, false,
             wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
     }
-    for (const auto mode : {
-             wsprrypi::TransmissionMode::WSPR,
-             wsprrypi::TransmissionMode::DFCW})
-    {
-        require_controller_policy(
-            wsprrypi::BackendKind::RPI_CLOCK_GPIO,
-            mode,
-            50294500.0, false, "BCM2711 6 m non-tone profile", false, false,
-            wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
-    }
+    require_controller_policy(
+        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+        wsprrypi::TransmissionMode::WSPR,
+        50294500.0, false, "BCM2711 6 m WSPR profile", false, false,
+        wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
     for (const double unavailable_frequency : {222101500.0, 432301500.0})
     {
         require_controller_policy(

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -158,13 +158,19 @@ void require_controller_policy(
     wsprrypi::TransmissionMode mode,
     double frequency_hz,
     bool expected_allowed,
-    const std::string& context)
+    const std::string& context,
+    bool allow_unqualified = false,
+    bool allow_non_amateur = false,
+    wsprrypi::HardwareProfile profile = wsprrypi::HardwareProfile::UNSPECIFIED)
 {
     wsprrypi::ExecutionPlanCompiler compiler;
     ProbeBackend backend(backend_kind);
     wsprrypi::TransmissionController controller(compiler, backend);
-    const auto result = controller.prepare(
-        request_for_mode(backend_kind, mode, frequency_hz));
+    auto request = request_for_mode(backend_kind, mode, frequency_hz);
+    request.policy.allow_unqualified_frequency = allow_unqualified;
+    request.policy.allow_non_amateur_frequency = allow_non_amateur;
+    request.policy.hardware_profile = profile;
+    const auto result = controller.prepare(request);
 
     require(
         result.ok == expected_allowed,
@@ -175,10 +181,8 @@ void require_controller_policy(
     if (!expected_allowed)
     {
         require(
-            result.error.find("Direct GPIO transmission is blocked") !=
-                std::string::npos &&
-            result.error.find("separately qualified") != std::string::npos,
-            context + " must provide an actionable GPIO-only error");
+            result.error.find("Transmission") != std::string::npos,
+            context + " must provide an actionable policy error");
         require(
             controller.prepared_plan() == nullptr,
             context + " must not retain a rejected execution plan");
@@ -249,9 +253,36 @@ int main()
             wsprrypi::BackendKind::RPI_CLOCK_GPIO,
             wsprrypi::TransmissionMode::TONE,
             adjacent_frequency,
-            true,
+            false,
             "frequency adjacent to a disqualified band");
     }
+
+    require_controller_policy(
+        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+        wsprrypi::TransmissionMode::QRSS,
+        50293000.0, true, "unqualified override", true, false);
+    require_controller_policy(
+        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+        wsprrypi::TransmissionMode::TONE,
+        30000000.0, false, "outside-band single override", true, false);
+    require_controller_policy(
+        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+        wsprrypi::TransmissionMode::TONE,
+        30000000.0, true, "outside-band dual override", true, true);
+    require_controller_policy(
+        wsprrypi::BackendKind::SI5351,
+        wsprrypi::TransmissionMode::TONE,
+        223500000.0, false, "unavailable cannot be overridden", true, true);
+    require_controller_policy(
+        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+        wsprrypi::TransmissionMode::WSPR,
+        137500.0, false, "legacy 2200 m profile", false, false,
+        wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+    require_controller_policy(
+        wsprrypi::BackendKind::RPI_CLOCK_GPIO,
+        wsprrypi::TransmissionMode::WSPR,
+        137500.0, true, "BCM2711 2200 m profile", false, false,
+        wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
 
     for (const auto mode : exercised_modes)
     {

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -297,30 +297,25 @@ int main()
         wsprrypi::TransmissionMode::TONE,
         137500.0, true, "legacy 2200 m TONE profile", false, false,
         wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
-    for (const auto untested_mode : {
+    for (const auto qualified_mode : {
              wsprrypi::TransmissionMode::QRSS,
              wsprrypi::TransmissionMode::FSKCW,
              wsprrypi::TransmissionMode::DFCW})
     {
         const auto decision = wsprrypi::evaluate_frequency_policy(
             wsprrypi::BackendKind::RPI_CLOCK_GPIO,
-            untested_mode,
+            qualified_mode,
             137500.0,
             false,
             false,
             wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
         require(
-            decision.qualification == wsprrypi::QualificationState::UNTESTED,
-            "legacy 2200 m untested CW mode must retain untested state");
+            decision.qualification == wsprrypi::QualificationState::QUALIFIED,
+            "legacy 2200 m qualified CW mode must retain qualified state");
         require_controller_policy(
             wsprrypi::BackendKind::RPI_CLOCK_GPIO,
-            untested_mode,
-            137500.0, false, "legacy 2200 m untested CW profile", false, false,
-            wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
-        require_controller_policy(
-            wsprrypi::BackendKind::RPI_CLOCK_GPIO,
-            untested_mode,
-            137500.0, true, "legacy 2200 m overridden CW profile", true, false,
+            qualified_mode,
+            137500.0, true, "legacy 2200 m qualified CW profile", false, false,
             wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
     }
     require_controller_policy(


### PR DESCRIPTION
## Summary

- add mode-aware qualification decisions across backend, hardware profile, mode, band, and experimental override state
- add CLI and INI controls for explicitly unqualified and non-amateur-frequency operation while preserving non-bypassable planner and hardware-safety checks
- record the completed wspr2 legacy GPIO, wspr4 BCM2711 GPIO, and wspr5 Si5351 Issue 401 qualification evidence
- update the WSPR-Transmitter submodule to the reviewed, published qualification policy commit

## Qualification results

- Legacy 500 MHz GPIO, 2200 m: TONE, QRSS, FSKCW, and DFCW qualified; WSPR remains unqualified
- BCM2711 GPIO, 6 m: TONE, QRSS, FSKCW, and DFCW qualified; WSPR remains unqualified
- Si5351, 2200 m: TONE/carrier, WSPR, QRSS, FSKCW, and DFCW qualified

Negative WSPR results are retained as completed qualification outcomes. Si5351 70 cm remains outside this issue.

## Validation

- `git diff --check origin/devel...HEAD`: passed
- exact WSPR-Transmitter gitlink `d2e329639e907f735531e48f202263d353320035`: confirmed available on GitHub
- recursive parent/submodule cleanliness and branch/upstream checks: passed
- focused Linux/Pi source builds and policy tests are recorded in the branch evidence
- local macOS `make semantics-test`: compile not completed because the existing Makefile passes GCC-only `-fmax-errors=10` to Clang under `-Werror`; no test assertion ran and the checkout remained clean

Related to #401. This PR does not close the issue.