### PR TITLE
Add immutable installed UI identity

### DIFF
--- a/WsprryPi-UI/README.md
+++ b/WsprryPi-UI/README.md
@@ -7,8 +7,7 @@ It is installed with the current application installation.
 
 `scripts/generate_ui_manifest.py` generates and validates the schema-v1,
 content-addressed manifest used to identify a packaged UI artifact. Generation
-is build-time infrastructure only; the installer and runtime do not consume the
-manifest yet.
+is build-time infrastructure; installation integration is handled separately.
 
 The identity covers every regular file below the selected UI root except the
 top-level runtime `cache/` and `backups/` directories, `ui-manifest.json`
@@ -34,5 +33,17 @@ The same module provides the read-only `classify_installed_ui()` comparison
 layer. It validates the immutable packaged manifest, calculates the identity
 of the covered files currently present, and returns `packaged`,
 `locally_modified`, or fail-closed `unknown` state with deterministic modified,
-added, and missing path lists. Classification does not alter the installed
-files and is not connected to the browser or installer yet.
+added, and missing path lists. Classification does not alter installed files.
+
+## Installed UI identity
+
+The UI-owned `/wsprrypi/ui-version.php` endpoint compares the installed UI to
+the immutable manifest and reports its installed and packaged identities,
+classification state, and modified, added, and missing path lists. The
+`/wsprrypi/ui-manifest.php` endpoint exposes the validated packaged manifest.
+Both responses disable caching.
+
+Every rendered page embeds the installed identity and uses it as the cache key
+for UI assets. These endpoints are ordinary Apache/PHP UI resources; they are
+not proxied to the running service. `/wsprrypi/version` remains the service
+version endpoint. Refresh-dialog and installer behavior are outside this slice.

