### PR TITLE
Prevent implicit legacy DMA backend startup

### DIFF
--- a/WsprryPi-UI/tests/conditional_transmit_gpio_integration_test.js
+++ b/WsprryPi-UI/tests/conditional_transmit_gpio_integration_test.js
@@ -58,13 +58,29 @@ async function waitFor(check, description, timeoutMs = 10000) {
     throw new Error(`Timed out waiting for ${description}${lastError ? `: ${lastError.message}` : ""}`);
 }
 
+function waitForExit(child, timeoutMs) {
+    if (child.exitCode !== null) return Promise.resolve(true);
+    return new Promise((resolve) => {
+        let timer;
+        const finish = (exited) => {
+            clearTimeout(timer);
+            child.off("exit", onExit);
+            resolve(exited);
+        };
+        const onExit = () => finish(true);
+        child.once("exit", onExit);
+        timer = setTimeout(() => finish(child.exitCode !== null), timeoutMs);
+    });
+}
+
 async function terminate(child) {
     if (!child || child.exitCode !== null) return;
     child.kill("SIGTERM");
-    await new Promise((resolve) => {
-        child.once("exit", resolve);
-        setTimeout(resolve, 2000);
-    });
+    if (await waitForExit(child, 2000)) return;
+    child.kill("SIGKILL");
+    if (!await waitForExit(child, 2000)) {
+        throw new Error(`Child process ${child.pid} did not terminate`);
+    }
 }
 
 class CdpClient {

--- a/WsprryPi-UI/tests/support_intake_ui_integration_test.js
+++ b/WsprryPi-UI/tests/support_intake_ui_integration_test.js
@@ -58,13 +58,29 @@ async function waitFor(check, description, timeoutMs = 12000) {
     throw new Error(`Timed out waiting for ${description}${lastError ? `: ${lastError.message}` : ""}`);
 }
 
+function waitForExit(child, timeoutMs) {
+    if (child.exitCode !== null) return Promise.resolve(true);
+    return new Promise((resolve) => {
+        let timer;
+        const finish = (exited) => {
+            clearTimeout(timer);
+            child.off("exit", onExit);
+            resolve(exited);
+        };
+        const onExit = () => finish(true);
+        child.once("exit", onExit);
+        timer = setTimeout(() => finish(child.exitCode !== null), timeoutMs);
+    });
+}
+
 async function terminate(child) {
     if (!child || child.exitCode !== null) return;
     child.kill("SIGTERM");
-    await new Promise((resolve) => {
-        child.once("exit", resolve);
-        setTimeout(resolve, 2000);
-    });
+    if (await waitForExit(child, 2000)) return;
+    child.kill("SIGKILL");
+    if (!await waitForExit(child, 2000)) {
+        throw new Error(`Child process ${child.pid} did not terminate`);
+    }
 }
 
 async function removeProfileDirectory(profileDir, options = {}) {

--- a/docs/research/compile-time-transmission-backend-selection.md
+++ b/docs/research/compile-time-transmission-backend-selection.md
@@ -203,10 +203,12 @@ Transmission backend GPIO is unavailable in this build. Compiled backends: si535
 ```
 
 There is no automatic fallback to Si5351, simulated, or any other backend.
-Construction selects the first enabled backend in canonical order as an
-explicit, generated default. The default all-backend profile therefore retains
-legacy GPIO startup behavior, while reduced profiles do not acquire an omitted
-backend dependency. Factory tests cover both enabled and omitted selections.
+Construction does not select or instantiate any backend. After platform and
+configuration validation, the application explicitly constructs only the
+selected backend. This is a hardware-safety boundary: a Pi 5 selecting Si5351
+or RP1 GPCLK never constructs the legacy mailbox/MMIO/DMA backend, even
+transiently during process startup. Factory tests cover this unselected initial
+state as well as enabled and omitted explicit selections.
 
 ### Capability reporting
 

--- a/src/WSPR-Transmitter/src/wspr_transmit.cpp
+++ b/src/WSPR-Transmitter/src/wspr_transmit.cpp
@@ -161,20 +161,6 @@ namespace
         return false;
     }
 
-    wsprrypi::BackendKind initial_compiled_backend() noexcept
-    {
-#if WSPRRYPI_BACKEND_RPI_GPIO
-        return wsprrypi::BackendKind::RPI_CLOCK_GPIO;
-#elif WSPRRYPI_BACKEND_RP1_GPCLK
-        return wsprrypi::BackendKind::RP1_GPCLK;
-#elif WSPRRYPI_BACKEND_SI5351
-        return wsprrypi::BackendKind::SI5351;
-#else
-        static_assert(WSPRRYPI_BACKEND_SIMULATED, "at least one backend is required");
-        return wsprrypi::BackendKind::SIMULATED;
-#endif
-    }
-
     static wsprrypi::ClockSource si5351_clock_source_from_index(int output) noexcept
     {
         switch (output)
@@ -406,7 +392,6 @@ WsprTransmitter::WsprTransmitter()
     {
         spin_ns_ = 0; // or 50'000 if you want a tiny spin
     }
-    selectBackend(initial_compiled_backend());
     callback_thread_ = std::thread(&WsprTransmitter::callback_worker_loop, this);
 }
 
@@ -476,6 +461,11 @@ void WsprTransmitter::selectBackend(
         std::make_unique<wsprrypi::TransmissionController>(
             execution_plan_compiler_,
             *backend_);
+}
+
+bool WsprTransmitter::hasSelectedBackend() const noexcept
+{
+    return backend_ != nullptr && transmission_controller_ != nullptr;
 }
 
 std::unique_ptr<wsprrypi::ITransmissionBackend> WsprTransmitter::createBackend(
@@ -685,12 +675,19 @@ void WsprTransmitter::clearExecutionStateAfterStop() noexcept
     current_cw_message_.clear();
     current_cw_active_char_index_.store(-1, std::memory_order_release);
     scheduled_start_rt_ns_.store(0, std::memory_order_release);
-    transmission_controller_->reset();
+    if (transmission_controller_ != nullptr)
+        transmission_controller_->reset();
 }
 
 void WsprTransmitter::configureExecution(
     const TransmissionRequest &request)
 {
+    if (!hasSelectedBackend())
+    {
+        throw std::logic_error(
+            "Transmission execution requires an explicitly selected backend.");
+    }
+
     if (!request.isSkipWindow())
     {
         const auto policy = wsprrypi::evaluate_gpio_band_policy(
@@ -827,6 +824,12 @@ void WsprTransmitter::configureExecution(
     const wsprrypi::TransmissionRequest& request,
     const TransmissionRequest& legacy_request)
 {
+    if (!hasSelectedBackend())
+    {
+        throw std::logic_error(
+            "Transmission execution requires an explicitly selected backend.");
+    }
+
     if (request.mode == wsprrypi::TransmissionMode::TONE &&
         request.output.backend != wsprrypi::BackendKind::SI5351)
     {

--- a/src/WSPR-Transmitter/src/wspr_transmit.hpp
+++ b/src/WSPR-Transmitter/src/wspr_transmit.hpp
@@ -324,6 +324,7 @@ public:
         wsprrypi::BackendKind backend_kind,
         const Si5351RuntimeConfig &si5351_config,
         const SimulatedRuntimeConfig &simulated_config);
+    bool hasSelectedBackend() const noexcept;
 
     /**
      * Place the selected backend into its safe startup state before any
@@ -1071,6 +1072,9 @@ private:
     wsprrypi::ExecutionPlanCompiler execution_plan_compiler_{};
     std::unique_ptr<wsprrypi::ITransmissionBackend> backend_;
     WsprRpiBackend *rpi_backend_{nullptr};
+    // A backend is created only after the application has validated its
+    // platform and explicit runtime selection. In particular, global
+    // construction must never instantiate the legacy DMA backend on Pi 5.
     wsprrypi::BackendKind selected_backend_{wsprrypi::BackendKind::RPI_CLOCK_GPIO};
     Si5351RuntimeConfig selected_si5351_config_{};
     SimulatedRuntimeConfig selected_simulated_config_{};

--- a/src/tests/backend_profile_factory_test.cpp
+++ b/src/tests/backend_profile_factory_test.cpp
@@ -30,6 +30,26 @@ bool compiled(wsprrypi::BackendKind backend)
 int main()
 {
     WsprTransmitter transmitter;
+    if (transmitter.hasSelectedBackend())
+        throw std::runtime_error(
+            "transmitter construction selected a backend before platform validation");
+    transmitter.clearExecutionStateAfterStop();
+    TransmissionRequest unselected_request;
+    unselected_request.skip_window = true;
+    bool rejected_unselected_execution = false;
+    try
+    {
+        transmitter.configureExecution(unselected_request);
+    }
+    catch (const std::logic_error &error)
+    {
+        rejected_unselected_execution =
+            std::string(error.what()).find("explicitly selected backend") !=
+            std::string::npos;
+    }
+    if (!rejected_unselected_execution)
+        throw std::runtime_error(
+            "execution without an explicitly selected backend did not fail closed");
     constexpr std::array backends{
         wsprrypi::BackendKind::RPI_CLOCK_GPIO,
         wsprrypi::BackendKind::RP1_GPCLK,
@@ -44,6 +64,8 @@ int main()
             transmitter.selectBackend(backend);
             if (!compiled(backend))
                 throw std::runtime_error("omitted backend selection unexpectedly succeeded");
+            if (!transmitter.hasSelectedBackend())
+                throw std::runtime_error("explicit backend selection did not create a backend");
         }
         catch (const std::invalid_argument &error)
         {

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1446,6 +1446,7 @@ int main(int argc, char *argv[])
 
     {
         WsprTransmitter transmitter;
+        transmitter.selectBackend(wsprrypi::BackendKind::SIMULATED);
 
         wsprrypi::TransmissionRequest controller_request;
         controller_request.mode = wsprrypi::TransmissionMode::TONE;
@@ -1975,6 +1976,7 @@ int main(int argc, char *argv[])
 
     {
         WsprTransmitter transmitter;
+        transmitter.selectBackend(wsprrypi::BackendKind::SIMULATED);
 
         TransmissionRequest committed_request;
         committed_request.mode = TransmissionMode::WSPR;


### PR DESCRIPTION
## Outcome

Prevent WsprryPi from constructing the legacy Raspberry Pi DMA transmitter backend before platform and route validation.

## Changes

- leave WsprTransmitter backendless until explicit validated selection
- fail closed when execution is attempted without a selected backend
- make pre-selection execution-state cleanup safe
- document the explicit backend-construction invariant
- add regression coverage for unselected construction, cleanup, and execution

## Validation

- native all-backend factory and startup-quiesce tests on Raspberry Pi 5: pass
- native runtime semantics, cleanup lifecycle, GPIO policy, UI source, timestamp, update comparison, and publication tests: pass
- live GPIO4 bounded carrier with corrected daemon using RP1 selection: complete, cleanup fault 0, DMA tick idle before and after
- live GPIO4 bounded carrier with corrected daemon using Si5351 selection: complete, cleanup fault 0, DMA tick idle before and after
- final target state restored: module 1.0.1, live_output disabled, GPIO4 input, clock prepare/enable counts zero

Frequency accuracy was explicitly outside this work.