--- a/WsprryPi-UI/README.md
+++ b/WsprryPi-UI/README.md
@@ -2,3 +2,30 @@
 
 This is the Bootstrap UI for [Wsprry Pi](https://github.com/WsprryPi/WsprryPi/).
 It is installed with the current application installation.
+
+## Packaged UI manifest
+
+`scripts/generate_ui_manifest.py` generates and validates the schema-v1,
+content-addressed manifest used to identify a packaged UI artifact. Generation
+is build-time infrastructure only; the installer and runtime do not consume the
+manifest yet.
+
+The identity covers every regular file below the selected UI root except the
+top-level runtime `cache/` and `backups/` directories, `ui-manifest.json`
+itself, and `.DS_Store` metadata. Symbolic links and unsafe or non-normalized
+manifest paths are rejected. Each record contains a normalized relative path
+and a SHA-256 content digest; timestamps, permissions, ownership, and traversal
+order are not identity inputs.
+
+Generate and then validate a manifest with:
+
+```sh
+python3 scripts/generate_ui_manifest.py \
+  --ui-root data \
+  --output /tmp/ui-manifest.json \
+  --source-commit "$(git rev-parse HEAD)" \
+  --application-version 0.0.0
+python3 scripts/generate_ui_manifest.py --validate /tmp/ui-manifest.json
+```
+
+Run the focused regression suite with `npm run test:manifest`.

--- a/WsprryPi-UI/README.md
+++ b/WsprryPi-UI/README.md
@@ -46,4 +46,12 @@ Both responses disable caching.
 Every rendered page embeds the installed identity and uses it as the cache key
 for UI assets. These endpoints are ordinary Apache/PHP UI resources; they are
 not proxied to the running service. `/wsprrypi/version` remains the service
-version endpoint. Refresh-dialog and installer behavior are outside this slice.
+version endpoint.
+
+An open page polls the UI-owned identity endpoint. A changed installed identity
+prompts once for a refresh and supplies that identity as the refresh cache key.
+A page that loads with the requested identity has converged; a mismatch instead
+shows a persistent consistency diagnostic and suppresses further prompts. A
+stable packaged or locally modified installation does not prompt, and service
+or executable version changes do not participate in UI refresh decisions.
+Installer behavior remains outside this component.

--- a/WsprryPi-UI/README.md
+++ b/WsprryPi-UI/README.md
@@ -29,3 +29,10 @@ python3 scripts/generate_ui_manifest.py --validate /tmp/ui-manifest.json
 ```
 
 Run the focused regression suite with `npm run test:manifest`.
+
+The same module provides the read-only `classify_installed_ui()` comparison
+layer. It validates the immutable packaged manifest, calculates the identity
+of the covered files currently present, and returns `packaged`,
+`locally_modified`, or fail-closed `unknown` state with deterministic modified,
+added, and missing path lists. Classification does not alter the installed
+files and is not connected to the browser or installer yet.

--- a/WsprryPi-UI/README.md
+++ b/WsprryPi-UI/README.md
@@ -7,7 +7,11 @@ It is installed with the current application installation.
 
 `scripts/generate_ui_manifest.py` generates and validates the schema-v1,
 content-addressed manifest used to identify a packaged UI artifact. Generation
-is build-time infrastructure; installation integration is handled separately.
+is build-time infrastructure. The normal installer copies the exact UI source
+into a sibling staging directory, generates and validates the manifest there,
+confirms that the staged installed and packaged identities match, and only then
+publishes the complete directory tree. Failed staging or validation does not
+replace the live UI.
 
 The identity covers every regular file below the selected UI root except the
 top-level runtime `cache/` and `backups/` directories, `ui-manifest.json`
@@ -54,4 +58,8 @@ A page that loads with the requested identity has converged; a mismatch instead
 shows a persistent consistency diagnostic and suppresses further prompts. A
 stable packaged or locally modified installation does not prompt, and service
 or executable version changes do not participate in UI refresh decisions.
-Installer behavior remains outside this component.
+
+The published manifest is read-only and owned outside the Apache/PHP runtime
+account. Top-level `cache/` and `backups/` content remains excluded from the
+identity and may be runtime-owned without changing the packaged classification.
+Policy for replacing a locally modified live installation is a later slice.

--- a/WsprryPi-UI/README.md
+++ b/WsprryPi-UI/README.md
@@ -62,4 +62,12 @@ or executable version changes do not participate in UI refresh decisions.
 The published manifest is read-only and owned outside the Apache/PHP runtime
 account. Top-level `cache/` and `backups/` content remains excluded from the
 identity and may be runtime-owned without changing the packaged classification.
-Policy for replacing a locally modified live installation is a later slice.
+
+Before replacing a locally modified installation, the publisher creates a
+unique verified backup below `/var/backups/wsprrypi/ui`. It preserves modified
+and added files plus the prior manifest, and records missing files in
+`modification-report.json`. If prior state is unknown, it backs up the complete
+covered UI tree. Backup failure prevents replacement; customizations are never
+merged automatically. `--fail-on-ui-modifications` makes the installer refuse
+replacement instead. The installer relists the affected files, backup and
+report locations, and actual replacement status as its final output block.

--- a/WsprryPi-UI/data/header.php
+++ b/WsprryPi-UI/data/header.php
@@ -12,6 +12,8 @@ $pathConfig = [
     'basePath' => $basePath,
     'configPath' => $basePath . '/config',
     'versionPath' => $basePath . '/version',
+    'uiIdentityPath' => $basePath . '/ui-version.php',
+    'uiManifestPath' => $basePath . '/ui-manifest.php',
     'repairPath' => $basePath . '/config/repair',
     'supportBundlesPath' => $basePath . '/api/support-bundles',
     'supportIntakePath' => $basePath . '/api/support-intake',
@@ -26,7 +28,8 @@ $pathConfig = [
     window.WSPRRYPI_VIEW = <?= json_encode($activeView) ?>;
     window.WSPRRYPI_PATHS = <?= json_encode($pathConfig, JSON_UNESCAPED_SLASHES) ?>;
     window.WSPRRYPI_UI_VERSION = <?= json_encode(getWsprryPiUiVersion()) ?>;
-    window.WSPRRYPI_UI_BUILD_ID = <?= json_encode(getWsprryPiUiBuildId()) ?>;
+    window.WSPRRYPI_INSTALLED_UI_BUILD_ID = <?= json_encode(getWsprryPiInstalledUiBuildId()) ?>;
+    window.WSPRRYPI_UI_BUILD_ID = window.WSPRRYPI_INSTALLED_UI_BUILD_ID;
 </script>
 <script>
     (function () {
@@ -49,11 +52,11 @@ $pathConfig = [
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="<?= htmlspecialchars(wsprrypiAssetUrl('vendor/fonts/google/fonts.css')) ?>">
-<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
-<link rel="manifest" href="site.webmanifest">
-<link rel="icon" type="image/x-icon" href="favicon.ico">
+<link rel="apple-touch-icon" sizes="180x180" href="<?= htmlspecialchars(wsprrypiAssetUrl('apple-touch-icon.png')) ?>">
+<link rel="icon" type="image/png" sizes="32x32" href="<?= htmlspecialchars(wsprrypiAssetUrl('favicon-32x32.png')) ?>">
+<link rel="icon" type="image/png" sizes="16x16" href="<?= htmlspecialchars(wsprrypiAssetUrl('favicon-16x16.png')) ?>">
+<link rel="manifest" href="<?= htmlspecialchars(wsprrypiAssetUrl('site.webmanifest')) ?>">
+<link rel="icon" type="image/x-icon" href="<?= htmlspecialchars(wsprrypiAssetUrl('favicon.ico')) ?>">
 
 <!-- Bootswatch Zephyr CSS -->
 <link

--- a/WsprryPi-UI/data/header.php
+++ b/WsprryPi-UI/data/header.php
@@ -27,9 +27,7 @@ $pathConfig = [
     window.currentPage = <?= json_encode($legacyCurrentPage) ?>;
     window.WSPRRYPI_VIEW = <?= json_encode($activeView) ?>;
     window.WSPRRYPI_PATHS = <?= json_encode($pathConfig, JSON_UNESCAPED_SLASHES) ?>;
-    window.WSPRRYPI_UI_VERSION = <?= json_encode(getWsprryPiUiVersion()) ?>;
     window.WSPRRYPI_INSTALLED_UI_BUILD_ID = <?= json_encode(getWsprryPiInstalledUiBuildId()) ?>;
-    window.WSPRRYPI_UI_BUILD_ID = window.WSPRRYPI_INSTALLED_UI_BUILD_ID;
 </script>
 <script>
     (function () {

--- a/WsprryPi-UI/data/page_shell_start.php
+++ b/WsprryPi-UI/data/page_shell_start.php
@@ -17,4 +17,16 @@ if (!isset($cardClass)) {
     <!-- Main Content -->
     <main id="main-content" class="page-shell" tabindex="-1">
         <div class="container page-shell__inner">
+            <div
+                id="uiConsistencyDiagnostic"
+                class="alert alert-warning ui-consistency-diagnostic d-none"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true">
+                <div class="ui-consistency-diagnostic__title">
+                    <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
+                    UI consistency could not be confirmed
+                </div>
+                <p class="ui-consistency-diagnostic__message mb-0"></p>
+            </div>
             <div class="card shadow-sm page-card <?= htmlspecialchars($cardClass) ?>">

--- a/WsprryPi-UI/data/site.css
+++ b/WsprryPi-UI/data/site.css
@@ -128,6 +128,28 @@
         visibility 0s linear 0s;
 }
 
+.ui-consistency-diagnostic {
+    max-width: 72rem;
+    margin: 0 auto 1rem;
+    overflow-wrap: anywhere;
+    border-color: color-mix(in srgb, var(--wspr-state-warning) 58%, var(--bs-border-color));
+}
+
+.ui-consistency-diagnostic__title {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.35rem;
+    font-family: var(--font-display);
+    font-size: var(--text-body-strong);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-tight);
+}
+
+.ui-consistency-diagnostic__message {
+    max-width: 68ch;
+}
+
 /* ------------------------------------------------------------
        Nav Items Wrapping
 ------------------------------------------------------------ */

--- a/WsprryPi-UI/data/site.js
+++ b/WsprryPi-UI/data/site.js
@@ -61,6 +61,10 @@ const VERSION_PATH = normalizeSameOriginPath(
     PATHS.versionPath,
     `${APP_BASE_PATH}/version`
 );
+const UI_IDENTITY_PATH = normalizeSameOriginPath(
+    PATHS.uiIdentityPath,
+    `${APP_BASE_PATH}/ui-version.php`
+);
 const REPAIR_PATH = normalizeSameOriginPath(
     PATHS.repairPath,
     `${APP_BASE_PATH}/config/repair`
@@ -95,6 +99,11 @@ const VERSION_ENDPOINT = createEndpointDefinition(
     "version",
     VERSION_PATH,
     buildDirectRestFallbackUrl("/version")
+);
+const UI_IDENTITY_ENDPOINT = createEndpointDefinition(
+    "UI identity",
+    UI_IDENTITY_PATH,
+    UI_IDENTITY_PATH
 );
 const REPAIR_ENDPOINT = createEndpointDefinition(
     "config/repair",
@@ -162,6 +171,7 @@ const UPDATE_MODAL_RATE_LIMIT_MS = 2 * 60 * 60 * 1000;
 const UPDATE_CHECK_RELEASES_URL = "https://github.com/WsprryPi/WsprryPi/releases";
 const UPDATE_CHECK_API_BASE = "https://api.github.com/repos/WsprryPi/WsprryPi";
 const UI_BUILD_POLL_INTERVAL_MS = 60 * 1000;
+const UI_REFRESH_REQUEST_PARAM = "ui_refresh";
 const GITHUB_UPDATE_POLL_INTERVAL_MS = 60 * 60 * 1000;
 const UPDATE_CHECK_ERROR_MESSAGES = Object.freeze({
     missing_version_data: "Update check failed: local version metadata is incomplete.",
@@ -377,12 +387,12 @@ let backendCurrentlyConnected = false;
 let websocketCurrentlyConnected = false;
 let outageBannerArmed = false;
 let pageUnloading = false;
-let dismissedUiRefreshVersion = null;
 let dismissedUiRefreshBuildId = null;
 let uiBuildPollTimer = null;
 let githubUpdatePollTimer = null;
 let uiBuildVersionCheckRunning = false;
 let uiRefreshPromptActive = false;
+let uiConsistencyDiagnosticActive = false;
 let pendingTestToneStopDisableAction = null;
 let pendingTestToneStartRequest = false;
 let unresolvedTestToneStartContext = null;
@@ -642,6 +652,9 @@ function loadPage() {
     initGithubUpdatePolling();
     populateConfig();
 }
+
+// Verify a requested refresh before polling for later installed-UI changes.
+checkUiRefreshConvergence();
 
 // Start UI build polling from global script initialization as soon as site.js
 // runs. The shared modal markup is already present before this script is
@@ -4044,7 +4057,6 @@ function updateWsprryPiVersion() {
                 lastWsprryPiVersionResponse = response;
                 versionElement.textContent = response.wspr_version;
                 versionElement.title = response.wspr_version;
-                maybePromptForUiRefresh(response);
                 checkForWsprryPiUpdate(response);
             } else {
                 versionElement.textContent = "Service unavailable";
@@ -4075,9 +4087,9 @@ function checkUiBuildVersion() {
     }
 
     uiBuildVersionCheckRunning = true;
-    getJsonWithEndpointFallback(VERSION_ENDPOINT)
+    getJsonWithEndpointFallback(UI_IDENTITY_ENDPOINT)
         .done(function (response) {
-            if (response && (response.ui_build_id || response.ui_version)) {
+            if (response && response.installed_ui_build_id) {
                 maybePromptForUiRefresh(response);
             }
         })
@@ -6436,10 +6448,6 @@ function checkForWsprryPiUpdate(response, options = {}) {
         });
 }
 
-function normalizeUiVersion(value) {
-    return typeof value === "string" ? value.trim() : "";
-}
-
 function normalizeUiBuildId(value) {
     return typeof value === "string" ? value.trim() : "";
 }
@@ -6450,23 +6458,12 @@ function sharedConfirmModalIsVisible() {
 }
 
 function maybePromptForUiRefresh(versionResponse) {
-    const loadedVersion = normalizeUiVersion(window.WSPRRYPI_UI_VERSION);
-    const loadedBuildId = normalizeUiBuildId(window.WSPRRYPI_UI_BUILD_ID);
-    const normalizedServerVersion = normalizeUiVersion(
+    const loadedBuildId = normalizeUiBuildId(window.WSPRRYPI_INSTALLED_UI_BUILD_ID);
+    const installedBuildId = normalizeUiBuildId(
         typeof versionResponse === "object" && versionResponse !== null
-            ? versionResponse.ui_version
+            ? versionResponse.installed_ui_build_id
             : versionResponse
     );
-    const normalizedServerBuildId = normalizeUiBuildId(
-        typeof versionResponse === "object" && versionResponse !== null
-            ? versionResponse.ui_build_id
-            : ""
-    );
-    const canCompareBuildId = loadedBuildId && normalizedServerBuildId;
-    const canCompareVersion = loadedVersion && normalizedServerVersion;
-    const refreshIdentity = canCompareBuildId
-        ? normalizedServerBuildId
-        : normalizedServerVersion;
 
     if (uiRefreshPromptActive && !sharedConfirmModalIsVisible()) {
         uiRefreshPromptActive = false;
@@ -6474,11 +6471,11 @@ function maybePromptForUiRefresh(versionResponse) {
 
     if (
         uiRefreshPromptActive ||
-        !refreshIdentity ||
-        (canCompareBuildId && normalizedServerBuildId === loadedBuildId) ||
-        (!canCompareBuildId && (!canCompareVersion || normalizedServerVersion === loadedVersion)) ||
-        (canCompareBuildId && normalizedServerBuildId === dismissedUiRefreshBuildId) ||
-        (!canCompareBuildId && normalizedServerVersion === dismissedUiRefreshVersion)
+        uiConsistencyDiagnosticActive ||
+        !loadedBuildId ||
+        !installedBuildId ||
+        installedBuildId === loadedBuildId ||
+        installedBuildId === dismissedUiRefreshBuildId
     ) {
         return;
     }
@@ -6496,23 +6493,15 @@ function maybePromptForUiRefresh(versionResponse) {
         confirmClass: "btn-primary",
         cancelLabel: "Cancel",
         onConfirm: () => {
-            refreshUiForVersion(normalizedServerVersion, normalizedServerBuildId);
+            refreshUiForIdentity(installedBuildId);
         },
         onCancel: () => {
-            if (canCompareBuildId) {
-                dismissedUiRefreshBuildId = normalizedServerBuildId;
-            } else {
-                dismissedUiRefreshVersion = normalizedServerVersion;
-            }
+            dismissedUiRefreshBuildId = installedBuildId;
             uiRefreshPromptActive = false;
         },
         onHidden: () => {
             if (uiRefreshPromptActive) {
-                if (canCompareBuildId) {
-                    dismissedUiRefreshBuildId = normalizedServerBuildId;
-                } else {
-                    dismissedUiRefreshVersion = normalizedServerVersion;
-                }
+                dismissedUiRefreshBuildId = installedBuildId;
                 uiRefreshPromptActive = false;
             }
         }
@@ -6521,17 +6510,56 @@ function maybePromptForUiRefresh(versionResponse) {
     uiRefreshPromptActive = promptShown === true;
 }
 
-function refreshUiForVersion(serverVersion, serverBuildId = "") {
+function refreshUiForIdentity(installedBuildId) {
     const url = new URL(window.location.href);
-    const normalizedVersion = normalizeUiVersion(serverVersion);
-    const normalizedBuildId = normalizeUiBuildId(serverBuildId);
+    const normalizedBuildId = normalizeUiBuildId(installedBuildId);
 
-    url.searchParams.set(
-        "ui_refresh",
-        normalizedBuildId || normalizedVersion || Date.now().toString()
-    );
+    if (!normalizedBuildId) {
+        return;
+    }
+
+    url.searchParams.set(UI_REFRESH_REQUEST_PARAM, normalizedBuildId);
 
     window.location.replace(url.toString());
+}
+
+function showUiConsistencyDiagnostic(expectedBuildId, loadedBuildId) {
+    const diagnostic = document.getElementById("uiConsistencyDiagnostic");
+    const message = diagnostic?.querySelector(".ui-consistency-diagnostic__message");
+
+    uiConsistencyDiagnosticActive = true;
+    if (!diagnostic || !message) {
+        debugConsole("error", "UI consistency could not be confirmed after refresh.");
+        return;
+    }
+
+    const expected = normalizeUiBuildId(expectedBuildId) || "unavailable";
+    const loaded = normalizeUiBuildId(loadedBuildId) || "unavailable";
+    message.textContent = `The requested UI identity (${expected}) did not match the page that loaded (${loaded}). The installation may still be changing. Wait for it to finish, then reload this page once.`;
+    diagnostic.classList.remove("d-none");
+}
+
+function checkUiRefreshConvergence() {
+    const url = new URL(window.location.href);
+    const expectedBuildId = normalizeUiBuildId(
+        url.searchParams.get(UI_REFRESH_REQUEST_PARAM)
+    );
+
+    if (!expectedBuildId) {
+        return true;
+    }
+
+    const loadedBuildId = normalizeUiBuildId(window.WSPRRYPI_INSTALLED_UI_BUILD_ID);
+    if (!loadedBuildId || loadedBuildId !== expectedBuildId) {
+        showUiConsistencyDiagnostic(expectedBuildId, loadedBuildId);
+        return false;
+    }
+
+    url.searchParams.delete(UI_REFRESH_REQUEST_PARAM);
+    if (window.history?.replaceState) {
+        window.history.replaceState(null, "", url.toString());
+    }
+    return true;
 }
 
 function updateClocks() {

--- a/WsprryPi-UI/data/ui-manifest.php
+++ b/WsprryPi-UI/data/ui-manifest.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/ui_version.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+$manifestPath = __DIR__ . DIRECTORY_SEPARATOR . WSPRRYPI_UI_MANIFEST_FILENAME;
+try {
+    wsprrypiUiLoadManifest($manifestPath);
+    $content = @file_get_contents($manifestPath);
+    if (!is_string($content)) {
+        throw new WsprryPiUiIdentityError('Packaged UI manifest could not be read.');
+    }
+    echo $content;
+} catch (WsprryPiUiIdentityError $error) {
+    http_response_code(404);
+    echo json_encode([
+        'schema_version' => WSPRRYPI_UI_MANIFEST_SCHEMA_VERSION,
+        'error' => 'packaged_ui_manifest_unavailable',
+    ]);
+}

--- a/WsprryPi-UI/data/ui-version.php
+++ b/WsprryPi-UI/data/ui-version.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/ui_version.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+echo json_encode(
+    wsprrypiUiIdentityStatus(),
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+);

--- a/WsprryPi-UI/data/ui_version.php
+++ b/WsprryPi-UI/data/ui_version.php
@@ -24,83 +24,332 @@ function getWsprryPiUiVersion(): string
     return $version;
 }
 
-function wsprrypiUiBuildFileRecords(): array
-{
-    $root = __DIR__;
-    $trackedExtensions = [
-        'css' => true,
-        'js' => true,
-        'php' => true,
-    ];
-    $excludedFiles = [
-        'view_diag_logs.php' => true,
-    ];
-    $excludedDirectories = [
-        'cache' => true,
-    ];
-    $records = [];
+const WSPRRYPI_UI_MANIFEST_SCHEMA_VERSION = 1;
+const WSPRRYPI_UI_MANIFEST_FILENAME = 'ui-manifest.json';
+const WSPRRYPI_UI_IDENTITY_DOMAIN = "wsprrypi-ui-manifest-v1\0";
 
-    $directory = new RecursiveDirectoryIterator(
-        $root,
-        FilesystemIterator::SKIP_DOTS
-    );
-    $filter = new RecursiveCallbackFilterIterator(
-        $directory,
-        static function (SplFileInfo $current) use ($root, $excludedDirectories): bool {
-            if (!$current->isDir()) {
+final class WsprryPiUiIdentityError extends RuntimeException
+{
+}
+
+function wsprrypiUiIsNormalizedPath(string $path): bool
+{
+    if ($path === '' || $path[0] === '/' || strpos($path, '\\') !== false ||
+        preg_match('//u', $path) !== 1) {
+        return false;
+    }
+
+    $parts = explode('/', $path);
+    foreach ($parts as $part) {
+        if ($part === '' || $part === '.' || $part === '..') {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function wsprrypiUiIsCoveredPath(string $path): bool
+{
+    if (!wsprrypiUiIsNormalizedPath($path)) {
+        return false;
+    }
+
+    $parts = explode('/', $path);
+    if (in_array($parts[0], ['cache', 'backups'], true)) {
+        return false;
+    }
+    $filename = $parts[count($parts) - 1];
+    return !in_array($filename, [WSPRRYPI_UI_MANIFEST_FILENAME, '.DS_Store'], true);
+}
+
+function wsprrypiUiNormalizedRelativePath(string $root, string $pathname): string
+{
+    $prefix = rtrim(str_replace('\\', '/', $root), '/') . '/';
+    $normalized = str_replace('\\', '/', $pathname);
+    if (strncmp($normalized, $prefix, strlen($prefix)) !== 0) {
+        throw new WsprryPiUiIdentityError('UI file is outside the UI root.');
+    }
+
+    $relative = substr($normalized, strlen($prefix));
+    if (!wsprrypiUiIsNormalizedPath($relative)) {
+        throw new WsprryPiUiIdentityError('UI file has an unsafe path.');
+    }
+    return $relative;
+}
+
+function wsprrypiUiBuildFileRecords(?string $uiRoot = null): array
+{
+    $requestedRoot = $uiRoot ?? __DIR__;
+    $root = realpath($requestedRoot);
+    if ($root === false || !is_dir($root) || !is_readable($root)) {
+        throw new WsprryPiUiIdentityError('UI root is unavailable.');
+    }
+
+    $records = [];
+    try {
+        $directory = new RecursiveDirectoryIterator(
+            $root,
+            FilesystemIterator::SKIP_DOTS
+        );
+        $filter = new RecursiveCallbackFilterIterator(
+            $directory,
+            static function (SplFileInfo $current) use ($root): bool {
+                $pathname = $current->getPathname();
+                $relative = str_replace(
+                    '\\',
+                    '/',
+                    substr($pathname, strlen($root) + 1)
+                );
+                $segments = explode('/', $relative);
+                if ($current->isDir() && count($segments) === 1 &&
+                    in_array($segments[0], ['cache', 'backups'], true)) {
+                    return false;
+                }
                 return true;
             }
+        );
+        $iterator = new RecursiveIteratorIterator(
+            $filter,
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+    } catch (UnexpectedValueException $error) {
+        throw new WsprryPiUiIdentityError('UI directory could not be read.', 0, $error);
+    }
 
-            $relative = str_replace('\\', '/', substr($current->getPathname(), strlen($root) + 1));
-            $segments = explode('/', $relative);
-            return !isset($excludedDirectories[$segments[0] ?? '']);
+    try {
+        foreach ($iterator as $file) {
+            if (!$file instanceof SplFileInfo) {
+                continue;
+            }
+            if ($file->isLink()) {
+                throw new WsprryPiUiIdentityError(
+                    'Symbolic links are not supported in UI artifacts.'
+                );
+            }
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $relative = wsprrypiUiNormalizedRelativePath($root, $file->getPathname());
+            if (!wsprrypiUiIsCoveredPath($relative)) {
+                continue;
+            }
+            if (!is_readable($file->getPathname())) {
+                throw new WsprryPiUiIdentityError('A covered UI file is unreadable.');
+            }
+            $contentHash = @hash_file('sha256', $file->getPathname());
+            if (!is_string($contentHash)) {
+                throw new WsprryPiUiIdentityError('A covered UI file could not be hashed.');
+            }
+            $records[] = [
+                'path' => $relative,
+                'sha256' => $contentHash,
+            ];
         }
+    } catch (UnexpectedValueException $error) {
+        throw new WsprryPiUiIdentityError('UI directory could not be read.', 0, $error);
+    }
+
+    usort(
+        $records,
+        static fn(array $left, array $right): int => strcmp($left['path'], $right['path'])
     );
-    $iterator = new RecursiveIteratorIterator($filter);
+    return $records;
+}
 
-    foreach ($iterator as $file) {
-        if (!$file instanceof SplFileInfo || !$file->isFile()) {
-            continue;
+function wsprrypiUiBuildIdFromRecords(array $records): string
+{
+    $context = hash_init('sha256');
+    hash_update($context, WSPRRYPI_UI_IDENTITY_DOMAIN);
+    foreach ($records as $record) {
+        hash_update($context, $record['path']);
+        hash_update($context, "\0");
+        hash_update($context, $record['sha256']);
+        hash_update($context, "\n");
+    }
+    return 'sha256:' . hash_final($context);
+}
+
+function wsprrypiUiValidateManifest(mixed $manifest): array
+{
+    if (!is_array($manifest) || array_is_list($manifest)) {
+        throw new WsprryPiUiIdentityError('Manifest must be a JSON object.');
+    }
+    $expectedFields = [
+        'application_version', 'files', 'packaged_ui_build_id',
+        'schema_version', 'source_commit',
+    ];
+    $actualFields = array_keys($manifest);
+    sort($actualFields, SORT_STRING);
+    if ($actualFields !== $expectedFields) {
+        throw new WsprryPiUiIdentityError('Manifest fields do not match schema version 1.');
+    }
+    if ($manifest['schema_version'] !== WSPRRYPI_UI_MANIFEST_SCHEMA_VERSION) {
+        throw new WsprryPiUiIdentityError('Unsupported manifest schema version.');
+    }
+    if (!is_string($manifest['source_commit']) ||
+        preg_match('/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/D', $manifest['source_commit']) !== 1) {
+        throw new WsprryPiUiIdentityError('Manifest source commit is invalid.');
+    }
+    if (!is_string($manifest['application_version']) ||
+        trim($manifest['application_version']) === '') {
+        throw new WsprryPiUiIdentityError('Manifest application version is invalid.');
+    }
+    if (!is_string($manifest['packaged_ui_build_id']) || !is_array($manifest['files']) ||
+        !array_is_list($manifest['files'])) {
+        throw new WsprryPiUiIdentityError('Manifest identity or files are invalid.');
+    }
+
+    $records = [];
+    $previousPath = null;
+    foreach ($manifest['files'] as $entry) {
+        if (!is_array($entry) || array_is_list($entry)) {
+            throw new WsprryPiUiIdentityError('Manifest file entry is invalid.');
         }
-
-        $relative = str_replace('\\', '/', substr($file->getPathname(), strlen($root) + 1));
-        if (isset($excludedFiles[$relative])) {
-            continue;
+        $entryFields = array_keys($entry);
+        sort($entryFields, SORT_STRING);
+        if ($entryFields !== ['path', 'sha256'] ||
+            !is_string($entry['path']) || !wsprrypiUiIsCoveredPath($entry['path']) ||
+            !is_string($entry['sha256']) ||
+            preg_match('/^[0-9a-f]{64}$/D', $entry['sha256']) !== 1) {
+            throw new WsprryPiUiIdentityError('Manifest file entry is unsafe or malformed.');
         }
-
-        $extension = strtolower($file->getExtension());
-        if (!isset($trackedExtensions[$extension])) {
-            continue;
+        if ($previousPath !== null && strcmp($entry['path'], $previousPath) <= 0) {
+            throw new WsprryPiUiIdentityError(
+                'Manifest paths must be unique and deterministically ordered.'
+            );
         }
+        $previousPath = $entry['path'];
+        $records[] = ['path' => $entry['path'], 'sha256' => $entry['sha256']];
+    }
 
-        $records[] = sprintf(
-            '%s|%d|%d',
-            $relative,
-            $file->getMTime(),
-            $file->getSize()
+    if (!hash_equals(
+        wsprrypiUiBuildIdFromRecords($records),
+        $manifest['packaged_ui_build_id']
+    )) {
+        throw new WsprryPiUiIdentityError('Manifest identity does not match its file records.');
+    }
+    return $manifest;
+}
+
+function wsprrypiUiLoadManifest(string $manifestPath): array
+{
+    if (!is_file($manifestPath) || !is_readable($manifestPath)) {
+        throw new WsprryPiUiIdentityError('Packaged UI manifest is unavailable.');
+    }
+    $content = @file_get_contents($manifestPath);
+    if (!is_string($content)) {
+        throw new WsprryPiUiIdentityError('Packaged UI manifest could not be read.');
+    }
+    try {
+        $manifest = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+    } catch (JsonException $error) {
+        throw new WsprryPiUiIdentityError('Packaged UI manifest is malformed.', 0, $error);
+    }
+    return wsprrypiUiValidateManifest($manifest);
+}
+
+function wsprrypiUiUnknownIdentity(
+    string $error,
+    ?string $packagedBuildId = null,
+    ?string $installedBuildId = null
+): array {
+    return [
+        'schema_version' => WSPRRYPI_UI_MANIFEST_SCHEMA_VERSION,
+        'installed_state' => 'unknown',
+        'packaged_ui_build_id' => $packagedBuildId,
+        'installed_ui_build_id' => $installedBuildId,
+        'modified_files' => [],
+        'added_files' => [],
+        'missing_files' => [],
+        'error' => $error,
+    ];
+}
+
+function wsprrypiUiIdentityStatus(
+    ?string $uiRoot = null,
+    ?string $manifestPath = null
+): array {
+    $root = $uiRoot ?? __DIR__;
+    $manifest = $manifestPath ?? $root . DIRECTORY_SEPARATOR . WSPRRYPI_UI_MANIFEST_FILENAME;
+    try {
+        $installedRecords = wsprrypiUiBuildFileRecords($root);
+        $installedBuildId = wsprrypiUiBuildIdFromRecords($installedRecords);
+    } catch (WsprryPiUiIdentityError $error) {
+        return wsprrypiUiUnknownIdentity($error->getMessage());
+    }
+
+    try {
+        $packagedManifest = wsprrypiUiLoadManifest($manifest);
+    } catch (WsprryPiUiIdentityError $error) {
+        return wsprrypiUiUnknownIdentity(
+            $error->getMessage(),
+            null,
+            $installedBuildId
         );
     }
 
-    sort($records, SORT_STRING);
-    return $records;
+    $packagedByPath = [];
+    foreach ($packagedManifest['files'] as $record) {
+        $packagedByPath[$record['path']] = $record['sha256'];
+    }
+    $installedByPath = [];
+    foreach ($installedRecords as $record) {
+        $installedByPath[$record['path']] = $record['sha256'];
+    }
+
+    $modifiedFiles = [];
+    foreach (array_intersect(array_keys($packagedByPath), array_keys($installedByPath)) as $path) {
+        if (!hash_equals($packagedByPath[$path], $installedByPath[$path])) {
+            $modifiedFiles[] = $path;
+        }
+    }
+    $addedFiles = array_values(array_diff(array_keys($installedByPath), array_keys($packagedByPath)));
+    $missingFiles = array_values(array_diff(array_keys($packagedByPath), array_keys($installedByPath)));
+    foreach ([&$modifiedFiles, &$addedFiles, &$missingFiles] as &$paths) {
+        usort($paths, static fn(string $left, string $right): int => strcmp($left, $right));
+    }
+    unset($paths);
+
+    $packagedBuildId = $packagedManifest['packaged_ui_build_id'];
+    $state = hash_equals($packagedBuildId, $installedBuildId) &&
+        $modifiedFiles === [] && $addedFiles === [] && $missingFiles === []
+        ? 'packaged'
+        : 'locally_modified';
+    return [
+        'schema_version' => WSPRRYPI_UI_MANIFEST_SCHEMA_VERSION,
+        'installed_state' => $state,
+        'packaged_ui_build_id' => $packagedBuildId,
+        'installed_ui_build_id' => $installedBuildId,
+        'modified_files' => $modifiedFiles,
+        'added_files' => $addedFiles,
+        'missing_files' => $missingFiles,
+        'error' => null,
+    ];
+}
+
+function getWsprryPiInstalledUiBuildId(): string
+{
+    static $buildId = null;
+    if ($buildId !== null) {
+        return $buildId;
+    }
+    $identity = wsprrypiUiIdentityStatus();
+    $buildId = is_string($identity['installed_ui_build_id'])
+        ? $identity['installed_ui_build_id']
+        : '';
+    return $buildId;
 }
 
 function getWsprryPiUiBuildId(): string
 {
-    static $buildId = null;
-
-    if ($buildId !== null) {
-        return $buildId;
-    }
-
-    $records = wsprrypiUiBuildFileRecords();
-    $buildId = 'mtime-' . substr(hash('sha256', implode("\n", $records)), 0, 16);
-    return $buildId;
+    return getWsprryPiInstalledUiBuildId();
 }
 
 function wsprrypiAssetUrl(string $path): string
 {
-    $buildId = getWsprryPiUiBuildId();
+    $buildId = getWsprryPiInstalledUiBuildId();
     if ($buildId === '') {
         return $path;
     }

--- a/WsprryPi-UI/package.json
+++ b/WsprryPi-UI/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:unit",
     "test:unit": "npm run test:manifest && node tests/cw_timing_state_test.js && node tests/responsive_shell_logs_test.js && node tests/spots_hardening_test.js && node tests/network_safety_ui_test.js && node tests/support_bundle_ui_test.js && node tests/support_intake_ui_harness_test.js && node tests/wspr_band_frequency_correlation_test.js && php tests/gpio_dropdown_test.php && php tests/spot_menu_test.php",
-    "test:manifest": "python3 tests/ui_manifest_test.py && python3 tests/ui_installation_classification_test.py",
+    "test:manifest": "python3 tests/ui_manifest_test.py && python3 tests/ui_installation_classification_test.py && php tests/ui_identity_test.php && python3 tests/ui_identity_http_integration_test.py",
     "test:browser": "node tests/conditional_transmit_gpio_integration_test.js && node tests/cw_duration_latch_integration_test.js && node tests/support_intake_ui_integration_test.js"
   },
   "devDependencies": {

--- a/WsprryPi-UI/package.json
+++ b/WsprryPi-UI/package.json
@@ -5,7 +5,8 @@
   "description": "Development and test dependencies for the WsprryPi UI component",
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node tests/cw_timing_state_test.js && node tests/responsive_shell_logs_test.js && node tests/spots_hardening_test.js && node tests/network_safety_ui_test.js && node tests/support_bundle_ui_test.js && node tests/support_intake_ui_harness_test.js && node tests/wspr_band_frequency_correlation_test.js && php tests/gpio_dropdown_test.php && php tests/spot_menu_test.php",
+    "test:unit": "npm run test:manifest && node tests/cw_timing_state_test.js && node tests/responsive_shell_logs_test.js && node tests/spots_hardening_test.js && node tests/network_safety_ui_test.js && node tests/support_bundle_ui_test.js && node tests/support_intake_ui_harness_test.js && node tests/wspr_band_frequency_correlation_test.js && php tests/gpio_dropdown_test.php && php tests/spot_menu_test.php",
+    "test:manifest": "python3 tests/ui_manifest_test.py",
     "test:browser": "node tests/conditional_transmit_gpio_integration_test.js && node tests/cw_duration_latch_integration_test.js && node tests/support_intake_ui_integration_test.js"
   },
   "devDependencies": {

--- a/WsprryPi-UI/package.json
+++ b/WsprryPi-UI/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:unit",
     "test:unit": "npm run test:manifest && node tests/cw_timing_state_test.js && node tests/responsive_shell_logs_test.js && node tests/spots_hardening_test.js && node tests/network_safety_ui_test.js && node tests/support_bundle_ui_test.js && node tests/support_intake_ui_harness_test.js && node tests/wspr_band_frequency_correlation_test.js && php tests/gpio_dropdown_test.php && php tests/spot_menu_test.php",
-    "test:manifest": "python3 tests/ui_manifest_test.py",
+    "test:manifest": "python3 tests/ui_manifest_test.py && python3 tests/ui_installation_classification_test.py",
     "test:browser": "node tests/conditional_transmit_gpio_integration_test.js && node tests/cw_duration_latch_integration_test.js && node tests/support_intake_ui_integration_test.js"
   },
   "devDependencies": {

--- a/WsprryPi-UI/scripts/generate_ui_manifest.py
+++ b/WsprryPi-UI/scripts/generate_ui_manifest.py
@@ -71,8 +71,13 @@ def collect_file_records(ui_root: Path) -> list[dict[str, str]]:
     if not root.is_dir():
         raise ManifestError(f"UI root is not a directory: {ui_root}")
 
+    def raise_walk_error(error: OSError) -> None:
+        raise error
+
     records: list[dict[str, str]] = []
-    for current, directory_names, file_names in os.walk(root, topdown=True, followlinks=False):
+    for current, directory_names, file_names in os.walk(
+        root, topdown=True, onerror=raise_walk_error, followlinks=False
+    ):
         current_path = Path(current)
         if current_path == root:
             directory_names[:] = [
@@ -215,6 +220,85 @@ def load_manifest(path: Path) -> dict[str, Any]:
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
         raise ManifestError(f"could not read manifest: {error}") from error
     return validate_manifest(value)
+
+
+def unknown_installation_classification(
+    error: str,
+    packaged_ui_build_id_value: str | None = None,
+) -> dict[str, Any]:
+    """Return a fail-closed result when either UI identity is unavailable."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "installed_state": "unknown",
+        "packaged_ui_build_id": packaged_ui_build_id_value,
+        "installed_ui_build_id": None,
+        "modified_files": [],
+        "added_files": [],
+        "missing_files": [],
+        "error": error,
+    }
+
+
+def classify_installed_ui(ui_root: Path, manifest_path: Path) -> dict[str, Any]:
+    """Compare installed UI files with a validated immutable package manifest.
+
+    Classification is read-only. Invalid or unreadable inputs produce an
+    ``unknown`` result rather than treating an unverified installation as
+    packaged or locally modified.
+    """
+    try:
+        manifest = load_manifest(manifest_path)
+    except ManifestError as error:
+        return unknown_installation_classification(str(error))
+
+    packaged_id = manifest["packaged_ui_build_id"]
+    try:
+        installed_records = collect_file_records(ui_root)
+    except (ManifestError, OSError) as error:
+        return unknown_installation_classification(str(error), packaged_id)
+
+    packaged_by_path = {
+        record["path"]: record["sha256"] for record in manifest["files"]
+    }
+    installed_by_path = {
+        record["path"]: record["sha256"] for record in installed_records
+    }
+    packaged_paths = set(packaged_by_path)
+    installed_paths = set(installed_by_path)
+    modified_files = sorted(
+        (
+            path for path in packaged_paths & installed_paths
+            if packaged_by_path[path] != installed_by_path[path]
+        ),
+        key=lambda path: path.encode("utf-8"),
+    )
+    added_files = sorted(
+        installed_paths - packaged_paths,
+        key=lambda path: path.encode("utf-8"),
+    )
+    missing_files = sorted(
+        packaged_paths - installed_paths,
+        key=lambda path: path.encode("utf-8"),
+    )
+    installed_id = packaged_ui_build_id(installed_records)
+    installed_state = (
+        "packaged"
+        if installed_id == packaged_id
+        and not modified_files
+        and not added_files
+        and not missing_files
+        else "locally_modified"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "installed_state": installed_state,
+        "packaged_ui_build_id": packaged_id,
+        "installed_ui_build_id": installed_id,
+        "modified_files": modified_files,
+        "added_files": added_files,
+        "missing_files": missing_files,
+        "error": None,
+    }
 
 
 def main() -> int:

--- a/WsprryPi-UI/scripts/generate_ui_manifest.py
+++ b/WsprryPi-UI/scripts/generate_ui_manifest.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Generate and validate a deterministic manifest for packaged WsprryPi UI files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+MANIFEST_FILENAME = "ui-manifest.json"
+EXCLUDED_TOP_LEVEL_DIRECTORIES = frozenset({"cache", "backups"})
+EXCLUDED_FILENAMES = frozenset({MANIFEST_FILENAME, ".DS_Store"})
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SOURCE_COMMIT_PATTERN = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+
+
+class ManifestError(ValueError):
+    """Raised when UI files or manifest data violate the schema contract."""
+
+
+def normalized_relative_path(ui_root: Path, candidate: Path) -> str:
+    """Return a portable, safe path for a file beneath *ui_root*."""
+    try:
+        relative = candidate.relative_to(ui_root)
+    except ValueError as error:
+        raise ManifestError(f"UI file is outside the UI root: {candidate}") from error
+
+    path = relative.as_posix()
+    pure = PurePosixPath(path)
+    if (
+        not path
+        or path.startswith("/")
+        or "\\" in path
+        or pure.is_absolute()
+        or any(part in {"", ".", ".."} for part in pure.parts)
+    ):
+        raise ManifestError(f"unsafe UI manifest path: {path!r}")
+    return path
+
+
+def is_covered_path(relative_path: str) -> bool:
+    """Return whether a normalized installed-UI path belongs in the identity."""
+    pure = PurePosixPath(relative_path)
+    if not pure.parts or any(part in {"", ".", ".."} for part in pure.parts):
+        return False
+    if pure.parts[0] in EXCLUDED_TOP_LEVEL_DIRECTORIES:
+        return False
+    if pure.name in EXCLUDED_FILENAMES:
+        return False
+    return True
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def collect_file_records(ui_root: Path) -> list[dict[str, str]]:
+    """Hash covered regular files below *ui_root* in normalized path order."""
+    root = ui_root.resolve()
+    if not root.is_dir():
+        raise ManifestError(f"UI root is not a directory: {ui_root}")
+
+    records: list[dict[str, str]] = []
+    for current, directory_names, file_names in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        if current_path == root:
+            directory_names[:] = [
+                name for name in directory_names
+                if name not in EXCLUDED_TOP_LEVEL_DIRECTORIES
+            ]
+        for directory_name in directory_names:
+            candidate = current_path / directory_name
+            if candidate.is_symlink():
+                raise ManifestError(
+                    f"symbolic links are not supported in UI artifacts: {candidate}"
+                )
+        directory_names.sort(key=lambda name: name.encode("utf-8"))
+        for file_name in sorted(file_names, key=lambda name: name.encode("utf-8")):
+            candidate = current_path / file_name
+            if candidate.is_symlink():
+                raise ManifestError(
+                    f"symbolic links are not supported in UI artifacts: {candidate}"
+                )
+            if not candidate.is_file():
+                continue
+            relative = normalized_relative_path(root, candidate)
+            if is_covered_path(relative):
+                records.append({"path": relative, "sha256": sha256_file(candidate)})
+
+    records.sort(key=lambda record: record["path"].encode("utf-8"))
+    return records
+
+
+def packaged_ui_build_id(records: Iterable[dict[str, str]]) -> str:
+    """Derive the schema-v1 identity from normalized paths and content hashes."""
+    digest = hashlib.sha256()
+    digest.update(b"wsprrypi-ui-manifest-v1\0")
+    for record in records:
+        path = record["path"]
+        content_hash = record["sha256"]
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(content_hash.encode("ascii"))
+        digest.update(b"\n")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def build_manifest(ui_root: Path, source_commit: str, application_version: str) -> dict[str, Any]:
+    source_commit = source_commit.strip()
+    application_version = application_version.strip()
+    if not SOURCE_COMMIT_PATTERN.fullmatch(source_commit):
+        raise ManifestError("source_commit must be a lowercase 40- or 64-character Git object ID")
+    if not application_version:
+        raise ManifestError("application_version must not be empty")
+
+    records = collect_file_records(ui_root)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "packaged_ui_build_id": packaged_ui_build_id(records),
+        "source_commit": source_commit,
+        "application_version": application_version,
+        "files": records,
+    }
+
+
+def validate_manifest(manifest: Any) -> dict[str, Any]:
+    """Validate schema-v1 structure, safe paths, ordering, and derived identity."""
+    if not isinstance(manifest, dict):
+        raise ManifestError("manifest must be a JSON object")
+    expected_fields = {
+        "schema_version", "packaged_ui_build_id", "source_commit",
+        "application_version", "files",
+    }
+    if set(manifest) != expected_fields:
+        raise ManifestError("manifest fields do not match schema version 1")
+    if manifest["schema_version"] != SCHEMA_VERSION or isinstance(manifest["schema_version"], bool):
+        raise ManifestError("unsupported schema_version")
+    if (
+        not isinstance(manifest["source_commit"], str)
+        or not SOURCE_COMMIT_PATTERN.fullmatch(manifest["source_commit"])
+    ):
+        raise ManifestError("source_commit must be a lowercase 40- or 64-character Git object ID")
+    if (
+        not isinstance(manifest["application_version"], str)
+        or not manifest["application_version"].strip()
+    ):
+        raise ManifestError("application_version must be a non-empty string")
+    if not isinstance(manifest["files"], list):
+        raise ManifestError("files must be an array")
+
+    records: list[dict[str, str]] = []
+    previous_path: bytes | None = None
+    for entry in manifest["files"]:
+        if not isinstance(entry, dict) or set(entry) != {"path", "sha256"}:
+            raise ManifestError("each file entry must contain only path and sha256")
+        path = entry["path"]
+        content_hash = entry["sha256"]
+        if not isinstance(path, str) or not is_covered_path(path):
+            raise ManifestError(f"unsafe or excluded manifest path: {path!r}")
+        pure = PurePosixPath(path)
+        if pure.as_posix() != path or path.startswith("/") or "\\" in path:
+            raise ManifestError(f"manifest path is not normalized: {path!r}")
+        if not isinstance(content_hash, str) or not SHA256_PATTERN.fullmatch(content_hash):
+            raise ManifestError(f"invalid SHA-256 for {path!r}")
+        encoded_path = path.encode("utf-8")
+        if previous_path is not None and encoded_path <= previous_path:
+            raise ManifestError("file entries must have unique paths in deterministic order")
+        previous_path = encoded_path
+        records.append({"path": path, "sha256": content_hash})
+
+    expected_id = packaged_ui_build_id(records)
+    if manifest["packaged_ui_build_id"] != expected_id:
+        raise ManifestError("packaged_ui_build_id does not match the file records")
+    return manifest
+
+
+def serialize_manifest(manifest: dict[str, Any]) -> bytes:
+    validate_manifest(manifest)
+    return (json.dumps(manifest, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def write_atomic(destination: Path, content: bytes) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.", dir=destination.parent
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as temporary_file:
+            temporary_file.write(content)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        os.replace(temporary_name, destination)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ManifestError(f"could not read manifest: {error}") from error
+    return validate_manifest(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ui-root", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--source-commit")
+    parser.add_argument("--application-version")
+    parser.add_argument("--validate", type=Path)
+    args = parser.parse_args()
+
+    try:
+        if args.validate is not None:
+            if any(value is not None for value in (
+                args.ui_root, args.output, args.source_commit, args.application_version
+            )):
+                parser.error("--validate cannot be combined with generation arguments")
+            load_manifest(args.validate)
+            print(f"UI manifest valid: {args.validate}")
+            return 0
+
+        if None in (args.ui_root, args.output, args.source_commit, args.application_version):
+            parser.error(
+                "generation requires --ui-root, --output, --source-commit, and --application-version"
+            )
+        manifest = build_manifest(
+            args.ui_root, args.source_commit, args.application_version
+        )
+        write_atomic(args.output, serialize_manifest(manifest))
+    except (ManifestError, OSError) as error:
+        print(f"UI manifest generation failed: {error}", file=os.sys.stderr)
+        return 1
+
+    print(f"UI manifest written: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/WsprryPi-UI/scripts/generate_ui_manifest.py
+++ b/WsprryPi-UI/scripts/generate_ui_manifest.py
@@ -225,13 +225,14 @@ def load_manifest(path: Path) -> dict[str, Any]:
 def unknown_installation_classification(
     error: str,
     packaged_ui_build_id_value: str | None = None,
+    installed_ui_build_id_value: str | None = None,
 ) -> dict[str, Any]:
     """Return a fail-closed result when either UI identity is unavailable."""
     return {
         "schema_version": SCHEMA_VERSION,
         "installed_state": "unknown",
         "packaged_ui_build_id": packaged_ui_build_id_value,
-        "installed_ui_build_id": None,
+        "installed_ui_build_id": installed_ui_build_id_value,
         "modified_files": [],
         "added_files": [],
         "missing_files": [],
@@ -247,15 +248,19 @@ def classify_installed_ui(ui_root: Path, manifest_path: Path) -> dict[str, Any]:
     packaged or locally modified.
     """
     try:
+        installed_records = collect_file_records(ui_root)
+    except (ManifestError, OSError, UnicodeError) as error:
+        return unknown_installation_classification(str(error))
+    installed_id = packaged_ui_build_id(installed_records)
+
+    try:
         manifest = load_manifest(manifest_path)
     except ManifestError as error:
-        return unknown_installation_classification(str(error))
+        return unknown_installation_classification(
+            str(error), installed_ui_build_id_value=installed_id
+        )
 
     packaged_id = manifest["packaged_ui_build_id"]
-    try:
-        installed_records = collect_file_records(ui_root)
-    except (ManifestError, OSError) as error:
-        return unknown_installation_classification(str(error), packaged_id)
 
     packaged_by_path = {
         record["path"]: record["sha256"] for record in manifest["files"]
@@ -280,7 +285,6 @@ def classify_installed_ui(ui_root: Path, manifest_path: Path) -> dict[str, Any]:
         packaged_paths - installed_paths,
         key=lambda path: path.encode("utf-8"),
     )
-    installed_id = packaged_ui_build_id(installed_records)
     installed_state = (
         "packaged"
         if installed_id == packaged_id
@@ -328,7 +332,7 @@ def main() -> int:
             args.ui_root, args.source_commit, args.application_version
         )
         write_atomic(args.output, serialize_manifest(manifest))
-    except (ManifestError, OSError) as error:
+    except (ManifestError, OSError, UnicodeError) as error:
         print(f"UI manifest generation failed: {error}", file=os.sys.stderr)
         return 1
 

--- a/WsprryPi-UI/tests/responsive_shell_logs_test.js
+++ b/WsprryPi-UI/tests/responsive_shell_logs_test.js
@@ -41,6 +41,16 @@ assert.match(
     "the keyboard bypass target must accept programmatic focus"
 );
 assert.match(
+    pageShell,
+    /id="uiConsistencyDiagnostic"[\s\S]*?role="status"[\s\S]*?aria-live="polite"[\s\S]*?UI consistency could not be confirmed/,
+    "the shared shell must provide a persistent, assistive-technology-readable UI consistency diagnostic"
+);
+assert.match(
+    siteCss,
+    /\.ui-consistency-diagnostic\s*{[\s\S]*?overflow-wrap:\s*anywhere;/,
+    "long UI identities must wrap without overflowing the diagnostic"
+);
+assert.match(
     logsJs,
     /isConnecting[\s\S]*?"Connecting…"[\s\S]*?btn\.disabled = isConnecting;[\s\S]*?aria-disabled/,
     "log reconnect must reject concurrent restart actions while connecting"

--- a/WsprryPi-UI/tests/ui_identity_http_integration_test.py
+++ b/WsprryPi-UI/tests/ui_identity_http_integration_test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Exercise the UI-owned PHP identity routes and rendered page metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def free_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def fetch(url: str) -> tuple[int, dict[str, str], bytes]:
+    try:
+        response = urllib.request.urlopen(url, timeout=5)
+    except urllib.error.HTTPError as error:
+        response = error
+    with response:
+        return response.status, dict(response.headers.items()), response.read()
+
+
+with tempfile.TemporaryDirectory() as temporary:
+    web_root = Path(temporary) / "data"
+    shutil.copytree(ROOT / "data", web_root)
+    subprocess.run(
+        [
+            "python3", str(ROOT / "scripts" / "generate_ui_manifest.py"),
+            "--ui-root", str(web_root),
+            "--output", str(web_root / "ui-manifest.json"),
+            "--source-commit", "d" * 40,
+            "--application-version", "1.2.3",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    port = free_port()
+    server = subprocess.Popen(
+        ["php", "-S", f"127.0.0.1:{port}", "-t", str(web_root)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        base = f"http://127.0.0.1:{port}"
+        for _ in range(50):
+            try:
+                status, _, _ = fetch(f"{base}/ui-version.php")
+                if status == 200:
+                    break
+            except OSError:
+                pass
+            time.sleep(0.05)
+        else:
+            raise AssertionError("PHP test server did not become ready")
+
+        status, headers, body = fetch(f"{base}/ui-version.php")
+        assert status == 200
+        assert "no-store" in headers.get("Cache-Control", "")
+        identity = json.loads(body)
+        assert identity["installed_state"] == "packaged"
+        assert identity["installed_ui_build_id"] == identity["packaged_ui_build_id"]
+        assert re.fullmatch(r"sha256:[0-9a-f]{64}", identity["installed_ui_build_id"])
+
+        status, page_headers, page = fetch(f"{base}/index.php")
+        assert status == 200
+        assert "no-cache" in page_headers.get("Cache-Control", "")
+        html = page.decode("utf-8")
+        match = re.search(
+            r'window\.WSPRRYPI_INSTALLED_UI_BUILD_ID = "(sha256:[0-9a-f]{64})";',
+            html,
+        )
+        assert match and match.group(1) == identity["installed_ui_build_id"]
+        encoded_identity = identity["installed_ui_build_id"].replace(":", "%3A")
+        assert f"site.css?v={encoded_identity}" in html
+        assert f"site.js?v={encoded_identity}" in html
+        assert f"site.webmanifest?v={encoded_identity}" in html
+
+        status, manifest_headers, manifest_body = fetch(f"{base}/ui-manifest.php")
+        assert status == 200
+        assert "no-store" in manifest_headers.get("Cache-Control", "")
+        exposed_manifest = json.loads(manifest_body)
+        assert exposed_manifest["packaged_ui_build_id"] == identity["packaged_ui_build_id"]
+
+        with (web_root / "site.css").open("a", encoding="utf-8") as stylesheet:
+            stylesheet.write("\n/* local edit */\n")
+        status, _, edited_body = fetch(f"{base}/ui-version.php")
+        assert status == 200
+        edited_identity = json.loads(edited_body)
+        assert edited_identity["installed_state"] == "locally_modified"
+        assert edited_identity["modified_files"] == ["site.css"]
+        assert edited_identity["installed_ui_build_id"] != identity["installed_ui_build_id"]
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            server.kill()
+            server.wait(timeout=5)
+        stdout, stderr = server.communicate()
+        if server.returncode not in (0, -15):
+            raise RuntimeError(f"PHP server failed ({server.returncode})\n{stdout}\n{stderr}")
+
+print("ui_identity_http_integration_test passed")

--- a/WsprryPi-UI/tests/ui_identity_test.php
+++ b/WsprryPi-UI/tests/ui_identity_test.php
@@ -1,0 +1,98 @@
+<?php
+require_once __DIR__ . '/../data/ui_version.php';
+
+function requireTrue(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function removeTree(string $root): void
+{
+    if (!is_dir($root)) {
+        return;
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $entry) {
+        if ($entry->isDir() && !$entry->isLink()) {
+            rmdir($entry->getPathname());
+        } else {
+            unlink($entry->getPathname());
+        }
+    }
+    rmdir($root);
+}
+
+$root = sys_get_temp_dir() . '/wsprrypi-ui-identity-' . bin2hex(random_bytes(8));
+$manifestPath = $root . '/ui-manifest.json';
+mkdir($root . '/views', 0700, true);
+mkdir($root . '/cache', 0700, true);
+mkdir($root . '/backups', 0700, true);
+file_put_contents($root . '/site.js', "const packaged = true;\n");
+file_put_contents($root . '/views/index.php', "<?php echo 'packaged';\n");
+file_put_contents($root . '/café.css', "body { color: black; }\n");
+
+try {
+    $generator = realpath(__DIR__ . '/../scripts/generate_ui_manifest.py');
+    requireTrue(is_string($generator), 'manifest generator was not found');
+    $command = implode(' ', [
+        'python3',
+        escapeshellarg($generator),
+        '--ui-root', escapeshellarg($root),
+        '--output', escapeshellarg($manifestPath),
+        '--source-commit', escapeshellarg(str_repeat('c', 40)),
+        '--application-version', escapeshellarg('1.2.3'),
+    ]);
+    exec($command, $output, $status);
+    requireTrue($status === 0, 'Python manifest generation failed');
+
+    $manifest = json_decode(file_get_contents($manifestPath), true, 512, JSON_THROW_ON_ERROR);
+    $packaged = wsprrypiUiIdentityStatus($root, $manifestPath);
+    requireTrue(
+        $packaged['installed_state'] === 'packaged',
+        'matching UI must be packaged: ' . json_encode($packaged)
+    );
+    requireTrue(
+        $packaged['installed_ui_build_id'] === $manifest['packaged_ui_build_id'],
+        'PHP and Python identities must match'
+    );
+    requireTrue($packaged['modified_files'] === [], 'packaged UI must not report modifications');
+
+    $edited = "const userEdited = true;\n";
+    file_put_contents($root . '/site.js', $edited);
+    file_put_contents($root . '/custom.css', "body { color: purple; }\n");
+    unlink($root . '/views/index.php');
+    file_put_contents($root . '/cache/runtime.json', "runtime\n");
+    file_put_contents($root . '/backups/site.js', "old\n");
+
+    $modified = wsprrypiUiIdentityStatus($root, $manifestPath);
+    requireTrue($modified['installed_state'] === 'locally_modified', 'edits must be local');
+    requireTrue($modified['modified_files'] === ['site.js'], 'changed file inventory mismatch');
+    requireTrue($modified['added_files'] === ['custom.css'], 'added file inventory mismatch');
+    requireTrue($modified['missing_files'] === ['views/index.php'], 'missing inventory mismatch');
+    requireTrue(file_get_contents($root . '/site.js') === $edited, 'classification changed user edit');
+
+    $unsafe = $manifest;
+    $unsafe['files'][0]['path'] = '../outside.js';
+    file_put_contents($manifestPath, json_encode($unsafe));
+    $unknown = wsprrypiUiIdentityStatus($root, $manifestPath);
+    requireTrue($unknown['installed_state'] === 'unknown', 'unsafe manifest must be unknown');
+    requireTrue(is_string($unknown['installed_ui_build_id']), 'installed identity should remain available');
+    requireTrue($unknown['packaged_ui_build_id'] === null, 'unsafe packaged identity must not be trusted');
+
+    unlink($manifestPath);
+    $missingManifest = wsprrypiUiIdentityStatus($root, $manifestPath);
+    requireTrue($missingManifest['installed_state'] === 'unknown', 'missing manifest must be unknown');
+    requireTrue(
+        is_string($missingManifest['installed_ui_build_id']),
+        'missing manifest must not suppress installed identity'
+    );
+} finally {
+    removeTree($root);
+}
+
+echo "ui_identity_test passed\n";

--- a/WsprryPi-UI/tests/ui_installation_classification_test.py
+++ b/WsprryPi-UI/tests/ui_installation_classification_test.py
@@ -44,9 +44,14 @@ class UiInstallationClassificationTest(unittest.TestCase):
     def classify(self):
         return manifest_module.classify_installed_ui(self.root, self.manifest_path)
 
-    def assert_unknown(self, result) -> None:
+    def assert_unknown(self, result, installed_identity_available=True) -> None:
         self.assertEqual(result["installed_state"], "unknown")
-        self.assertIsNone(result["installed_ui_build_id"])
+        if installed_identity_available:
+            self.assertRegex(
+                result["installed_ui_build_id"], r"^sha256:[0-9a-f]{64}$"
+            )
+        else:
+            self.assertIsNone(result["installed_ui_build_id"])
         self.assertTrue(result["error"])
         self.assertEqual(result["modified_files"], [])
         self.assertEqual(result["added_files"], [])
@@ -115,11 +120,8 @@ class UiInstallationClassificationTest(unittest.TestCase):
             side_effect=PermissionError("installed file permission denied"),
         ):
             result = self.classify()
-        self.assert_unknown(result)
-        self.assertEqual(
-            result["packaged_ui_build_id"],
-            self.packaged_manifest["packaged_ui_build_id"],
-        )
+        self.assert_unknown(result, installed_identity_available=False)
+        self.assertIsNone(result["packaged_ui_build_id"])
 
     def test_unreadable_installed_directory_is_unknown(self) -> None:
         def denied_walk(*args, **kwargs):
@@ -128,11 +130,8 @@ class UiInstallationClassificationTest(unittest.TestCase):
 
         with mock.patch.object(manifest_module.os, "walk", side_effect=denied_walk):
             result = self.classify()
-        self.assert_unknown(result)
-        self.assertEqual(
-            result["packaged_ui_build_id"],
-            self.packaged_manifest["packaged_ui_build_id"],
-        )
+        self.assert_unknown(result, installed_identity_available=False)
+        self.assertIsNone(result["packaged_ui_build_id"])
 
     def test_malformed_json_is_unknown(self) -> None:
         self.manifest_path.write_text("{not json\n", encoding="utf-8")

--- a/WsprryPi-UI/tests/ui_installation_classification_test.py
+++ b/WsprryPi-UI/tests/ui_installation_classification_test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Regression tests for installed WsprryPi UI identity classification."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "generate_ui_manifest.py"
+SPEC = importlib.util.spec_from_file_location("generate_ui_manifest", SCRIPT)
+assert SPEC and SPEC.loader
+manifest_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(manifest_module)
+
+
+class UiInstallationClassificationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        (self.root / "views").mkdir()
+        (self.root / "cache").mkdir()
+        (self.root / "backups").mkdir()
+        (self.root / "site.js").write_text("const packaged = true;\n", encoding="utf-8")
+        (self.root / "views" / "index.php").write_text("<?php echo 'packaged';\n", encoding="utf-8")
+        self.manifest_path = self.root / "ui-manifest.json"
+        self.packaged_manifest = manifest_module.build_manifest(
+            self.root, "b" * 40, "1.2.3"
+        )
+        self.write_manifest(self.packaged_manifest)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_manifest(self, manifest) -> None:
+        self.manifest_path.write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def classify(self):
+        return manifest_module.classify_installed_ui(self.root, self.manifest_path)
+
+    def assert_unknown(self, result) -> None:
+        self.assertEqual(result["installed_state"], "unknown")
+        self.assertIsNone(result["installed_ui_build_id"])
+        self.assertTrue(result["error"])
+        self.assertEqual(result["modified_files"], [])
+        self.assertEqual(result["added_files"], [])
+        self.assertEqual(result["missing_files"], [])
+
+    def test_matching_installation_is_packaged(self) -> None:
+        result = self.classify()
+        self.assertEqual(result["installed_state"], "packaged")
+        self.assertEqual(
+            result["installed_ui_build_id"], result["packaged_ui_build_id"]
+        )
+        self.assertEqual(result["modified_files"], [])
+        self.assertEqual(result["added_files"], [])
+        self.assertEqual(result["missing_files"], [])
+        self.assertIsNone(result["error"])
+
+    def test_changed_added_and_missing_files_are_reported(self) -> None:
+        (self.root / "site.js").write_text("const userEdited = true;\n", encoding="utf-8")
+        (self.root / "custom.css").write_text("body { color: purple; }\n", encoding="utf-8")
+        (self.root / "views" / "index.php").unlink()
+
+        result = self.classify()
+
+        self.assertEqual(result["installed_state"], "locally_modified")
+        self.assertNotEqual(
+            result["installed_ui_build_id"], result["packaged_ui_build_id"]
+        )
+        self.assertEqual(result["modified_files"], ["site.js"])
+        self.assertEqual(result["added_files"], ["custom.css"])
+        self.assertEqual(result["missing_files"], ["views/index.php"])
+
+    def test_stable_user_edit_is_classified_without_being_changed(self) -> None:
+        edited = b"const userEdited = true;\n"
+        target = self.root / "site.js"
+        target.write_bytes(edited)
+
+        first = self.classify()
+        second = self.classify()
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["installed_state"], "locally_modified")
+        self.assertEqual(first["modified_files"], ["site.js"])
+        self.assertEqual(target.read_bytes(), edited)
+
+    def test_excluded_runtime_and_backup_files_do_not_change_state(self) -> None:
+        (self.root / "cache" / "spots.json").write_text("runtime\n", encoding="utf-8")
+        (self.root / "backups" / "site.js").write_text("old\n", encoding="utf-8")
+
+        result = self.classify()
+
+        self.assertEqual(result["installed_state"], "packaged")
+        self.assertEqual(result["added_files"], [])
+
+    def test_unreadable_manifest_is_unknown(self) -> None:
+        with mock.patch.object(
+            manifest_module.Path,
+            "read_text",
+            side_effect=PermissionError("manifest permission denied"),
+        ):
+            self.assert_unknown(self.classify())
+
+    def test_unreadable_installed_file_is_unknown(self) -> None:
+        with mock.patch.object(
+            manifest_module,
+            "sha256_file",
+            side_effect=PermissionError("installed file permission denied"),
+        ):
+            result = self.classify()
+        self.assert_unknown(result)
+        self.assertEqual(
+            result["packaged_ui_build_id"],
+            self.packaged_manifest["packaged_ui_build_id"],
+        )
+
+    def test_unreadable_installed_directory_is_unknown(self) -> None:
+        def denied_walk(*args, **kwargs):
+            kwargs["onerror"](PermissionError("installed directory permission denied"))
+            yield from ()
+
+        with mock.patch.object(manifest_module.os, "walk", side_effect=denied_walk):
+            result = self.classify()
+        self.assert_unknown(result)
+        self.assertEqual(
+            result["packaged_ui_build_id"],
+            self.packaged_manifest["packaged_ui_build_id"],
+        )
+
+    def test_malformed_json_is_unknown(self) -> None:
+        self.manifest_path.write_text("{not json\n", encoding="utf-8")
+        self.assert_unknown(self.classify())
+
+    def test_unsupported_schema_is_unknown(self) -> None:
+        manifest = dict(self.packaged_manifest)
+        manifest["schema_version"] = 2
+        self.write_manifest(manifest)
+        self.assert_unknown(self.classify())
+
+    def test_unsafe_manifest_path_is_unknown(self) -> None:
+        manifest = json.loads(json.dumps(self.packaged_manifest))
+        manifest["files"][0]["path"] = "../outside.js"
+        self.write_manifest(manifest)
+        self.assert_unknown(self.classify())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/WsprryPi-UI/tests/ui_manifest_test.py
+++ b/WsprryPi-UI/tests/ui_manifest_test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Regression tests for the schema-v1 deterministic UI manifest generator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "generate_ui_manifest.py"
+SPEC = importlib.util.spec_from_file_location("generate_ui_manifest", SCRIPT)
+assert SPEC and SPEC.loader
+manifest_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(manifest_module)
+
+
+class UiManifestTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        (self.root / "views").mkdir()
+        (self.root / "assets").mkdir()
+        (self.root / "cache").mkdir()
+        (self.root / "site.js").write_text("const value = 1;\n", encoding="utf-8")
+        (self.root / "views" / "index.php").write_text("<?php echo 'ok';\n", encoding="utf-8")
+        (self.root / "assets" / "icon.png").write_bytes(b"\x89PNG\r\nfixture")
+        (self.root / "cache" / "runtime.json").write_text("{}\n", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def build(self):
+        return manifest_module.build_manifest(self.root, "a" * 40, "1.2.3")
+
+    def test_schema_and_identity_are_deterministic(self) -> None:
+        first = self.build()
+        second = self.build()
+        self.assertEqual(first, second)
+        self.assertEqual(first["schema_version"], 1)
+        self.assertRegex(first["packaged_ui_build_id"], r"^sha256:[0-9a-f]{64}$")
+        self.assertEqual(
+            [entry["path"] for entry in first["files"]],
+            ["assets/icon.png", "site.js", "views/index.php"],
+        )
+        self.assertEqual(
+            manifest_module.serialize_manifest(first),
+            manifest_module.serialize_manifest(second),
+        )
+
+    def test_content_changes_identity_for_each_covered_file_type(self) -> None:
+        original = self.build()["packaged_ui_build_id"]
+        candidates = [
+            self.root / "site.js",
+            self.root / "views" / "index.php",
+            self.root / "assets" / "icon.png",
+        ]
+        for candidate in candidates:
+            before = candidate.read_bytes()
+            candidate.write_bytes(before + b"changed")
+            self.assertNotEqual(self.build()["packaged_ui_build_id"], original)
+            candidate.write_bytes(before)
+
+    def test_timestamps_permissions_and_excluded_files_do_not_change_identity(self) -> None:
+        original = self.build()["packaged_ui_build_id"]
+        target = self.root / "site.js"
+        later = time.time() + 3600
+        os.utime(target, (later, later))
+        target.chmod(stat.S_IRUSR)
+        (self.root / "cache" / "runtime.json").write_text('{"changed":true}\n', encoding="utf-8")
+        (self.root / "ui-manifest.json").write_text('{"self":"excluded"}\n', encoding="utf-8")
+        (self.root / ".DS_Store").write_bytes(b"metadata")
+        self.assertEqual(self.build()["packaged_ui_build_id"], original)
+
+    def test_traversal_order_does_not_change_identity(self) -> None:
+        first = self.build()
+        records = list(reversed(first["files"]))
+        records.sort(key=lambda entry: entry["path"].encode("utf-8"))
+        self.assertEqual(
+            manifest_module.packaged_ui_build_id(records),
+            first["packaged_ui_build_id"],
+        )
+
+    def test_validator_rejects_malformed_or_unsafe_manifests(self) -> None:
+        valid = self.build()
+        malformed = []
+
+        missing_field = dict(valid)
+        missing_field.pop("source_commit")
+        malformed.append(missing_field)
+
+        wrong_schema = dict(valid)
+        wrong_schema["schema_version"] = 2
+        malformed.append(wrong_schema)
+
+        invalid_commit = dict(valid)
+        invalid_commit["source_commit"] = "not-a-commit"
+        malformed.append(invalid_commit)
+
+        unsafe_path = json.loads(json.dumps(valid))
+        unsafe_path["files"][0]["path"] = "../escape.js"
+        malformed.append(unsafe_path)
+
+        invalid_hash = json.loads(json.dumps(valid))
+        invalid_hash["files"][0]["sha256"] = "ABC"
+        malformed.append(invalid_hash)
+
+        unsorted = json.loads(json.dumps(valid))
+        unsorted["files"].reverse()
+        malformed.append(unsorted)
+
+        wrong_identity = dict(valid)
+        wrong_identity["packaged_ui_build_id"] = f"sha256:{'0' * 64}"
+        malformed.append(wrong_identity)
+
+        for candidate in malformed:
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(manifest_module.ManifestError):
+                    manifest_module.validate_manifest(candidate)
+
+    def test_generator_rejects_symbolic_links(self) -> None:
+        link = self.root / "linked.js"
+        try:
+            link.symlink_to(self.root / "site.js")
+        except (OSError, NotImplementedError):
+            self.skipTest("symbolic links are unavailable")
+        with self.assertRaises(manifest_module.ManifestError):
+            self.build()
+
+    def test_excluded_runtime_tree_is_not_inspected(self) -> None:
+        link = self.root / "cache" / "runtime-link"
+        try:
+            link.symlink_to(self.root / "site.js")
+        except (OSError, NotImplementedError):
+            self.skipTest("symbolic links are unavailable")
+        self.build()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/copy_ui.py
+++ b/scripts/copy_ui.py
@@ -1,156 +1,245 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
+"""Build, validate, and transactionally publish the installed WsprryPi UI."""
 
-"""
-@file copy_ui.py
-@brief Deploys the WsprryPi-UI component to a web directory.
-@details This script verifies the existence of the WsprryPi-UI component
-         in a Git repository, then copies its data to the /var/www/html/wsprrypi directory.
-         It ensures correct ownership (www-data) and permissions for all copied files.
+from __future__ import annotations
 
-@usage ./copy_ui.py
-
-@dependencies
-- Requires `sudo` privileges for file operations in `/var/www/html/`
-- Requires Git installed to locate the repository root
-- Must be run inside a Git repository containing `WsprryPi-UI`
-"""
-
+import argparse
+import importlib.util
 import os
+from pathlib import Path
+import pwd
+import grp
+import shutil
+import stat
 import subprocess
 import sys
+import tempfile
+from typing import Callable
 
-def get_git_root():
-    """
-    @brief Determine the Git repository root directory (using the script's location).
-    @return The Git root directory as a string, or None if not in a Git repo.
-    """
-    # Figure out where this script lives on disk
-    script_dir = os.path.dirname(os.path.realpath(__file__))
+MANIFEST_FILENAME = "ui-manifest.json"
 
+
+class UiPublicationError(RuntimeError):
+    """Raised when a UI artifact cannot be staged, validated, or published."""
+
+
+def get_git_root() -> Path | None:
+    script_dir = Path(__file__).resolve().parent
     try:
-        # Run git rev-parse from the script's folder, so you always
-        # climb up to the repository root rather than the UI component.
+        return Path(subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], cwd=script_dir, text=True
+        ).strip())
+    except subprocess.CalledProcessError:
+        return None
+
+
+def get_source_commit(git_root: Path) -> str:
+    try:
         return subprocess.check_output(
-            ['git', 'rev-parse', '--show-toplevel'],
-            cwd=script_dir,
-            text=True
+            ["git", "rev-parse", "HEAD"], cwd=git_root, text=True
         ).strip()
-    except subprocess.CalledProcessError:
-        return None  # Not in a Git repository
+    except subprocess.CalledProcessError as error:
+        raise UiPublicationError("unable to determine the UI source commit") from error
 
-def component_exists(git_root, component_name):
-    """
-    @brief Check if a specified component exists in the Git repository.
-    @param git_root The root directory of the Git repository.
-    @param component_name The name of the component to check.
-    @return True if the component exists, otherwise False.
-    """
-    component_path = os.path.join(git_root, component_name)
-    return os.path.exists(component_path)
 
-def remove_existing_web_directory(web_path):
-    """
-    @brief Removes the existing web directory if it exists.
-    @param web_path The directory to remove.
-    @return True on success, False otherwise.
-    """
-    if os.path.exists(web_path):
-        try:
-            subprocess.run(['sudo', 'rm', '-rf', web_path], check=True)
-            return True
-        except subprocess.CalledProcessError:
-            print(f"Error: Failed to remove {web_path}.")
-            return False
-    return True  # Nothing to remove
-
-def copy_files(src, dest):
-    """
-    @brief Copy files recursively from source to destination.
-    @param src The source directory.
-    @param dest The destination directory.
-    @return True on success, False otherwise.
-    """
-    if os.path.exists(src):
-        try:
-            subprocess.run(['sudo', 'cp', '-r', src, dest], check=True)
-            return True
-        except subprocess.CalledProcessError:
-            print(f"Error: Failed to copy files from {src} to {dest}.")
-            return False
-    print(f"Error: Source directory {src} does not exist.")
-    return False
-
-def link_ini(src, dest):
-    """
-    @brief Link configuration file
-    @param src The source directory.
-    @param dest The destination directory.
-    @return True on success, False otherwise.
-    """
-    if os.path.exists(src):
-        try:
-            subprocess.run(['sudo', 'ln', '-sf', src, dest], check=True)
-            return True
-        except subprocess.CalledProcessError:
-            print(f"Error: Failed to link config from {src} to {dest}.")
-            return False
-    print(f"Error: Source config file {src} does not exist.")
-    return False
-
-def set_permissions(dest):
-    """
-    @brief Set owner and permissions for copied files.
-    @param dest The destination directory where files were copied.
-    @return True on success, False otherwise.
-    """
+def get_application_version(git_root: Path) -> str:
+    version_script = git_root / "scripts" / "get_semantic_version.py"
     try:
-        # Change ownership to www-data
-        subprocess.run(['sudo', 'chown', '-R', 'www-data:www-data', dest], check=True)
+        version = subprocess.check_output(
+            [sys.executable, str(version_script)], cwd=git_root, text=True
+        ).strip()
+    except subprocess.CalledProcessError as error:
+        raise UiPublicationError("unable to determine the application version") from error
+    if not version:
+        raise UiPublicationError("application version is empty")
+    return version
 
-        # Change permissions to -rw-r--r-- for all files
-        for root, _, files in os.walk(dest):
-            for file in files:
-                file_path = os.path.join(root, file)
-                subprocess.run(['sudo', 'chmod', '644', file_path], check=True)
 
-        return True
-    except subprocess.CalledProcessError:
-        print(f"Error: Failed to set ownership or permissions in {dest}.")
-        return False
+def load_manifest_module(git_root: Path):
+    module_path = git_root / "WsprryPi-UI" / "scripts" / "generate_ui_manifest.py"
+    if not module_path.is_file():
+        raise UiPublicationError(f"manifest generator not found: {module_path}")
+    spec = importlib.util.spec_from_file_location("wsprrypi_ui_manifest", module_path)
+    if spec is None or spec.loader is None:
+        raise UiPublicationError(f"unable to load manifest generator: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
-def main():
-    """
-    @brief Main function to check component existence and deploy files.
-    """
+
+def _safe_publication_paths(source: Path, target: Path) -> tuple[Path, Path]:
+    if target.is_symlink():
+        raise UiPublicationError(f"UI publication target must not be a symlink: {target}")
+    source = source.resolve(strict=True)
+    target = target.resolve(strict=False)
+    if not source.is_dir():
+        raise UiPublicationError(f"UI source directory not found: {source}")
+    if target == Path(target.anchor) or target.parent == target:
+        raise UiPublicationError(f"unsafe UI publication target: {target}")
+    if target == source or source in target.parents or target in source.parents:
+        raise UiPublicationError("UI source and publication target must not overlap")
+    if target.exists() and not target.is_dir():
+        raise UiPublicationError(f"UI publication target is not a directory: {target}")
+    return source, target
+
+
+def _set_tree_permissions(root: Path, owner: str | None, group: str | None) -> None:
+    if (owner or group) and os.geteuid() != 0:
+        raise UiPublicationError(
+            "root privileges are required to make the UI immutable to the runtime account"
+        )
+    uid = pwd.getpwnam(owner).pw_uid if owner else -1
+    gid = grp.getgrnam(group).gr_gid if group else -1
+    static_uid = 0 if os.geteuid() == 0 else uid
+    static_gid = 0 if os.geteuid() == 0 else gid
+    for directory, child_directories, files in os.walk(root):
+        directory_path = Path(directory)
+        os.chmod(directory_path, 0o755)
+        if owner or group:
+            os.chown(directory_path, static_uid, static_gid)
+        for name in child_directories:
+            child = directory_path / name
+            if child.is_symlink():
+                raise UiPublicationError(f"symbolic links are not permitted: {child}")
+        for name in files:
+            child = directory_path / name
+            if child.is_symlink():
+                raise UiPublicationError(f"symbolic links are not permitted: {child}")
+            os.chmod(child, 0o644)
+            if owner or group:
+                os.chown(child, static_uid, static_gid)
+
+    for mutable_name in ("cache", "backups"):
+        mutable_root = root / mutable_name
+        if not mutable_root.is_dir() or not (owner or group):
+            continue
+        for directory, _, files in os.walk(mutable_root):
+            directory_path = Path(directory)
+            os.chown(directory_path, uid, gid)
+            for name in files:
+                os.chown(directory_path / name, uid, gid)
+
+    manifest = root / MANIFEST_FILENAME
+    os.chmod(manifest, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    if os.geteuid() == 0:
+        os.chown(manifest, 0, 0)
+
+
+def publish_ui(
+    source: Path,
+    target: Path,
+    *,
+    source_commit: str,
+    application_version: str,
+    manifest_module,
+    owner: str | None = None,
+    group: str | None = None,
+    before_publish: Callable[[Path], None] | None = None,
+) -> dict:
+    """Publish one validated UI directory tree without exposing partial staging."""
+    source, target = _safe_publication_paths(source, target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix=f".{target.name}.stage.", dir=target.parent))
+    previous = target.parent / f".{target.name}.previous.{os.getpid()}"
+    previous_created = False
+
+    try:
+        shutil.copytree(source, stage, dirs_exist_ok=True, symlinks=True)
+        manifest_path = stage / MANIFEST_FILENAME
+        manifest = manifest_module.build_manifest(
+            stage,
+            source_commit,
+            application_version,
+        )
+        manifest_module.write_atomic(
+            manifest_path, manifest_module.serialize_manifest(manifest)
+        )
+        validated = manifest_module.load_manifest(manifest_path)
+        installed = manifest_module.classify_installed_ui(stage, manifest_path)
+        if (
+            installed.get("installed_state") != "packaged"
+            or installed.get("packaged_ui_build_id") != installed.get("installed_ui_build_id")
+            or installed.get("installed_ui_build_id") != validated["packaged_ui_build_id"]
+        ):
+            raise UiPublicationError("staged UI identity does not match its manifest")
+
+        _set_tree_permissions(stage, owner, group)
+        if before_publish:
+            before_publish(stage)
+        final_status = manifest_module.classify_installed_ui(stage, manifest_path)
+        if (
+            final_status.get("installed_state") != "packaged"
+            or final_status.get("installed_ui_build_id")
+            != installed.get("installed_ui_build_id")
+        ):
+            raise UiPublicationError("staged UI changed after manifest validation")
+
+        if previous.exists():
+            raise UiPublicationError(f"stale publication rollback path exists: {previous}")
+        if target.exists():
+            os.replace(target, previous)
+            previous_created = True
+        try:
+            os.replace(stage, target)
+        except Exception:
+            if previous_created:
+                os.replace(previous, target)
+                previous_created = False
+            raise
+        if previous_created:
+            shutil.rmtree(previous)
+            previous_created = False
+        return installed
+    except UiPublicationError:
+        raise
+    except Exception as error:
+        raise UiPublicationError(str(error)) from error
+    finally:
+        if stage.exists():
+            shutil.rmtree(stage)
+        if previous_created and previous.exists() and not target.exists():
+            os.replace(previous, target)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--target", type=Path, default=Path("/var/www/html/wsprrypi"))
+    parser.add_argument("--source-commit")
+    parser.add_argument("--application-version")
+    parser.add_argument("--owner", default="www-data")
+    parser.add_argument("--group", default="www-data")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     git_root = get_git_root()
-    if not git_root:
-        print("Error: Not inside a Git repository.")
-        sys.exit(1)
+    if git_root is None:
+        print("Error: Not inside a Git repository.", file=sys.stderr)
+        return 1
+    source = args.source or git_root / "WsprryPi-UI" / "data"
+    try:
+        source_commit = args.source_commit or get_source_commit(git_root)
+        application_version = args.application_version or get_application_version(git_root)
+        status = publish_ui(
+            source,
+            args.target,
+            source_commit=source_commit,
+            application_version=application_version,
+            manifest_module=load_manifest_module(git_root),
+            owner=args.owner or None,
+            group=args.group or None,
+        )
+    except (OSError, KeyError, UiPublicationError) as error:
+        print(f"Error: UI publication failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        "Deployment successful: "
+        f"{status['installed_ui_build_id']} ({status['installed_state']})."
+    )
+    return 0
 
-    component_name = "WsprryPi-UI"
-    web_path = "/var/www/html/wsprrypi"
-    component_data_path = os.path.join(git_root, component_name, "data")
-    print(component_data_path)
-
-    # Check if the WsprryPi-UI component is present
-    if not component_exists(git_root, component_name):
-        print(f"Error: Required component '{component_name}' not found in {git_root}.")
-        sys.exit(1)
-
-    # Remove existing directory
-    if not remove_existing_web_directory(web_path):
-        sys.exit(1)
-
-    # Copy files
-    if not copy_files(component_data_path, web_path):
-        sys.exit(1)
-
-    # Set permissions
-    if not set_permissions(web_path):
-        sys.exit(1)
-
-    print("Deployment successful.")
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/copy_ui.py
+++ b/scripts/copy_ui.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
+import hashlib
 import importlib.util
+import json
 import os
 from pathlib import Path
 import pwd
@@ -21,6 +24,51 @@ MANIFEST_FILENAME = "ui-manifest.json"
 
 class UiPublicationError(RuntimeError):
     """Raised when a UI artifact cannot be staged, validated, or published."""
+
+    def __init__(self, message: str, result: dict | None = None):
+        super().__init__(message)
+        self.result = result
+
+
+def _write_json_atomic(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    finally:
+        if os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _new_result() -> dict:
+    return {
+        "schema_version": 1,
+        "prior_state": "not_installed",
+        "modified_files": [],
+        "added_files": [],
+        "missing_files": [],
+        "prior_manifest_backup": None,
+        "modification_report_path": None,
+        "backup_directory": None,
+        "backup_verified": None,
+        "replacement_completed": False,
+        "final_installed_state": None,
+        "final_installed_ui_build_id": None,
+        "error": None,
+    }
 
 
 def get_git_root() -> Path | None:
@@ -125,6 +173,88 @@ def _set_tree_permissions(root: Path, owner: str | None, group: str | None) -> N
         os.chown(manifest, 0, 0)
 
 
+def _copy_verified(source_root: Path, backup_root: Path, paths: list[str]) -> None:
+    for relative in paths:
+        source = source_root / relative
+        destination = backup_root / "files" / relative
+        if not source.is_file() or source.is_symlink():
+            raise UiPublicationError(f"unable to back up covered UI file: {relative}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        if _sha256(source) != _sha256(destination):
+            raise UiPublicationError(f"backup verification failed for: {relative}")
+
+
+def _create_modification_backup(
+    target: Path,
+    classification: dict,
+    manifest_module,
+    backup_parent: Path,
+    result: dict,
+) -> None:
+    backup_parent = backup_parent.resolve(strict=False)
+    if backup_parent == target or backup_parent in target.parents or target in backup_parent.parents:
+        raise UiPublicationError("UI backup directory must be outside the live web root")
+    backup_parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup = Path(tempfile.mkdtemp(prefix=f"ui-backup-{timestamp}-", dir=backup_parent))
+    result["backup_directory"] = str(backup)
+    try:
+        if classification["installed_state"] == "unknown":
+            paths = [record["path"] for record in manifest_module.collect_file_records(target)]
+        else:
+            paths = sorted(
+                set(classification["modified_files"] + classification["added_files"]),
+                key=lambda value: value.encode("utf-8"),
+            )
+        _copy_verified(target, backup, paths)
+
+        prior_manifest = target / MANIFEST_FILENAME
+        if prior_manifest.is_file() and not prior_manifest.is_symlink():
+            manifest_backup = backup / "prior-manifest.json"
+            shutil.copy2(prior_manifest, manifest_backup)
+            if _sha256(prior_manifest) != _sha256(manifest_backup):
+                raise UiPublicationError("prior manifest backup verification failed")
+            result["prior_manifest_backup"] = str(manifest_backup)
+
+        report_path = backup / "modification-report.json"
+        result["modification_report_path"] = str(report_path)
+        result["backup_verified"] = True
+        _write_json_atomic(report_path, result)
+
+        for relative in paths:
+            if _sha256(target / relative) != _sha256(backup / "files" / relative):
+                raise UiPublicationError(f"final backup verification failed for: {relative}")
+        if result["prior_manifest_backup"] and (
+            _sha256(prior_manifest) != _sha256(Path(result["prior_manifest_backup"]))
+        ):
+            raise UiPublicationError("final prior manifest verification failed")
+        confirmed = manifest_module.classify_installed_ui(
+            target, target / MANIFEST_FILENAME
+        )
+        for field in (
+            "installed_state",
+            "installed_ui_build_id",
+            "packaged_ui_build_id",
+            "modified_files",
+            "added_files",
+            "missing_files",
+        ):
+            if confirmed.get(field) != classification.get(field):
+                raise UiPublicationError(
+                    "live UI changed while its modification backup was being verified"
+                )
+    except Exception as error:
+        result["backup_verified"] = False
+        result["error"] = str(error)
+        if result["modification_report_path"]:
+            try:
+                _write_json_atomic(Path(result["modification_report_path"]), result)
+            except Exception:
+                pass
+        raise
+
+
 def publish_ui(
     source: Path,
     target: Path,
@@ -134,6 +264,8 @@ def publish_ui(
     manifest_module,
     owner: str | None = None,
     group: str | None = None,
+    backup_parent: Path = Path("/var/backups/wsprrypi/ui"),
+    fail_on_ui_modifications: bool = False,
     before_publish: Callable[[Path], None] | None = None,
 ) -> dict:
     """Publish one validated UI directory tree without exposing partial staging."""
@@ -142,6 +274,7 @@ def publish_ui(
     stage = Path(tempfile.mkdtemp(prefix=f".{target.name}.stage.", dir=target.parent))
     previous = target.parent / f".{target.name}.previous.{os.getpid()}"
     previous_created = False
+    result = _new_result()
 
     try:
         shutil.copytree(source, stage, dirs_exist_ok=True, symlinks=True)
@@ -162,6 +295,26 @@ def publish_ui(
             or installed.get("installed_ui_build_id") != validated["packaged_ui_build_id"]
         ):
             raise UiPublicationError("staged UI identity does not match its manifest")
+
+        if target.exists():
+            classification = manifest_module.classify_installed_ui(
+                target, target / MANIFEST_FILENAME
+            )
+            result["prior_state"] = classification["installed_state"]
+            for field in ("modified_files", "added_files", "missing_files"):
+                result[field] = list(classification[field])
+            requires_backup = classification["installed_state"] in {
+                "locally_modified", "unknown"
+            }
+            if fail_on_ui_modifications and requires_backup:
+                raise UiPublicationError(
+                    f"existing UI state is {classification['installed_state']}; replacement refused",
+                    result,
+                )
+            if requires_backup:
+                _create_modification_backup(
+                    target, classification, manifest_module, backup_parent, result
+                )
 
         _set_tree_permissions(stage, owner, group)
         if before_publish:
@@ -186,14 +339,28 @@ def publish_ui(
                 os.replace(previous, target)
                 previous_created = False
             raise
+        final_status = manifest_module.classify_installed_ui(
+            target, target / MANIFEST_FILENAME
+        )
+        result["replacement_completed"] = True
+        result["final_installed_state"] = final_status["installed_state"]
+        result["final_installed_ui_build_id"] = final_status["installed_ui_build_id"]
         if previous_created:
             shutil.rmtree(previous)
             previous_created = False
-        return installed
-    except UiPublicationError:
+        if final_status["installed_state"] != "packaged":
+            raise UiPublicationError("published UI did not classify as packaged", result)
+        if result["modification_report_path"]:
+            _write_json_atomic(Path(result["modification_report_path"]), result)
+        return result
+    except UiPublicationError as error:
+        if error.result is None:
+            error.result = result
+        result["error"] = str(error)
         raise
     except Exception as error:
-        raise UiPublicationError(str(error)) from error
+        result["error"] = str(error)
+        raise UiPublicationError(str(error), result) from error
     finally:
         if stage.exists():
             shutil.rmtree(stage)
@@ -209,20 +376,62 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--application-version")
     parser.add_argument("--owner", default="www-data")
     parser.add_argument("--group", default="www-data")
+    parser.add_argument("--backup-directory", type=Path, default=Path("/var/backups/wsprrypi/ui"))
+    parser.add_argument("--fail-on-ui-modifications", action="store_true")
+    parser.add_argument("--result-file", type=Path)
+    parser.add_argument("--render-result", type=Path)
     return parser.parse_args(argv)
+
+
+def render_result(path: Path) -> int:
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print("\nUI replacement report")
+        print(f"  Result unavailable: {error}")
+        return 1
+    print("\nUI replacement report")
+    print(f"  Prior state: {result.get('prior_state') or 'unknown'}")
+    for label, field in (
+        ("Modified files", "modified_files"),
+        ("Added files", "added_files"),
+        ("Missing files", "missing_files"),
+    ):
+        values = result.get(field) or []
+        print(f"  {label}:")
+        if values:
+            for value in values:
+                print(f"    - {value}")
+        else:
+            print("    - (none)")
+    print(f"  Prior manifest backup: {result.get('prior_manifest_backup') or '(none)'}")
+    print(f"  Modification report: {result.get('modification_report_path') or '(none)'}")
+    print(f"  Backup directory: {result.get('backup_directory') or '(none)'}")
+    backup_verified = result.get("backup_verified")
+    print(
+        "  Backup verified: "
+        + ("not required" if backup_verified is None else ("yes" if backup_verified else "no"))
+    )
+    print(f"  Replacement completed: {'yes' if result.get('replacement_completed') else 'no'}")
+    if result.get("error"):
+        print(f"  Error: {result['error']}")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.render_result:
+        return render_result(args.render_result)
     git_root = get_git_root()
     if git_root is None:
         print("Error: Not inside a Git repository.", file=sys.stderr)
         return 1
     source = args.source or git_root / "WsprryPi-UI" / "data"
+    result = _new_result()
     try:
         source_commit = args.source_commit or get_source_commit(git_root)
         application_version = args.application_version or get_application_version(git_root)
-        status = publish_ui(
+        result = publish_ui(
             source,
             args.target,
             source_commit=source_commit,
@@ -230,13 +439,25 @@ def main(argv: list[str] | None = None) -> int:
             manifest_module=load_manifest_module(git_root),
             owner=args.owner or None,
             group=args.group or None,
+            backup_parent=args.backup_directory,
+            fail_on_ui_modifications=args.fail_on_ui_modifications,
         )
     except (OSError, KeyError, UiPublicationError) as error:
+        if isinstance(error, UiPublicationError) and error.result is not None:
+            result = error.result
+        result["error"] = str(error)
+        if args.result_file:
+            try:
+                _write_json_atomic(args.result_file, result)
+            except OSError as report_error:
+                print(f"Error: unable to write UI result: {report_error}", file=sys.stderr)
         print(f"Error: UI publication failed: {error}", file=sys.stderr)
         return 1
+    if args.result_file:
+        _write_json_atomic(args.result_file, result)
     print(
         "Deployment successful: "
-        f"{status['installed_ui_build_id']} ({status['installed_state']})."
+        f"{result['final_installed_ui_build_id']} ({result['final_installed_state']})."
     )
     return 0
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6551,6 +6551,8 @@ manage_web() {
     local source_path="$LOCAL_WWW_DIR"
     local target_path="/var/www/html/${REPO_NAME,,}"
     local retval=0 # Initialize return value
+    local publisher="${LOCAL_REPO_DIR}/scripts/copy_ui.py"
+    local source_commit=""
 
     if [[ "$ACTION" == "install" ]]; then
         # Validate source directory exists
@@ -6560,48 +6562,36 @@ manage_web() {
             return 1
         fi
 
-        # Ensure target directory exists
-        debug_print "Creating target web directory if missing." "$debug"
-        if [[ "$DRY_RUN" == "true" ]]; then
-            logD "Exec: mkdir -p $target_path"
-        else
-            exec_command "Create target web directory" mkdir -p "${target_path}" "$debug" || retval=1
+        if [[ ! -x "$publisher" ]]; then
+            logE "Error: UI publisher '$publisher' is missing or not executable."
+            debug_end "$debug"
+            return 1
         fi
 
-        # Copy web files
-        debug_print "Copying web files from '$source_path' to '$target_path'." "$debug"
+        source_commit=$(git -C "$LOCAL_REPO_DIR" rev-parse HEAD 2>/dev/null) || {
+            logE "Error: Unable to determine the exact UI source commit."
+            debug_end "$debug"
+            return 1
+        }
+
+        debug_print "Staging, validating, and publishing web files from '$source_path' to '$target_path'." "$debug"
         if [[ "$DRY_RUN" == "true" ]]; then
-            logD "Exec: cp -r $source_path* $target_path/"
+            logD "Exec: $publisher --source $source_path --target $target_path --source-commit $source_commit --application-version $SEM_VER --owner www-data --group www-data"
         else
-            exec_command "Copy web files" \
-                cp -r "${source_path}"/* "${target_path}/" \
+            exec_command "Publish validated UI artifact" \
+                "$publisher" \
+                --source "$source_path" \
+                --target "$target_path" \
+                --source-commit "$source_commit" \
+                --application-version "$SEM_VER" \
+                --owner www-data \
+                --group www-data \
                 "$debug" || retval=1
-        fi
-
-        # Change ownership and permissions
-        debug_print "Setting permissions for '$target_path'." "$debug"
-        if [[ "$DRY_RUN" == "true" ]]; then
-            logD "Exec: sudo chown -R www-data:www-data $target_path"
-            logD "Exec: sudo chmod -R 755 $target_path"
-            logD "Exec: sudo usermod -aG systemd-journal www-data"
-        else
-            # Set ownership for the entire directory
-            exec_command "Set ownership" chown -R www-data:www-data "${target_path}" "$debug" || retval=1
-
-            # Set correct permissions:
-            # - Directories: `rwxr-xr-x` (755)
-            # - Files: `rw-r--r--` (644)
-            exec_command "Set directory permissions" \
-                find "$target_path" -type d -exec sudo chmod 755 {} + \
-                "$debug" || retval=1
-
-            exec_command "Set file permissions" \
-                find "$target_path" -type f -exec sudo chmod 644 {} + \
-                "$debug" || retval=1
-
-            exec_command "Set log permissions" \
-                sudo usermod -aG systemd-journal www-data \
-                "$debug" || retval=1
+            if [[ "$retval" -eq 0 ]]; then
+                exec_command "Set log permissions" \
+                    usermod -aG systemd-journal www-data \
+                    "$debug" || retval=1
+            fi
         fi
 
     elif [[ "$ACTION" == "uninstall" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -220,6 +220,9 @@ declare GIT_TAG="${GIT_TAG:-v$SEM_VER}"
 declare GIT_RAW_BASE="https://raw.githubusercontent.com"
 declare GIT_API_BASE="https://api.github.com/repos"
 declare GIT_CLONE_BASE="https://github.com"
+declare FAIL_ON_UI_MODIFICATIONS="${FAIL_ON_UI_MODIFICATIONS:-false}"
+declare UI_PUBLICATION_ATTEMPTED="false"
+declare UI_PUBLICATION_RESULT_FILE=""
 
 # -----------------------------------------------------------------------------
 # Declare Arguments Variables
@@ -972,7 +975,9 @@ declare REBOOT=${REBOOT:-false}
 # shellcheck disable=SC2317
 # shellcheck disable=SC2329
 egress() {
-    true
+    local status=$?
+    report_ui_publication_result
+    return "$status"
 }
 
 # -----------------------------------------------------------------------------
@@ -5129,6 +5134,7 @@ OPTIONS_LIST=(
     "-v|--version 0 print_version Display $WSPR_SERVICE version 1"
     "--no-web 0 set_no_web Disable web UI installation and Apache integration (service will run with --no-web) 0"
     "--release 0 set_release_build Build as release regardless of branch 0"
+    "--fail-on-ui-modifications 0 set_fail_on_ui_modifications Refuse to replace a modified or unknown installed UI 0"
 )
 
 # -----------------------------------------------------------------------------
@@ -5198,6 +5204,16 @@ set_no_web() {
 
     NO_WEB="true"
 
+    debug_end "$debug"
+    return 0
+}
+
+# shellcheck disable=SC2329
+set_fail_on_ui_modifications() {
+    local debug
+    debug=$(debug_start "$@")
+    eval set -- "$(debug_filter "$@")"
+    FAIL_ON_UI_MODIFICATIONS="true"
     debug_end "$debug"
     return 0
 }
@@ -6553,6 +6569,7 @@ manage_web() {
     local retval=0 # Initialize return value
     local publisher="${LOCAL_REPO_DIR}/scripts/copy_ui.py"
     local source_commit=""
+    local publisher_args=()
 
     if [[ "$ACTION" == "install" ]]; then
         # Validate source directory exists
@@ -6574,18 +6591,31 @@ manage_web() {
             return 1
         }
 
+        UI_PUBLICATION_RESULT_FILE="/run/wsprrypi-ui-publication-${$}.json"
+        if [[ "$DRY_RUN" != "true" ]]; then
+            UI_PUBLICATION_ATTEMPTED="true"
+            rm -f "$UI_PUBLICATION_RESULT_FILE"
+        fi
+        publisher_args=(
+            --source "$source_path"
+            --target "$target_path"
+            --source-commit "$source_commit"
+            --application-version "$SEM_VER"
+            --owner www-data
+            --group www-data
+            --result-file "$UI_PUBLICATION_RESULT_FILE"
+        )
+        if [[ "$FAIL_ON_UI_MODIFICATIONS" == "true" ]]; then
+            publisher_args+=(--fail-on-ui-modifications)
+        fi
+
         debug_print "Staging, validating, and publishing web files from '$source_path' to '$target_path'." "$debug"
         if [[ "$DRY_RUN" == "true" ]]; then
-            logD "Exec: $publisher --source $source_path --target $target_path --source-commit $source_commit --application-version $SEM_VER --owner www-data --group www-data"
+            logD "Exec: $publisher ${publisher_args[*]}"
         else
             exec_command "Publish validated UI artifact" \
                 "$publisher" \
-                --source "$source_path" \
-                --target "$target_path" \
-                --source-commit "$source_commit" \
-                --application-version "$SEM_VER" \
-                --owner www-data \
-                --group www-data \
+                "${publisher_args[@]}" \
                 "$debug" || retval=1
             if [[ "$retval" -eq 0 ]]; then
                 exec_command "Set log permissions" \
@@ -7797,6 +7827,20 @@ flag_need_reboot() {
 }
 
 # -----------------------------------------------------------------------------
+report_ui_publication_result() {
+    if [[ "$UI_PUBLICATION_ATTEMPTED" != "true" ]]; then
+        return 0
+    fi
+    if [[ -n "$UI_PUBLICATION_RESULT_FILE" && -f "$UI_PUBLICATION_RESULT_FILE" ]]; then
+        python3 "${LOCAL_REPO_DIR}/scripts/copy_ui.py" \
+            --render-result "$UI_PUBLICATION_RESULT_FILE" || true
+    else
+        printf "\nUI replacement report\n"
+        printf "  Result unavailable: the UI publisher did not create its result file.\n"
+        printf "  Replacement completed: unknown\n"
+    fi
+}
+
 # @brief Finalizes the installation or uninstallation process.
 # @details Logs and displays a completion message based on whether the install
 #          or uninstall was successful or failed. It also provides follow-up

--- a/scripts/tests/installer_dependency_test.sh
+++ b/scripts/tests/installer_dependency_test.sh
@@ -65,4 +65,20 @@ if grep -Eiq 'rp1[-_]gpclk|live_output|kernel_2712_phase|dtoverlay=rp1' "$INSTAL
     exit 1
 fi
 
+if ! grep -Fq 'exec_command "Publish validated UI artifact"' "$INSTALLER"; then
+    echo "install.sh must publish the UI through the validated artifact publisher" >&2
+    exit 1
+fi
+
+if ! grep -Fq -- '--source-commit "$source_commit"' "$INSTALLER" ||
+    ! grep -Fq -- '--application-version "$SEM_VER"' "$INSTALLER"; then
+    echo "install.sh must bind the UI manifest to the exact source commit and application version" >&2
+    exit 1
+fi
+
+if awk '/manage_web\(\)/,/^}/' "$INSTALLER" | grep -Eq 'cp -r .*source_path|chown -R .*target_path'; then
+    echo "manage_web must not copy or mutate the live UI tree incrementally" >&2
+    exit 1
+fi
+
 echo "installer dependency tests: PASS"

--- a/scripts/tests/installer_dependency_test.sh
+++ b/scripts/tests/installer_dependency_test.sh
@@ -76,6 +76,24 @@ if ! grep -Fq -- '--source-commit "$source_commit"' "$INSTALLER" ||
     exit 1
 fi
 
+for required in \
+    '"--fail-on-ui-modifications 0 set_fail_on_ui_modifications' \
+    '--result-file "$UI_PUBLICATION_RESULT_FILE"' \
+    'publisher_args+=(--fail-on-ui-modifications)' \
+    'report_ui_publication_result' \
+    'trap egress EXIT'
+do
+    if ! grep -Fq -- "$required" "$INSTALLER"; then
+        echo "install.sh is missing UI modification/reporting contract: $required" >&2
+        exit 1
+    fi
+done
+
+if ! awk '/egress\(\)/,/^}/' "$INSTALLER" | grep -Fq 'report_ui_publication_result'; then
+    echo "the UI replacement report must be emitted from the final EXIT trap" >&2
+    exit 1
+fi
+
 if awk '/manage_web\(\)/,/^}/' "$INSTALLER" | grep -Eq 'cp -r .*source_path|chown -R .*target_path'; then
     echo "manage_web must not copy or mutate the live UI tree incrementally" >&2
     exit 1

--- a/scripts/tests/ui_publication_test.py
+++ b/scripts/tests/ui_publication_test.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
 import os
 from pathlib import Path
 import stat
 import tempfile
 import unittest
 from unittest import mock
+from contextlib import redirect_stdout
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -49,6 +52,7 @@ class UiPublicationTest(unittest.TestCase):
         self.temporary.cleanup()
 
     def publish(self, **kwargs):
+        kwargs.setdefault("backup_parent", self.root / "external-backups")
         return PUBLISHER.publish_ui(
             self.source,
             self.target,
@@ -64,7 +68,7 @@ class UiPublicationTest(unittest.TestCase):
         validated = MANIFEST.load_manifest(manifest_path)
         installed = MANIFEST.classify_installed_ui(self.target, manifest_path)
 
-        self.assertEqual(status["installed_state"], "packaged")
+        self.assertEqual(status["final_installed_state"], "packaged")
         self.assertEqual(installed["installed_state"], "packaged")
         self.assertEqual(
             installed["installed_ui_build_id"],
@@ -96,7 +100,7 @@ class UiPublicationTest(unittest.TestCase):
         self.assertEqual(
             installed["packaged_ui_build_id"], installed["installed_ui_build_id"]
         )
-        self.assertEqual(status["installed_ui_build_id"], installed["installed_ui_build_id"])
+        self.assertEqual(status["final_installed_ui_build_id"], installed["installed_ui_build_id"])
 
     def test_runtime_and_backup_paths_do_not_change_identity(self):
         status = self.publish()
@@ -107,8 +111,122 @@ class UiPublicationTest(unittest.TestCase):
         )
         self.assertEqual(installed["installed_state"], "packaged")
         self.assertEqual(
-            installed["installed_ui_build_id"], status["installed_ui_build_id"]
+            installed["installed_ui_build_id"], status["final_installed_ui_build_id"]
         )
+
+    def test_locally_modified_files_are_backed_up_and_replaced(self):
+        self.publish()
+        prior_manifest = (self.target / "ui-manifest.json").read_bytes()
+        (self.target / "index.php").chmod(0o644)
+        (self.target / "index.php").write_text("locally modified\n")
+        (self.target / "custom.php").write_text("custom addition\n")
+        (self.target / "site.css").unlink()
+
+        result = self.publish(backup_parent=self.root / "external-backups")
+        backup = Path(result["backup_directory"])
+        self.assertEqual(result["prior_state"], "locally_modified")
+        self.assertEqual(result["modified_files"], ["index.php"])
+        self.assertEqual(result["added_files"], ["custom.php"])
+        self.assertEqual(result["missing_files"], ["site.css"])
+        self.assertEqual((backup / "files" / "index.php").read_text(), "locally modified\n")
+        self.assertEqual((backup / "files" / "custom.php").read_text(), "custom addition\n")
+        self.assertEqual(Path(result["prior_manifest_backup"]).read_bytes(), prior_manifest)
+        report = json.loads(Path(result["modification_report_path"]).read_text())
+        self.assertTrue(report["backup_verified"])
+        self.assertTrue(report["replacement_completed"])
+        self.assertTrue(result["replacement_completed"])
+        self.assertFalse((self.target / "custom.php").exists())
+        final = MANIFEST.classify_installed_ui(self.target, self.target / "ui-manifest.json")
+        self.assertEqual(final["installed_state"], "packaged")
+
+    def test_unknown_prior_state_backs_up_complete_covered_tree(self):
+        self.target.mkdir(parents=True)
+        (self.target / "index.php").write_text("unknown old index\n")
+        (self.target / "custom.php").write_text("unknown custom\n")
+        (self.target / "cache").mkdir()
+        (self.target / "cache" / "runtime").write_text("excluded\n")
+        result = self.publish(backup_parent=self.root / "external-backups")
+        backup = Path(result["backup_directory"])
+        self.assertEqual(result["prior_state"], "unknown")
+        self.assertEqual((backup / "files" / "index.php").read_text(), "unknown old index\n")
+        self.assertEqual((backup / "files" / "custom.php").read_text(), "unknown custom\n")
+        self.assertFalse((backup / "files" / "cache").exists())
+
+    def test_backup_failure_prevents_replacement(self):
+        self.publish()
+        live_file = self.target / "index.php"
+        live_file.chmod(0o644)
+        live_file.write_text("must survive\n")
+        with mock.patch.object(
+            PUBLISHER, "_copy_verified", side_effect=OSError("injected backup failure")
+        ):
+            with self.assertRaises(PUBLISHER.UiPublicationError) as caught:
+                self.publish(backup_parent=self.root / "external-backups")
+        self.assertEqual(live_file.read_text(), "must survive\n")
+        self.assertFalse(caught.exception.result["replacement_completed"])
+        self.assertFalse(caught.exception.result["backup_verified"])
+
+    def test_live_churn_during_backup_prevents_replacement(self):
+        self.publish()
+        live_file = self.target / "index.php"
+        live_file.chmod(0o644)
+        live_file.write_text("must survive\n")
+        real_copy = PUBLISHER._copy_verified
+
+        def copy_then_change(*args):
+            real_copy(*args)
+            (self.target / "late-change.php").write_text("arrived during backup\n")
+
+        with mock.patch.object(PUBLISHER, "_copy_verified", side_effect=copy_then_change):
+            with self.assertRaisesRegex(PUBLISHER.UiPublicationError, "changed while") as caught:
+                self.publish(backup_parent=self.root / "external-backups")
+        self.assertEqual(live_file.read_text(), "must survive\n")
+        self.assertTrue((self.target / "late-change.php").exists())
+        self.assertFalse(caught.exception.result["replacement_completed"])
+
+    def test_fail_on_modifications_refuses_replacement(self):
+        self.publish()
+        live_file = self.target / "index.php"
+        live_file.chmod(0o644)
+        live_file.write_text("must survive\n")
+        with self.assertRaisesRegex(PUBLISHER.UiPublicationError, "replacement refused"):
+            self.publish(
+                backup_parent=self.root / "external-backups",
+                fail_on_ui_modifications=True,
+            )
+        self.assertEqual(live_file.read_text(), "must survive\n")
+
+    def test_final_renderer_relists_inventory_and_actual_completion(self):
+        result = PUBLISHER._new_result()
+        result.update({
+            "prior_state": "locally_modified",
+            "modified_files": ["index.php"],
+            "added_files": ["custom.php"],
+            "missing_files": ["site.css"],
+            "prior_manifest_backup": "/backup/prior-manifest.json",
+            "modification_report_path": "/backup/modification-report.json",
+            "backup_directory": "/backup",
+            "backup_verified": True,
+            "replacement_completed": False,
+            "error": "publication stopped",
+        })
+        result_path = self.root / "result.json"
+        PUBLISHER._write_json_atomic(result_path, result)
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(PUBLISHER.render_result(result_path), 0)
+        rendered = output.getvalue()
+        for expected in (
+            "Modified files:\n    - index.php",
+            "Added files:\n    - custom.php",
+            "Missing files:\n    - site.css",
+            "Prior manifest backup: /backup/prior-manifest.json",
+            "Modification report: /backup/modification-report.json",
+            "Backup directory: /backup",
+            "Replacement completed: no",
+            "Error: publication stopped",
+        ):
+            self.assertIn(expected, rendered)
 
     def test_validation_failure_leaves_live_tree_untouched(self):
         self.target.mkdir(parents=True)
@@ -206,6 +324,24 @@ class UiPublicationTest(unittest.TestCase):
             with self.assertRaises(PUBLISHER.UiPublicationError):
                 self.publish()
         self.assertEqual(old_file.read_text(encoding="utf-8"), "old live UI\n")
+
+    def test_postpublication_cleanup_failure_reports_replacement_truthfully(self):
+        self.target.mkdir(parents=True)
+        (self.target / "index.php").write_text("unknown old UI\n")
+        real_rmtree = PUBLISHER.shutil.rmtree
+
+        def fail_previous_cleanup(path, *args, **kwargs):
+            if ".wsprrypi.previous." in Path(path).name:
+                raise OSError("injected prior-tree cleanup failure")
+            return real_rmtree(path, *args, **kwargs)
+
+        with mock.patch.object(PUBLISHER.shutil, "rmtree", side_effect=fail_previous_cleanup):
+            with self.assertRaises(PUBLISHER.UiPublicationError) as caught:
+                self.publish()
+        self.assertTrue(caught.exception.result["replacement_completed"])
+        self.assertEqual(caught.exception.result["final_installed_state"], "packaged")
+        final = MANIFEST.classify_installed_ui(self.target, self.target / "ui-manifest.json")
+        self.assertEqual(final["installed_state"], "packaged")
 
     def test_postvalidation_change_is_not_published(self):
         self.target.mkdir(parents=True)

--- a/scripts/tests/ui_publication_test.py
+++ b/scripts/tests/ui_publication_test.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Hardware-free regression tests for coherent UI artifact publication."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import stat
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PUBLISHER = load_module("copy_ui", ROOT / "scripts" / "copy_ui.py")
+MANIFEST = load_module(
+    "generate_ui_manifest",
+    ROOT / "WsprryPi-UI" / "scripts" / "generate_ui_manifest.py",
+)
+
+
+class UiPublicationTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "source"
+        self.target = self.root / "live" / "wsprrypi"
+        (self.source / "views").mkdir(parents=True)
+        (self.source / "cache").mkdir()
+        (self.source / "backups").mkdir()
+        (self.source / "index.php").write_text("<?php echo 'new';\n", encoding="utf-8")
+        (self.source / "site.css").write_text("body { color: black; }\n", encoding="utf-8")
+        (self.source / "views" / "operation.php").write_text("operation\n", encoding="utf-8")
+        (self.source / "cache" / "runtime.json").write_text("runtime\n", encoding="utf-8")
+        (self.source / "backups" / "old.php").write_text("backup\n", encoding="utf-8")
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def publish(self, **kwargs):
+        return PUBLISHER.publish_ui(
+            self.source,
+            self.target,
+            source_commit="a" * 40,
+            application_version="3.2.0-test",
+            manifest_module=MANIFEST,
+            **kwargs,
+        )
+
+    def test_published_tree_exactly_matches_manifest(self):
+        status = self.publish()
+        manifest_path = self.target / "ui-manifest.json"
+        validated = MANIFEST.load_manifest(manifest_path)
+        installed = MANIFEST.classify_installed_ui(self.target, manifest_path)
+
+        self.assertEqual(status["installed_state"], "packaged")
+        self.assertEqual(installed["installed_state"], "packaged")
+        self.assertEqual(
+            installed["installed_ui_build_id"],
+            validated["packaged_ui_build_id"],
+        )
+        self.assertEqual(
+            validated["files"],
+            MANIFEST.collect_file_records(self.target),
+        )
+        self.assertEqual(
+            stat.S_IMODE(manifest_path.stat().st_mode),
+            0o444,
+            "the installed manifest must not be runtime-writable",
+        )
+
+    def test_repository_ui_artifact_converges(self):
+        repository_target = self.root / "repository-live" / "wsprrypi"
+        status = PUBLISHER.publish_ui(
+            ROOT / "WsprryPi-UI" / "data",
+            repository_target,
+            source_commit="b" * 40,
+            application_version="3.2.0-test",
+            manifest_module=MANIFEST,
+        )
+        installed = MANIFEST.classify_installed_ui(
+            repository_target, repository_target / "ui-manifest.json"
+        )
+        self.assertEqual(installed["installed_state"], "packaged")
+        self.assertEqual(
+            installed["packaged_ui_build_id"], installed["installed_ui_build_id"]
+        )
+        self.assertEqual(status["installed_ui_build_id"], installed["installed_ui_build_id"])
+
+    def test_runtime_and_backup_paths_do_not_change_identity(self):
+        status = self.publish()
+        (self.target / "cache" / "new-runtime.json").write_text("changed\n")
+        (self.target / "backups" / "new-backup.php").write_text("changed\n")
+        installed = MANIFEST.classify_installed_ui(
+            self.target, self.target / "ui-manifest.json"
+        )
+        self.assertEqual(installed["installed_state"], "packaged")
+        self.assertEqual(
+            installed["installed_ui_build_id"], status["installed_ui_build_id"]
+        )
+
+    def test_validation_failure_leaves_live_tree_untouched(self):
+        self.target.mkdir(parents=True)
+        old_file = self.target / "index.php"
+        old_file.write_text("old live UI\n", encoding="utf-8")
+        with mock.patch.object(
+            MANIFEST, "load_manifest", side_effect=ValueError("invalid staged manifest")
+        ):
+            with self.assertRaises(PUBLISHER.UiPublicationError):
+                self.publish()
+        self.assertEqual(old_file.read_text(encoding="utf-8"), "old live UI\n")
+        self.assertFalse((self.target / "ui-manifest.json").exists())
+
+    def test_staging_failure_leaves_live_tree_untouched(self):
+        self.target.mkdir(parents=True)
+        old_file = self.target / "index.php"
+        old_file.write_text("old live UI\n", encoding="utf-8")
+        os.symlink(self.source / "index.php", self.source / "unsafe-link.php")
+        with self.assertRaises(PUBLISHER.UiPublicationError):
+            self.publish()
+        self.assertEqual(old_file.read_text(encoding="utf-8"), "old live UI\n")
+
+    def test_symlink_publication_target_is_rejected(self):
+        actual = self.root / "actual-live"
+        actual.mkdir()
+        marker = actual / "marker"
+        marker.write_text("untouched\n")
+        self.target.parent.mkdir(parents=True)
+        os.symlink(actual, self.target)
+        with self.assertRaisesRegex(PUBLISHER.UiPublicationError, "must not be a symlink"):
+            self.publish()
+        self.assertEqual(marker.read_text(), "untouched\n")
+
+    def test_runtime_ownership_requires_root(self):
+        with mock.patch.object(PUBLISHER.os, "geteuid", return_value=501):
+            with self.assertRaisesRegex(PUBLISHER.UiPublicationError, "root privileges"):
+                self.publish(owner="www-data", group="www-data")
+        self.assertFalse(self.target.exists())
+
+    def test_static_tree_is_runtime_immutable_but_cache_is_runtime_owned(self):
+        staged = self.root / "permission-stage"
+        (staged / "cache").mkdir(parents=True)
+        (staged / "index.php").write_text("static\n")
+        (staged / "ui-manifest.json").write_text("{}\n")
+        (staged / "cache" / "runtime.json").write_text("runtime\n")
+        ownership = {}
+
+        def record_chown(path, uid, gid):
+            ownership[Path(path)] = (uid, gid)
+
+        with (
+            mock.patch.object(PUBLISHER.os, "geteuid", return_value=0),
+            mock.patch.object(PUBLISHER.pwd, "getpwnam", return_value=mock.Mock(pw_uid=33)),
+            mock.patch.object(PUBLISHER.grp, "getgrnam", return_value=mock.Mock(gr_gid=44)),
+            mock.patch.object(PUBLISHER.os, "chown", side_effect=record_chown),
+        ):
+            PUBLISHER._set_tree_permissions(staged, "www-data", "www-data")
+
+        self.assertEqual(ownership[staged], (0, 0))
+        self.assertEqual(ownership[staged / "index.php"], (0, 0))
+        self.assertEqual(ownership[staged / "ui-manifest.json"], (0, 0))
+        self.assertEqual(ownership[staged / "cache"], (33, 44))
+        self.assertEqual(ownership[staged / "cache" / "runtime.json"], (33, 44))
+        self.assertEqual(stat.S_IMODE((staged / "ui-manifest.json").stat().st_mode), 0o444)
+
+    def test_prepublication_failure_leaves_live_tree_untouched(self):
+        self.target.mkdir(parents=True)
+        old_file = self.target / "index.php"
+        old_file.write_text("old live UI\n", encoding="utf-8")
+
+        def fail_before_publish(stage: Path):
+            self.assertTrue((stage / "ui-manifest.json").is_file())
+            raise RuntimeError("injected prepublication failure")
+
+        with self.assertRaises(PUBLISHER.UiPublicationError):
+            self.publish(before_publish=fail_before_publish)
+        self.assertEqual(old_file.read_text(encoding="utf-8"), "old live UI\n")
+
+    def test_publish_rename_failure_restores_live_tree(self):
+        self.target.mkdir(parents=True)
+        old_file = self.target / "index.php"
+        old_file.write_text("old live UI\n", encoding="utf-8")
+        real_replace = os.replace
+        rejected = False
+
+        def fail_new_tree_once(source, destination):
+            nonlocal rejected
+            source_path = Path(source)
+            if source_path.name.startswith(".wsprrypi.stage.") and not rejected:
+                rejected = True
+                raise OSError("injected publication rename failure")
+            return real_replace(source, destination)
+
+        with mock.patch.object(PUBLISHER.os, "replace", side_effect=fail_new_tree_once):
+            with self.assertRaises(PUBLISHER.UiPublicationError):
+                self.publish()
+        self.assertEqual(old_file.read_text(encoding="utf-8"), "old live UI\n")
+
+    def test_postvalidation_change_is_not_published(self):
+        self.target.mkdir(parents=True)
+        old_file = self.target / "index.php"
+        old_file.write_text("old live UI\n", encoding="utf-8")
+
+        def change_staged_file(stage: Path):
+            os.chmod(stage / "site.css", 0o644)
+            (stage / "site.css").write_text("changed after validation\n")
+
+        with self.assertRaisesRegex(
+            PUBLISHER.UiPublicationError, "changed after manifest validation"
+        ):
+            self.publish(before_publish=change_staged_file)
+        self.assertEqual(old_file.read_text(encoding="utf-8"), "old live UI\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Makefile
+++ b/src/Makefile
@@ -1093,7 +1093,7 @@ $(BIN_DIR)/$(OUT): $(PROFILE_RELEASE_BIN) FORCE_PROFILE_BINARY
 .PHONY: semantics-test machine-power-control-test websocket-lifecycle-test wspr-band-catalog-test gpio-band-policy-test
 .PHONY: support-request-guard-test privileged-network-policy-test backend-http-guard-test websocket-upgrade-guard-test apache-privileged-network-policy-test privileged-network-transaction-test privileged-network-runtime-test privileged-network-runtime-wiring-test privileged-network-admin-test support-bundle-job-manager-test support-bundle-result-validator-test
 .PHONY: support-bundle-collector-executor-test support-bundle-runtime-test support-bundle-runtime-installer-test
-.PHONY: installer-dependency-test support-bundle-age-dependency-test support-bundle-http-test support-bundle-web-server-wiring-test
+.PHONY: installer-dependency-test ui-publication-test support-bundle-age-dependency-test support-bundle-http-test support-bundle-web-server-wiring-test
 .PHONY: support-bundle-download-file-test support-bundle-checksum-file-test support-bundle-archive-digest-test
 .PHONY: support-bundle-download-preparation-test support-bundle-job-directory-remover-test support-bundle-startup-cleanup-test
 .PHONY: support-bundle-private-artifact-test support-bundle-age-roundtrip-test support-bundle-key-provisioning-test
@@ -1177,6 +1177,8 @@ semantics-test: $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(CLEANUP_LIFECYCLE_
 	$(Q)node tests/log_timestamp_display_test.js
 	$(Q)echo "Running update-check comparison tests."
 	$(Q)node tests/update_check_comparison_test.js
+	$(Q)echo "Running coherent UI publication tests."
+	$(Q)python3 ../scripts/tests/ui_publication_test.py
 
 websocket-lifecycle-test: $(BIN_DIR)/$(WEBSOCKET_LIFECYCLE_TEST_OUT)
 	$(Q)./$(BIN_DIR)/$(WEBSOCKET_LIFECYCLE_TEST_OUT)
@@ -1276,6 +1278,9 @@ support-bundle-runtime-installer-test:
 
 installer-dependency-test:
 	$(Q)bash ../scripts/tests/installer_dependency_test.sh
+
+ui-publication-test:
+	$(Q)python3 ../scripts/tests/ui_publication_test.py
 
 support-bundle-age-dependency-test:
 	$(Q)bash ../scripts/tests/support_bundle_age_dependency_test.sh

--- a/src/tests/apache_privileged_network_policy_test.cpp
+++ b/src/tests/apache_privileged_network_policy_test.cpp
@@ -62,11 +62,15 @@ int main(int argc, char **argv) {
     const std::string installer = read_file(source_root / "../scripts/install.sh");
     assert(stock_vhost.find("ProxyPreserveHost On") != std::string::npos);
     assert(stock_vhost.find("ProxyPass        /wsprrypi/config") != std::string::npos);
+    assert(stock_vhost.find("ProxyPass        /wsprrypi/version http://127.0.0.1:31415/version") != std::string::npos);
     assert(stock_vhost.find("ProxyPass        /wsprrypi/socket") != std::string::npos);
     assert(installer.find("# BEGIN WsprryPi proxy configuration") != std::string::npos);
     assert(installer.find("ProxyPass        /wsprrypi/config") != std::string::npos);
+    assert(installer.find("ProxyPass        /wsprrypi/version http://127.0.0.1:31415/version") != std::string::npos);
     assert(installer.find("ProxyPass        /wsprrypi/socket") != std::string::npos);
     for (const std::string *source : {&stock_vhost, &installer}) {
+        assert(source->find("ProxyPass        /wsprrypi/ui-version.php") == std::string::npos);
+        assert(source->find("ProxyPass        /wsprrypi/ui-manifest.php") == std::string::npos);
         assert(source->find("RequestHeader set Host") == std::string::npos);
         assert(source->find("RequestHeader set Origin") == std::string::npos);
         assert(source->find("RemoteIPHeader") == std::string::npos);

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -1266,6 +1266,10 @@ int main()
         read_repo_text_file("/WsprryPi-UI/data/html_cache_headers.php");
     const std::string version_endpoint_source =
         read_repo_text_file("/WsprryPi-UI/data/version.php");
+    const std::string ui_identity_endpoint_source =
+        read_repo_text_file("/WsprryPi-UI/data/ui-version.php");
+    const std::string ui_manifest_endpoint_source =
+        read_repo_text_file("/WsprryPi-UI/data/ui-manifest.php");
     const std::string fetch_spots_source =
         read_repo_text_file("/WsprryPi-UI/data/fetch_spots.php");
     const std::string log_stream_source =
@@ -1282,26 +1286,40 @@ int main()
         "footer markup must keep the native click-based About disclosure and provide a site-global update-check toggle for disabling or re-enabling checks");
     require(
         header_source.find("window.WSPRRYPI_UI_VERSION = <?= json_encode(getWsprryPiUiVersion()) ?>;") != std::string::npos &&
-            header_source.find("window.WSPRRYPI_UI_BUILD_ID = <?= json_encode(getWsprryPiUiBuildId()) ?>;") != std::string::npos &&
+            header_source.find("window.WSPRRYPI_INSTALLED_UI_BUILD_ID = <?= json_encode(getWsprryPiInstalledUiBuildId()) ?>;") != std::string::npos &&
+            header_source.find("window.WSPRRYPI_UI_BUILD_ID = window.WSPRRYPI_INSTALLED_UI_BUILD_ID;") != std::string::npos &&
+            header_source.find("'uiIdentityPath' => $basePath . '/ui-version.php'") != std::string::npos &&
+            header_source.find("'uiManifestPath' => $basePath . '/ui-manifest.php'") != std::string::npos &&
             ui_version_source.find("function getWsprryPiUiVersion(): string") != std::string::npos &&
-            ui_version_source.find("function wsprrypiUiBuildFileRecords(): array") != std::string::npos &&
+            ui_version_source.find("function wsprrypiUiBuildFileRecords(?string $uiRoot = null): array") != std::string::npos &&
+            ui_version_source.find("function wsprrypiUiIdentityStatus(") != std::string::npos &&
+            ui_version_source.find("function getWsprryPiInstalledUiBuildId(): string") != std::string::npos &&
             ui_version_source.find("function getWsprryPiUiBuildId(): string") != std::string::npos &&
-            ui_version_source.find("'view_diag_logs.php' => true") != std::string::npos &&
-            ui_version_source.find("'cache' => true") != std::string::npos &&
-            ui_version_source.find("'%s|%d|%d'") != std::string::npos &&
-            ui_version_source.find("'mtime-' . substr(hash('sha256', implode(\"\\n\", $records)), 0, 16)") != std::string::npos &&
+            ui_version_source.find("WSPRRYPI_UI_IDENTITY_DOMAIN") != std::string::npos &&
+            ui_version_source.find("hash_file('sha256'") != std::string::npos &&
+            ui_version_source.find("'cache', 'backups'") != std::string::npos &&
+            ui_version_source.find("'installed_state' => $state") != std::string::npos &&
+            ui_version_source.find("'modified_files' => $modifiedFiles") != std::string::npos &&
+            ui_version_source.find("'added_files' => $addedFiles") != std::string::npos &&
+            ui_version_source.find("'missing_files' => $missingFiles") != std::string::npos &&
             ui_version_source.find("function wsprrypiAssetUrl(string $path): string") != std::string::npos &&
             ui_version_source.find("'v=' . rawurlencode($buildId)") != std::string::npos &&
             version_endpoint_source.find("'ui_build_id' => $uiBuildId") != std::string::npos &&
             version_endpoint_source.find("Cache-Control") != std::string::npos &&
             version_endpoint_source.find("no-store") != std::string::npos &&
+            ui_identity_endpoint_source.find("wsprrypiUiIdentityStatus()") != std::string::npos &&
+            ui_identity_endpoint_source.find("Cache-Control: no-store") != std::string::npos &&
+            ui_manifest_endpoint_source.find("wsprrypiUiLoadManifest($manifestPath)") != std::string::npos &&
+            ui_manifest_endpoint_source.find("Cache-Control: no-store") != std::string::npos &&
             header_source.find("wsprrypiAssetUrl('site.css')") != std::string::npos &&
+            header_source.find("wsprrypiAssetUrl('site.webmanifest')") != std::string::npos &&
+            header_source.find("wsprrypiAssetUrl('favicon.ico')") != std::string::npos &&
             footer_source.find("wsprrypiAssetUrl('site.js')") != std::string::npos &&
             index_page_source.find("wsprrypiAssetUrl($stylesheet)") != std::string::npos &&
             index_page_source.find("wsprrypiAssetUrl($script)") != std::string::npos &&
             script_include_source.find("wsprrypiAssetUrl('vendor/js/jquery-3.7.1.min.js')") != std::string::npos &&
             script_include_source.find("wsprrypiAssetUrl('vendor/js/bootstrap.bundle-5.3.8.min.js')") != std::string::npos,
-        "PHP template assets must use the centralized WsprryPi UI build id query string for CSS and JS cache busting, and /version must expose the same no-store UI build id while excluding diagnostic logs and transient paths");
+        "PHP pages and UI-owned endpoints must use the installed content identity for asset cache busting and report packaged, modified, added, missing, and unknown state without replacing the running-service /version contract");
     require(
         html_cache_headers_source.find("header('Cache-Control: no-cache, must-revalidate');") != std::string::npos &&
             index_page_source.find("<?php require_once __DIR__ . '/html_cache_headers.php'; ?>") == 0 &&
@@ -1309,6 +1327,8 @@ int main()
             diagnostic_logs_source.find("require_once __DIR__ . '/html_cache_headers.php';") < diagnostic_logs_source.find("<!doctype html>") &&
             read_repo_text_file("/WsprryPi-UI/data/template.php").find("<?php require_once __DIR__ . '/html_cache_headers.php'; ?>") == 0 &&
             version_endpoint_source.find("html_cache_headers.php") == std::string::npos &&
+            ui_identity_endpoint_source.find("html_cache_headers.php") == std::string::npos &&
+            ui_manifest_endpoint_source.find("html_cache_headers.php") == std::string::npos &&
             fetch_spots_source.find("html_cache_headers.php") == std::string::npos &&
             log_stream_source.find("html_cache_headers.php") == std::string::npos,
         "HTML PHP shell pages must send no-cache revalidation headers before output while JSON/API endpoints keep their existing cache behavior");

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -656,12 +656,13 @@ int main()
             site_source.find("preserveLineBreaks = options.preserveLineBreaks === true") != std::string::npos,
         "shared confirm modal must support preserving diagnostic line breaks for detail dialogs");
     require(
-        site_source.find("let dismissedUiRefreshVersion = null;") != std::string::npos &&
+        site_source.find("let dismissedUiRefreshVersion = null;") == std::string::npos &&
             site_source.find("let dismissedUiRefreshBuildId = null;") != std::string::npos &&
             site_source.find("const UI_BUILD_POLL_INTERVAL_MS = 60 * 1000;") != std::string::npos &&
+            site_source.find("const UI_REFRESH_REQUEST_PARAM = \"ui_refresh\";") != std::string::npos &&
             site_source.find("const GITHUB_UPDATE_POLL_INTERVAL_MS = 60 * 60 * 1000;") != std::string::npos &&
-            site_source.find("window.WSPRRYPI_UI_VERSION") != std::string::npos &&
-            site_source.find("window.WSPRRYPI_UI_BUILD_ID") != std::string::npos &&
+            site_source.find("window.WSPRRYPI_INSTALLED_UI_BUILD_ID") != std::string::npos &&
+            site_source.find("window.WSPRRYPI_UI_BUILD_ID") == std::string::npos &&
             site_source.find("let githubUpdatePollTimer = null;") != std::string::npos &&
             site_source.find("function checkUiBuildVersion()") != std::string::npos &&
             site_source.find("function initUiBuildChangePolling()") != std::string::npos &&
@@ -675,14 +676,14 @@ int main()
             site_source.find("const modalEl = document.getElementById(\"confirmModal\");") != std::string::npos &&
             site_source.find("const promptShown = showConfirmationDialog({") != std::string::npos &&
             site_source.find("uiRefreshPromptActive = promptShown === true;") != std::string::npos &&
-            site_source.find("getJsonWithEndpointFallback(VERSION_ENDPOINT)\n        .done(function (response) {\n            if (response && (response.ui_build_id || response.ui_version)) {\n                maybePromptForUiRefresh(response);") != std::string::npos &&
+            site_source.find("getJsonWithEndpointFallback(UI_IDENTITY_ENDPOINT)\n        .done(function (response) {\n            if (response && response.installed_ui_build_id) {\n                maybePromptForUiRefresh(response);") != std::string::npos &&
             site_source.find("// Start UI build polling from global script initialization as soon as site.js") != std::string::npos &&
             site_source.find("initUiBuildChangePolling();\ninitGithubUpdatePolling();\n\nfunction getPersistedTabStorageKey") != std::string::npos &&
             site_source.find("initUiBuildChangePolling();\n    initGithubUpdatePolling();\n    populateConfig();") != std::string::npos &&
             site_source.find("initGithubUpdatePolling();\n    populateConfig();") != std::string::npos &&
             site_source.find("if (uiBuildPollTimer !== null)") != std::string::npos &&
-            site_source.find("const canCompareBuildId = loadedBuildId && normalizedServerBuildId;") != std::string::npos &&
-            site_source.find("normalizedServerBuildId === dismissedUiRefreshBuildId") != std::string::npos &&
+            site_source.find("installedBuildId === dismissedUiRefreshBuildId") != std::string::npos &&
+            site_source.find("maybePromptForUiRefresh(response);\n                checkForWsprryPiUpdate(response);") == std::string::npos &&
             web_server_source.find("j[\"ui_version\"] = get_raw_version_string();") != std::string::npos &&
             web_server_source.find("j[\"wspr_version_raw\"] = get_exe_version();") != std::string::npos &&
             web_server_source.find("j[\"wspr_version_parsed\"] = parse_version_for_update_metadata(get_exe_version());") != std::string::npos &&
@@ -691,7 +692,7 @@ int main()
             web_server_source.find("j[\"wspr_display_branch\"] = get_exe_branch();") != std::string::npos &&
             web_server_source.find("j[\"wspr_exe_version\"] = get_exe_version();") != std::string::npos &&
             web_server_source.find("j[\"wspr_commit\"] = get_exe_commit();") != std::string::npos,
-        "site.js must detect backend UI version changes using the existing /version response, and backend /version must expose raw and parsed executable version, raw branch, branch state, executable version, and commit metadata");
+        "site.js must poll the UI-owned installed identity independently while backend /version remains available only for service and update metadata");
     require(
         site_source.find("title: \"UI refresh required\"") != std::string::npos &&
             site_source.find("The WsprryPi web interface has been updated. Refresh this page to load the new web pages, CSS, and JavaScript.") != std::string::npos &&
@@ -700,18 +701,21 @@ int main()
             site_source.find("showConfirmationDialog({") != std::string::npos,
         "UI refresh prompt must use the shared Bootstrap confirmation modal path with the required copy and labels");
     require(
-        site_source.find("function refreshUiForVersion(serverVersion, serverBuildId = \"\")") != std::string::npos &&
+        site_source.find("function refreshUiForIdentity(installedBuildId)") != std::string::npos &&
             site_source.find("const url = new URL(window.location.href);") != std::string::npos &&
-            site_source.find("url.searchParams.set(\n        \"ui_refresh\",") != std::string::npos &&
+            site_source.find("url.searchParams.set(UI_REFRESH_REQUEST_PARAM, normalizedBuildId);") != std::string::npos &&
             site_source.find("window.location.replace(url.toString());") != std::string::npos &&
-            site_source.find("normalizedBuildId || normalizedVersion || Date.now().toString()") != std::string::npos &&
-            site_source.find("refreshUiForVersion(normalizedServerVersion, normalizedServerBuildId);") != std::string::npos &&
-            site_source.find("dismissedUiRefreshBuildId = normalizedServerBuildId;") != std::string::npos &&
+            site_source.find("refreshUiForIdentity(installedBuildId);") != std::string::npos &&
+            site_source.find("dismissedUiRefreshBuildId = installedBuildId;") != std::string::npos &&
+            site_source.find("function checkUiRefreshConvergence()") != std::string::npos &&
+            site_source.find("function showUiConsistencyDiagnostic(expectedBuildId, loadedBuildId)") != std::string::npos &&
+            site_source.find("uiConsistencyDiagnosticActive = true;") != std::string::npos &&
+            site_source.find("window.history.replaceState(null, \"\", url.toString());") != std::string::npos &&
             site_source.find("if (typeof options.onCancel === \"function\")") != std::string::npos &&
             site_source.find("if (typeof options.onHidden === \"function\")") != std::string::npos &&
             site_source.find("confirmModal.show();\n        return true;") != std::string::npos &&
             site_source.find("return false;") != std::string::npos,
-        "UI refresh prompt must replace the current URL with a ui_refresh cache-busting query parameter on OK and suppress repeat prompts for the same server build id on Cancel or dismiss");
+        "UI refresh must cache-bust with installed identity, verify convergence, diagnose a mismatch persistently, and suppress repeat prompts for a dismissed identity");
     require(
         site_source.find("function initFooterMetaPanelInteractions()") != std::string::npos &&
             site_source.find("document.addEventListener(\"click\", function (event) {") != std::string::npos &&
@@ -1285,9 +1289,9 @@ int main()
             site_css_source.find(".footer-meta__action") != std::string::npos,
         "footer markup must keep the native click-based About disclosure and provide a site-global update-check toggle for disabling or re-enabling checks");
     require(
-        header_source.find("window.WSPRRYPI_UI_VERSION = <?= json_encode(getWsprryPiUiVersion()) ?>;") != std::string::npos &&
+        header_source.find("window.WSPRRYPI_UI_VERSION") == std::string::npos &&
             header_source.find("window.WSPRRYPI_INSTALLED_UI_BUILD_ID = <?= json_encode(getWsprryPiInstalledUiBuildId()) ?>;") != std::string::npos &&
-            header_source.find("window.WSPRRYPI_UI_BUILD_ID = window.WSPRRYPI_INSTALLED_UI_BUILD_ID;") != std::string::npos &&
+            header_source.find("window.WSPRRYPI_UI_BUILD_ID") == std::string::npos &&
             header_source.find("'uiIdentityPath' => $basePath . '/ui-version.php'") != std::string::npos &&
             header_source.find("'uiManifestPath' => $basePath . '/ui-manifest.php'") != std::string::npos &&
             ui_version_source.find("function getWsprryPiUiVersion(): string") != std::string::npos &&

--- a/src/tests/update_check_comparison_test.js
+++ b/src/tests/update_check_comparison_test.js
@@ -338,14 +338,14 @@ async function runBuildPriorityCase({
 
     const originalGetElementById = context.document.getElementById;
     let promptAttempts = 0;
-    let promptReturnValue = false;
-    context.window.WSPRRYPI_UI_BUILD_ID = "loaded-build";
-    context.window.WSPRRYPI_UI_VERSION = "3.0.0";
+    let promptOptions = null;
+    let refreshModalVisible = false;
+    context.window.WSPRRYPI_INSTALLED_UI_BUILD_ID = "loaded-build";
     context.document.getElementById = (id) => {
         if (id === "confirmModal") {
             return {
                 classList: {
-                    contains: () => false,
+                    contains: () => refreshModalVisible,
                 },
             };
         }
@@ -353,27 +353,65 @@ async function runBuildPriorityCase({
     };
     context.showConfirmationDialog = (options) => {
         promptAttempts += 1;
+        promptOptions = options;
         assert.strictEqual(options.title, "UI refresh required");
         assert.strictEqual(options.confirmLabel, "Refresh");
-        promptReturnValue = promptAttempts > 1;
-        return promptReturnValue;
+        refreshModalVisible = true;
+        return true;
     };
 
     context.maybePromptForUiRefresh({
-        ui_build_id: "server-build",
-        ui_version: "3.0.1",
+        installed_ui_build_id: "loaded-build",
     });
-    assert.strictEqual(promptAttempts, 1);
+    assert.strictEqual(promptAttempts, 0, "a stable installed identity must not prompt");
 
     context.maybePromptForUiRefresh({
-        ui_build_id: "server-build",
-        ui_version: "3.0.1",
+        ui_build_id: "service-build",
+        ui_version: "9.9.9",
     });
-    assert.strictEqual(
-        promptAttempts,
-        2,
-        "polling must retry the UI refresh prompt when the first modal show attempt does not become active"
-    );
+    assert.strictEqual(promptAttempts, 0, "service version metadata must not prompt");
+
+    context.maybePromptForUiRefresh({
+        installed_ui_build_id: "changed-build",
+    });
+    assert.strictEqual(promptAttempts, 1, "an installed-file change must prompt once");
+    context.maybePromptForUiRefresh({ installed_ui_build_id: "changed-build" });
+    assert.strictEqual(promptAttempts, 1, "an active prompt must not repeat");
+
+    let replacedUrl = "";
+    context.window.location.replace = (url) => { replacedUrl = url; };
+    promptOptions.onConfirm();
+    assert.ok(replacedUrl.includes("ui_refresh=changed-build"), "refresh must cache-bust with the new installed identity");
+
+    refreshModalVisible = false;
+    promptOptions.onCancel();
+    context.maybePromptForUiRefresh({ installed_ui_build_id: "changed-build" });
+    assert.strictEqual(promptAttempts, 1, "a dismissed identity must stay suppressed while stable");
+
+    let historyUrl = "";
+    context.window.history = { replaceState: (_state, _title, url) => { historyUrl = url; } };
+    context.window.location.href = "http://localhost/?ui_refresh=loaded-build";
+    assert.strictEqual(context.checkUiRefreshConvergence(), true);
+    assert.ok(!historyUrl.includes("ui_refresh"), "successful convergence must remove the refresh token");
+
+    let diagnosticMessage = "";
+    let diagnosticShown = false;
+    const diagnostic = {
+        classList: { remove: (name) => { diagnosticShown = name === "d-none"; } },
+        querySelector: () => ({
+            set textContent(value) { diagnosticMessage = value; },
+        }),
+    };
+    context.document.getElementById = (id) => id === "uiConsistencyDiagnostic"
+        ? diagnostic
+        : originalGetElementById(id);
+    context.window.location.href = "http://localhost/?ui_refresh=requested-build";
+    assert.strictEqual(context.checkUiRefreshConvergence(), false);
+    assert.strictEqual(diagnosticShown, true);
+    assert.ok(diagnosticMessage.includes("requested-build"));
+    assert.ok(diagnosticMessage.includes("loaded-build"));
+    context.maybePromptForUiRefresh({ installed_ui_build_id: "another-build" });
+    assert.strictEqual(promptAttempts, 1, "a convergence diagnostic must replace further prompts");
 
     context.document.getElementById = originalGetElementById;
 


### PR DESCRIPTION
Implements issue #422 across deterministic manifest generation, installed-state classification, UI-owned identity endpoints, refresh convergence, coherent publication, and verified backup-and-replace behavior.\n\nValidation includes focused automated tests and actual-host qualification on wspr5 for clean, modified, unknown, backup-failure, refresh, version-mismatch, convergence, and persistent-diagnostic scenarios.